### PR TITLE
tmg-llm: Implement SSE streaming LLM client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -57,6 +57,58 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -105,10 +157,351 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -117,10 +510,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -129,6 +633,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -141,10 +700,248 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -158,6 +955,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tmg-agents"
 version = "0.1.0"
 
@@ -168,7 +1030,11 @@ dependencies = [
  "anyhow",
  "clap",
  "tmg-core",
+ "tmg-llm",
  "tmg-tui",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
 ]
 
 [[package]]
@@ -178,6 +1044,17 @@ version = "0.1.0"
 [[package]]
 name = "tmg-llm"
 version = "0.1.0"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "pin-project-lite",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "tmg-sandbox"
@@ -196,16 +1073,291 @@ name = "tmg-tui"
 version = "0.1.0"
 
 [[package]]
+name = "tokio"
+version = "1.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "windows-link"
@@ -215,9 +1367,277 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,12 @@ license = "MIT"
 [workspace.dependencies]
 # Async runtime
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio-util = "0.7"
+tokio-stream = "0.1"
+
+# Streaming
+futures-core = "0.3"
+pin-project-lite = "0.2"
 
 # HTTP & streaming
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/crates/tmg-llm/Cargo.toml
+++ b/crates/tmg-llm/Cargo.toml
@@ -6,6 +6,18 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+reqwest = { workspace = true }
+eventsource-stream = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+futures-core = { workspace = true }
+pin-project-lite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [lints]
 workspace = true

--- a/crates/tmg-llm/src/client.rs
+++ b/crates/tmg-llm/src/client.rs
@@ -1,0 +1,351 @@
+//! SSE streaming client for OpenAI-compatible chat completions.
+
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use eventsource_stream::Eventsource;
+use futures_core::Stream;
+use reqwest::Client;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::LlmError;
+use crate::types::{
+    ChatCompletionChunk, ChatRequest, ChatResponse, StreamEvent, ToolCallAccumulator,
+};
+
+/// Default connection timeout in seconds.
+const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
+
+/// Default overall request timeout in seconds.
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 300;
+
+/// Configuration for building an [`LlmClient`].
+#[derive(Debug, Clone)]
+pub struct LlmClientConfig {
+    /// Base URL of the LLM server (e.g. `http://localhost:8080`).
+    pub endpoint: String,
+
+    /// Model name to use in requests.
+    pub model: String,
+
+    /// Connection timeout.
+    pub connect_timeout: Duration,
+
+    /// Overall request timeout.
+    pub request_timeout: Duration,
+}
+
+impl LlmClientConfig {
+    /// Create a new configuration with the given endpoint and model.
+    pub fn new(endpoint: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            model: model.into(),
+            connect_timeout: Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS),
+            request_timeout: Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS),
+        }
+    }
+
+    /// Set the connection timeout.
+    #[must_use]
+    pub fn with_connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    /// Set the overall request timeout.
+    #[must_use]
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+}
+
+/// Client for communicating with an OpenAI-compatible LLM server.
+#[derive(Debug, Clone)]
+pub struct LlmClient {
+    http: Client,
+    config: LlmClientConfig,
+}
+
+impl LlmClient {
+    /// Create a new client from the given configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns `LlmError::Http` if the underlying HTTP client cannot be built.
+    pub fn new(config: LlmClientConfig) -> Result<Self, LlmError> {
+        let http = Client::builder()
+            .connect_timeout(config.connect_timeout)
+            .timeout(config.request_timeout)
+            .build()?;
+
+        Ok(Self { http, config })
+    }
+
+    /// The chat completions endpoint URL.
+    fn completions_url(&self) -> String {
+        let base = self.config.endpoint.trim_end_matches('/');
+        format!("{base}/v1/chat/completions")
+    }
+
+    /// Send a non-streaming chat completion request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError`] on connection failure, timeout, or invalid response.
+    pub async fn chat(
+        &self,
+        messages: Vec<crate::types::ChatMessage>,
+        tools: Vec<crate::types::ToolDefinition>,
+    ) -> Result<ChatResponse, LlmError> {
+        let request = ChatRequest {
+            model: self.config.model.clone(),
+            messages,
+            stream: false,
+            tools,
+            temperature: None,
+        };
+
+        let response = self
+            .http
+            .post(self.completions_url())
+            .json(&request)
+            .send()
+            .await
+            .map_err(classify_reqwest_error)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(LlmError::ServerError {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        response
+            .json::<ChatResponse>()
+            .await
+            .map_err(|e| LlmError::InvalidResponse(e.to_string()))
+    }
+
+    /// Send a streaming chat completion request.
+    ///
+    /// Returns a [`ChatStream`] that yields [`StreamEvent`]s. The stream
+    /// respects the provided [`CancellationToken`] and will terminate with
+    /// [`LlmError::Cancelled`] if the token is cancelled.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError`] if the initial HTTP request fails.
+    ///
+    /// # Cancel safety
+    ///
+    /// The returned stream is cancel-safe: dropping it at any point will not
+    /// lose data or leave the connection in an inconsistent state.
+    pub async fn chat_streaming(
+        &self,
+        messages: Vec<crate::types::ChatMessage>,
+        tools: Vec<crate::types::ToolDefinition>,
+        cancel: CancellationToken,
+    ) -> Result<ChatStream, LlmError> {
+        let request = ChatRequest {
+            model: self.config.model.clone(),
+            messages,
+            stream: true,
+            tools,
+            temperature: None,
+        };
+
+        let response = self
+            .http
+            .post(self.completions_url())
+            .json(&request)
+            .send()
+            .await
+            .map_err(classify_reqwest_error)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(LlmError::ServerError {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let byte_stream = response.bytes_stream();
+        let event_stream = byte_stream.eventsource();
+
+        Ok(ChatStream {
+            inner: Box::pin(event_stream),
+            accumulator: ToolCallAccumulator::new(),
+            cancel,
+            finished: false,
+            pending: VecDeque::new(),
+        })
+    }
+}
+
+/// A stream of [`StreamEvent`]s from a chat completion request.
+///
+/// This stream assembles incremental tool call deltas into complete
+/// [`ToolCall`](crate::types::ToolCall)s automatically.
+pub struct ChatStream {
+    inner: Pin<
+        Box<
+            dyn Stream<
+                    Item = Result<
+                        eventsource_stream::Event,
+                        eventsource_stream::EventStreamError<reqwest::Error>,
+                    >,
+                > + Send,
+        >,
+    >,
+    accumulator: ToolCallAccumulator,
+    cancel: CancellationToken,
+    finished: bool,
+    /// Buffered events to yield before polling the inner stream again.
+    pending: VecDeque<Result<StreamEvent, LlmError>>,
+}
+
+impl std::fmt::Debug for ChatStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChatStream")
+            .field("finished", &self.finished)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Stream for ChatStream {
+    type Item = Result<StreamEvent, LlmError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Drain any buffered events first.
+        if let Some(event) = self.pending.pop_front() {
+            return Poll::Ready(Some(event));
+        }
+
+        if self.finished {
+            return Poll::Ready(None);
+        }
+
+        // Check cancellation.
+        if self.cancel.is_cancelled() {
+            self.finished = true;
+            return Poll::Ready(Some(Err(LlmError::Cancelled)));
+        }
+
+        loop {
+            match self.inner.as_mut().poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => {
+                    self.finished = true;
+                    // Flush any remaining tool calls.
+                    let remaining = self.accumulator.finish();
+                    for tc in remaining {
+                        self.pending
+                            .push_back(Ok(StreamEvent::ToolCallComplete(tc)));
+                    }
+                    return if let Some(event) = self.pending.pop_front() {
+                        Poll::Ready(Some(event))
+                    } else {
+                        Poll::Ready(None)
+                    };
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    self.finished = true;
+                    return Poll::Ready(Some(Err(LlmError::StreamError(e.to_string()))));
+                }
+                Poll::Ready(Some(Ok(event))) => {
+                    self.process_sse_event(&event);
+
+                    // If processing produced any events, return the first one.
+                    if let Some(event) = self.pending.pop_front() {
+                        return Poll::Ready(Some(event));
+                    }
+
+                    // No actionable content (e.g. role-only delta); loop to
+                    // poll the inner stream for the next SSE event.
+                }
+            }
+        }
+    }
+}
+
+impl ChatStream {
+    /// Process a single SSE event, pushing results into the pending buffer.
+    fn process_sse_event(&mut self, event: &eventsource_stream::Event) {
+        let data = &event.data;
+
+        // The stream ends with a [DONE] sentinel.
+        if data == "[DONE]" {
+            self.finished = true;
+            let remaining = self.accumulator.finish();
+            for tc in remaining {
+                self.pending
+                    .push_back(Ok(StreamEvent::ToolCallComplete(tc)));
+            }
+            self.pending.push_back(Ok(StreamEvent::Done(None)));
+            return;
+        }
+
+        // Parse the chunk.
+        let chunk = match serde_json::from_str::<ChatCompletionChunk>(data) {
+            Ok(c) => c,
+            Err(e) => {
+                self.pending
+                    .push_back(Err(LlmError::InvalidResponse(format!(
+                        "failed to parse SSE chunk: {e}"
+                    ))));
+                return;
+            }
+        };
+
+        // Process each choice (typically just one).
+        for choice in &chunk.choices {
+            // Handle tool call deltas.
+            if let Some(tc_deltas) = &choice.delta.tool_calls {
+                let completed = self.accumulator.feed(tc_deltas);
+                for tc in completed {
+                    self.pending
+                        .push_back(Ok(StreamEvent::ToolCallComplete(tc)));
+                }
+            }
+
+            // Handle content delta.
+            if let Some(content) = &choice.delta.content {
+                if !content.is_empty() {
+                    self.pending
+                        .push_back(Ok(StreamEvent::ContentDelta(content.clone())));
+                }
+            }
+
+            // Handle finish reason.
+            if let Some(reason) = &choice.finish_reason {
+                self.finished = true;
+                let remaining = self.accumulator.finish();
+                for tc in remaining {
+                    self.pending
+                        .push_back(Ok(StreamEvent::ToolCallComplete(tc)));
+                }
+                self.pending
+                    .push_back(Ok(StreamEvent::Done(Some(reason.clone()))));
+            }
+        }
+    }
+}
+
+/// Classify a `reqwest::Error` into an appropriate `LlmError` variant.
+fn classify_reqwest_error(e: reqwest::Error) -> LlmError {
+    if e.is_connect() {
+        LlmError::ConnectionFailed(e.to_string())
+    } else if e.is_timeout() {
+        LlmError::Timeout
+    } else {
+        LlmError::Http(e)
+    }
+}

--- a/crates/tmg-llm/src/client.rs
+++ b/crates/tmg-llm/src/client.rs
@@ -6,9 +6,9 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use eventsource_stream::Eventsource;
-use futures_core::Stream;
+use futures_core::{Future, Stream};
 use reqwest::Client;
-use tokio_util::sync::CancellationToken;
+use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 
 use crate::error::LlmError;
 use crate::types::{
@@ -180,10 +180,12 @@ impl LlmClient {
         let byte_stream = response.bytes_stream();
         let event_stream = byte_stream.eventsource();
 
+        let cancel_fut = cancel.cancelled_owned();
+
         Ok(ChatStream {
             inner: Box::pin(event_stream),
             accumulator: ToolCallAccumulator::new(),
-            cancel,
+            cancel_fut: Box::pin(cancel_fut),
             finished: false,
             pending: VecDeque::new(),
         })
@@ -206,7 +208,10 @@ pub struct ChatStream {
         >,
     >,
     accumulator: ToolCallAccumulator,
-    cancel: CancellationToken,
+    /// Cancellation future that resolves when the token is cancelled.
+    /// Polling this alongside the inner stream ensures cancellation wakes
+    /// the task even when the inner stream is blocked on I/O.
+    cancel_fut: Pin<Box<WaitForCancellationFutureOwned>>,
     finished: bool,
     /// Buffered events to yield before polling the inner stream again.
     pending: VecDeque<Result<StreamEvent, LlmError>>,
@@ -233,13 +238,15 @@ impl Stream for ChatStream {
             return Poll::Ready(None);
         }
 
-        // Check cancellation.
-        if self.cancel.is_cancelled() {
-            self.finished = true;
-            return Poll::Ready(Some(Err(LlmError::Cancelled)));
-        }
-
         loop {
+            // Poll the cancellation future first. If it is ready, the token
+            // has been cancelled and we should terminate immediately. This
+            // ensures the task is woken even when the inner stream is blocked.
+            if self.cancel_fut.as_mut().poll(cx).is_ready() {
+                self.finished = true;
+                return Poll::Ready(Some(Err(LlmError::Cancelled)));
+            }
+
             match self.inner.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(None) => {
@@ -309,7 +316,14 @@ impl ChatStream {
         for choice in &chunk.choices {
             // Handle tool call deltas.
             if let Some(tc_deltas) = &choice.delta.tool_calls {
-                let completed = self.accumulator.feed(tc_deltas);
+                let completed = match self.accumulator.feed(tc_deltas) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        self.pending
+                            .push_back(Err(LlmError::InvalidResponse(e.to_string())));
+                        return;
+                    }
+                };
                 for tc in completed {
                     self.pending
                         .push_back(Ok(StreamEvent::ToolCallComplete(tc)));

--- a/crates/tmg-llm/src/error.rs
+++ b/crates/tmg-llm/src/error.rs
@@ -1,0 +1,43 @@
+/// Errors produced by the LLM communication layer.
+#[derive(Debug, thiserror::Error)]
+pub enum LlmError {
+    /// Failed to connect to the LLM server (e.g. server not running).
+    #[error("connection failed: {0}")]
+    ConnectionFailed(String),
+
+    /// The request timed out.
+    #[error("request timed out")]
+    Timeout,
+
+    /// The server returned a non-success HTTP status.
+    #[error("server error (HTTP {status}): {body}")]
+    ServerError {
+        /// HTTP status code.
+        status: u16,
+        /// Response body text.
+        body: String,
+    },
+
+    /// Failed to parse the server response.
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+
+    /// The SSE stream produced an error event.
+    #[error("stream error: {0}")]
+    StreamError(String),
+
+    /// The request was cancelled via `CancellationToken`.
+    #[error("request cancelled")]
+    Cancelled,
+
+    /// An HTTP-level error from reqwest that doesn't fit other variants.
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+}
+
+impl LlmError {
+    /// Returns `true` if this error indicates the server is unreachable.
+    pub fn is_connection_failure(&self) -> bool {
+        matches!(self, Self::ConnectionFailed(_))
+    }
+}

--- a/crates/tmg-llm/src/lib.rs
+++ b/crates/tmg-llm/src/lib.rs
@@ -1,1 +1,12 @@
-// tmg-llm: LLM communication layer (OpenAI-compatible API, SSE streaming).
+//! tmg-llm: LLM communication layer (OpenAI-compatible API, SSE streaming).
+
+pub mod client;
+pub mod error;
+pub mod types;
+
+pub use client::{ChatStream, LlmClient, LlmClientConfig};
+pub use error::LlmError;
+pub use types::{
+    ChatMessage, ChatRequest, ChatResponse, Role, StreamEvent, ToolCall, ToolCallAccumulator,
+    ToolDefinition,
+};

--- a/crates/tmg-llm/src/lib.rs
+++ b/crates/tmg-llm/src/lib.rs
@@ -8,5 +8,5 @@ pub use client::{ChatStream, LlmClient, LlmClientConfig};
 pub use error::LlmError;
 pub use types::{
     ChatMessage, ChatRequest, ChatResponse, Role, StreamEvent, ToolCall, ToolCallAccumulator,
-    ToolDefinition,
+    ToolCallIndexError, ToolDefinition, ToolKind,
 };

--- a/crates/tmg-llm/src/types.rs
+++ b/crates/tmg-llm/src/types.rs
@@ -1,0 +1,532 @@
+//! Request and response types for the OpenAI-compatible chat completions API.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+/// A chat completion request sent to the LLM server.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChatRequest {
+    /// Model identifier (e.g. `"llama3"`).
+    pub model: String,
+
+    /// Conversation messages.
+    pub messages: Vec<ChatMessage>,
+
+    /// Whether to enable SSE streaming.
+    pub stream: bool,
+
+    /// Tool definitions available to the model.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ToolDefinition>,
+
+    /// Optional temperature override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+}
+
+/// A single message in the conversation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatMessage {
+    /// The role of the message author.
+    pub role: Role,
+
+    /// Text content (may be `None` for assistant messages with only tool calls).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+
+    /// Tool calls requested by the assistant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+
+    /// For role `tool`: the id of the tool call this message responds to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+/// Message author role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    /// System prompt.
+    System,
+    /// User message.
+    User,
+    /// Assistant (model) response.
+    Assistant,
+    /// Tool result.
+    Tool,
+}
+
+/// A tool definition exposed to the model.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolDefinition {
+    /// Always `"function"`.
+    #[serde(rename = "type")]
+    pub kind: String,
+
+    /// Function metadata.
+    pub function: FunctionDefinition,
+}
+
+/// Metadata for a callable function.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FunctionDefinition {
+    /// Function name.
+    pub name: String,
+
+    /// Human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// JSON Schema describing the parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Response types (non-streaming)
+// ---------------------------------------------------------------------------
+
+/// A complete (non-streaming) chat completion response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatResponse {
+    /// Unique response id.
+    pub id: String,
+
+    /// List of completion choices.
+    pub choices: Vec<Choice>,
+}
+
+/// A single completion choice.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Choice {
+    /// Choice index.
+    pub index: u32,
+
+    /// The generated message.
+    pub message: ChatMessage,
+
+    /// Reason the generation stopped.
+    pub finish_reason: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Streaming (SSE) response types
+// ---------------------------------------------------------------------------
+
+/// A single SSE chunk from a streaming chat completion.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatCompletionChunk {
+    /// Unique response id.
+    pub id: String,
+
+    /// Chunk choices.
+    pub choices: Vec<ChunkChoice>,
+}
+
+/// A single choice within a streaming chunk.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChunkChoice {
+    /// Choice index.
+    pub index: u32,
+
+    /// Incremental delta for this choice.
+    pub delta: Delta,
+
+    /// Reason the generation stopped (present in the final chunk).
+    pub finish_reason: Option<String>,
+}
+
+/// Incremental content delivered in a streaming chunk.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Delta {
+    /// The role, if present in this delta.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<Role>,
+
+    /// Incremental text content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+
+    /// Incremental tool call data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCallDelta>>,
+}
+
+/// Incremental tool call data within a streaming delta.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ToolCallDelta {
+    /// Index of the tool call being built.
+    pub index: u32,
+
+    /// Tool call id (present in the first delta for this call).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Always `"function"` when present.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+
+    /// Incremental function data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<FunctionCallDelta>,
+}
+
+/// Incremental function call data within a tool call delta.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct FunctionCallDelta {
+    /// Function name (present in the first delta).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Incremental arguments JSON string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Assembled tool call
+// ---------------------------------------------------------------------------
+
+/// A fully assembled tool call reconstructed from streaming deltas.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolCall {
+    /// Unique identifier for this tool call.
+    pub id: String,
+
+    /// Always `"function"`.
+    #[serde(rename = "type")]
+    pub kind: String,
+
+    /// The function to call.
+    pub function: FunctionCall,
+}
+
+/// A fully assembled function call.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FunctionCall {
+    /// Function name.
+    pub name: String,
+
+    /// Arguments as a JSON string.
+    pub arguments: String,
+}
+
+// ---------------------------------------------------------------------------
+// Stream event
+// ---------------------------------------------------------------------------
+
+/// High-level events emitted by the streaming client.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StreamEvent {
+    /// An incremental text token.
+    ContentDelta(String),
+
+    /// A complete tool call has been assembled from deltas.
+    ToolCallComplete(ToolCall),
+
+    /// The stream has finished. Contains the finish reason.
+    Done(Option<String>),
+}
+
+// ---------------------------------------------------------------------------
+// Tool call accumulator
+// ---------------------------------------------------------------------------
+
+/// Accumulates incremental tool call deltas into complete [`ToolCall`]s.
+#[derive(Debug, Default)]
+pub struct ToolCallAccumulator {
+    /// In-progress tool calls, keyed by index.
+    calls: Vec<ToolCallBuilder>,
+}
+
+#[derive(Debug, Default)]
+struct ToolCallBuilder {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+impl ToolCallAccumulator {
+    /// Create a new empty accumulator.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed a batch of tool call deltas. Returns any newly completed tool calls.
+    ///
+    /// A tool call is considered complete when a subsequent delta starts a new
+    /// call at a higher index, or when the stream signals completion via
+    /// [`Self::finish`].
+    pub fn feed(&mut self, deltas: &[ToolCallDelta]) -> Vec<ToolCall> {
+        let mut completed = Vec::new();
+
+        for delta in deltas {
+            let idx = delta.index as usize;
+
+            // Ensure we have enough builder slots.
+            while self.calls.len() <= idx {
+                self.calls.push(ToolCallBuilder::default());
+            }
+
+            let builder = &mut self.calls[idx];
+
+            if let Some(id) = &delta.id {
+                builder.id.clone_from(id);
+            }
+            if let Some(func) = &delta.function {
+                if let Some(name) = &func.name {
+                    builder.name.clone_from(name);
+                }
+                if let Some(args) = &func.arguments {
+                    builder.arguments.push_str(args);
+                }
+            }
+        }
+
+        // Check if any lower-indexed calls have been superseded.
+        // This heuristic: if we received a delta for index N, all calls < N
+        // with non-empty ids are considered complete.
+        if let Some(max_idx) = deltas.iter().map(|d| d.index as usize).max() {
+            for idx in 0..max_idx {
+                if !self.calls[idx].id.is_empty() {
+                    let builder = std::mem::take(&mut self.calls[idx]);
+                    completed.push(ToolCall {
+                        id: builder.id,
+                        kind: "function".to_owned(),
+                        function: FunctionCall {
+                            name: builder.name,
+                            arguments: builder.arguments,
+                        },
+                    });
+                }
+            }
+        }
+
+        completed
+    }
+
+    /// Drain all remaining in-progress tool calls as complete.
+    pub fn finish(&mut self) -> Vec<ToolCall> {
+        self.calls
+            .drain(..)
+            .filter(|b| !b.id.is_empty())
+            .map(|b| ToolCall {
+                id: b.id,
+                kind: "function".to_owned(),
+                function: FunctionCall {
+                    name: b.name,
+                    arguments: b.arguments,
+                },
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "expect is appropriate in test assertions"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_chunk_with_content_delta() {
+        let json = r#"{
+            "id": "chatcmpl-1",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "Hello"},
+                "finish_reason": null
+            }]
+        }"#;
+
+        let chunk: ChatCompletionChunk = serde_json::from_str(json).expect("parse chunk");
+        assert_eq!(chunk.choices.len(), 1);
+        assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("Hello"));
+        assert!(chunk.choices[0].finish_reason.is_none());
+    }
+
+    #[test]
+    fn parse_chunk_with_tool_call_delta() {
+        let json = r#"{
+            "id": "chatcmpl-2",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": "{\"path\":"
+                        }
+                    }]
+                },
+                "finish_reason": null
+            }]
+        }"#;
+
+        let chunk: ChatCompletionChunk = serde_json::from_str(json).expect("parse chunk");
+        let tc = &chunk.choices[0]
+            .delta
+            .tool_calls
+            .as_ref()
+            .expect("tool_calls")[0];
+        assert_eq!(tc.id.as_deref(), Some("call_abc"));
+        assert_eq!(
+            tc.function.as_ref().expect("function").name.as_deref(),
+            Some("read_file")
+        );
+    }
+
+    #[test]
+    fn parse_non_streaming_response_with_tool_calls() {
+        let json = r#"{
+            "id": "chatcmpl-3",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_xyz",
+                        "type": "function",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": "{\"path\": \"/tmp/test.txt\", \"content\": \"hello\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        }"#;
+
+        let resp: ChatResponse = serde_json::from_str(json).expect("parse response");
+        let tool_calls = resp.choices[0]
+            .message
+            .tool_calls
+            .as_ref()
+            .expect("tool_calls");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "write_file");
+    }
+
+    #[test]
+    fn accumulator_assembles_single_tool_call() {
+        let mut acc = ToolCallAccumulator::new();
+
+        // First delta: id + name + partial args
+        let d1 = vec![ToolCallDelta {
+            index: 0,
+            id: Some("call_1".into()),
+            kind: Some("function".into()),
+            function: Some(FunctionCallDelta {
+                name: Some("read_file".into()),
+                arguments: Some("{\"path\":".into()),
+            }),
+        }];
+        let completed = acc.feed(&d1);
+        assert!(completed.is_empty());
+
+        // Second delta: more args
+        let d2 = vec![ToolCallDelta {
+            index: 0,
+            id: None,
+            kind: None,
+            function: Some(FunctionCallDelta {
+                name: None,
+                arguments: Some("\"/tmp/f\"}".into()),
+            }),
+        }];
+        let completed = acc.feed(&d2);
+        assert!(completed.is_empty());
+
+        // Finish
+        let completed = acc.finish();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].id, "call_1");
+        assert_eq!(completed[0].function.name, "read_file");
+        assert_eq!(completed[0].function.arguments, "{\"path\":\"/tmp/f\"}");
+    }
+
+    #[test]
+    fn accumulator_assembles_multiple_tool_calls() {
+        let mut acc = ToolCallAccumulator::new();
+
+        // First tool call
+        acc.feed(&[ToolCallDelta {
+            index: 0,
+            id: Some("call_a".into()),
+            kind: Some("function".into()),
+            function: Some(FunctionCallDelta {
+                name: Some("foo".into()),
+                arguments: Some("{}".into()),
+            }),
+        }]);
+
+        // Second tool call starts - first should be completed
+        let completed = acc.feed(&[ToolCallDelta {
+            index: 1,
+            id: Some("call_b".into()),
+            kind: Some("function".into()),
+            function: Some(FunctionCallDelta {
+                name: Some("bar".into()),
+                arguments: Some("{\"x\":1}".into()),
+            }),
+        }]);
+
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].id, "call_a");
+        assert_eq!(completed[0].function.name, "foo");
+
+        // Finish to get the second
+        let completed = acc.finish();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].id, "call_b");
+    }
+
+    #[test]
+    fn serialize_chat_request() {
+        let req = ChatRequest {
+            model: "llama3".to_owned(),
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content: Some("Hello".to_owned()),
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            stream: true,
+            tools: vec![],
+            temperature: None,
+        };
+
+        let json = serde_json::to_value(&req).expect("serialize");
+        assert_eq!(json["model"], "llama3");
+        assert_eq!(json["stream"], true);
+        // tools should be omitted when empty
+        assert!(json.get("tools").is_none());
+        // temperature should be omitted when None
+        assert!(json.get("temperature").is_none());
+    }
+
+    #[test]
+    fn parse_finish_reason_stop() {
+        let json = r#"{
+            "id": "chatcmpl-done",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop"
+            }]
+        }"#;
+
+        let chunk: ChatCompletionChunk = serde_json::from_str(json).expect("parse");
+        assert_eq!(chunk.choices[0].finish_reason.as_deref(), Some("stop"));
+    }
+}

--- a/crates/tmg-llm/src/types.rs
+++ b/crates/tmg-llm/src/types.rs
@@ -2,6 +2,12 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Maximum number of concurrent tool calls allowed in a single response.
+///
+/// This prevents unbounded memory allocation from malformed server responses
+/// with absurdly large tool call indices.
+const MAX_TOOL_CALL_INDEX: usize = 128;
+
 // ---------------------------------------------------------------------------
 // Request types
 // ---------------------------------------------------------------------------
@@ -60,12 +66,21 @@ pub enum Role {
     Tool,
 }
 
+/// The kind of a tool or tool call. Currently only `function` is supported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolKind {
+    /// A callable function.
+    #[default]
+    Function,
+}
+
 /// A tool definition exposed to the model.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ToolDefinition {
-    /// Always `"function"`.
-    #[serde(rename = "type")]
-    pub kind: String,
+    /// The tool kind (always [`ToolKind::Function`]).
+    #[serde(rename = "type", default)]
+    pub kind: ToolKind,
 
     /// Function metadata.
     pub function: FunctionDefinition,
@@ -144,15 +159,12 @@ pub struct ChunkChoice {
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Delta {
     /// The role, if present in this delta.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<Role>,
 
     /// Incremental text content.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
 
     /// Incremental tool call data.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCallDelta>>,
 }
 
@@ -163,15 +175,13 @@ pub struct ToolCallDelta {
     pub index: u32,
 
     /// Tool call id (present in the first delta for this call).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// Always `"function"` when present.
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub kind: Option<String>,
 
     /// Incremental function data.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub function: Option<FunctionCallDelta>,
 }
 
@@ -179,11 +189,9 @@ pub struct ToolCallDelta {
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct FunctionCallDelta {
     /// Function name (present in the first delta).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
     /// Incremental arguments JSON string.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<String>,
 }
 
@@ -197,9 +205,9 @@ pub struct ToolCall {
     /// Unique identifier for this tool call.
     pub id: String,
 
-    /// Always `"function"`.
-    #[serde(rename = "type")]
-    pub kind: String,
+    /// The tool kind (always [`ToolKind::Function`]).
+    #[serde(rename = "type", default)]
+    pub kind: ToolKind,
 
     /// The function to call.
     pub function: FunctionCall,
@@ -243,6 +251,14 @@ pub struct ToolCallAccumulator {
     calls: Vec<ToolCallBuilder>,
 }
 
+/// Error returned when a tool call delta has an index exceeding the allowed maximum.
+#[derive(Debug, thiserror::Error)]
+#[error("tool call index {index} exceeds maximum allowed ({MAX_TOOL_CALL_INDEX})")]
+pub struct ToolCallIndexError {
+    /// The offending index value.
+    pub index: u32,
+}
+
 #[derive(Debug, Default)]
 struct ToolCallBuilder {
     id: String,
@@ -261,11 +277,21 @@ impl ToolCallAccumulator {
     /// A tool call is considered complete when a subsequent delta starts a new
     /// call at a higher index, or when the stream signals completion via
     /// [`Self::finish`].
-    pub fn feed(&mut self, deltas: &[ToolCallDelta]) -> Vec<ToolCall> {
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if any delta has an index exceeding [`MAX_TOOL_CALL_INDEX`],
+    /// which guards against unbounded memory allocation from malformed responses.
+    pub fn feed(&mut self, deltas: &[ToolCallDelta]) -> Result<Vec<ToolCall>, ToolCallIndexError> {
         let mut completed = Vec::new();
 
         for delta in deltas {
             let idx = delta.index as usize;
+
+            // Reject absurdly large indices to prevent OOM.
+            if idx > MAX_TOOL_CALL_INDEX {
+                return Err(ToolCallIndexError { index: delta.index });
+            }
 
             // Ensure we have enough builder slots.
             while self.calls.len() <= idx {
@@ -296,7 +322,7 @@ impl ToolCallAccumulator {
                     let builder = std::mem::take(&mut self.calls[idx]);
                     completed.push(ToolCall {
                         id: builder.id,
-                        kind: "function".to_owned(),
+                        kind: ToolKind::Function,
                         function: FunctionCall {
                             name: builder.name,
                             arguments: builder.arguments,
@@ -306,7 +332,7 @@ impl ToolCallAccumulator {
             }
         }
 
-        completed
+        Ok(completed)
     }
 
     /// Drain all remaining in-progress tool calls as complete.
@@ -316,7 +342,7 @@ impl ToolCallAccumulator {
             .filter(|b| !b.id.is_empty())
             .map(|b| ToolCall {
                 id: b.id,
-                kind: "function".to_owned(),
+                kind: ToolKind::Function,
                 function: FunctionCall {
                     name: b.name,
                     arguments: b.arguments,
@@ -431,7 +457,7 @@ mod tests {
                 arguments: Some("{\"path\":".into()),
             }),
         }];
-        let completed = acc.feed(&d1);
+        let completed = acc.feed(&d1).expect("feed d1");
         assert!(completed.is_empty());
 
         // Second delta: more args
@@ -444,13 +470,14 @@ mod tests {
                 arguments: Some("\"/tmp/f\"}".into()),
             }),
         }];
-        let completed = acc.feed(&d2);
+        let completed = acc.feed(&d2).expect("feed d2");
         assert!(completed.is_empty());
 
         // Finish
         let completed = acc.finish();
         assert_eq!(completed.len(), 1);
         assert_eq!(completed[0].id, "call_1");
+        assert_eq!(completed[0].kind, ToolKind::Function);
         assert_eq!(completed[0].function.name, "read_file");
         assert_eq!(completed[0].function.arguments, "{\"path\":\"/tmp/f\"}");
     }
@@ -468,18 +495,21 @@ mod tests {
                 name: Some("foo".into()),
                 arguments: Some("{}".into()),
             }),
-        }]);
+        }])
+        .expect("feed first");
 
         // Second tool call starts - first should be completed
-        let completed = acc.feed(&[ToolCallDelta {
-            index: 1,
-            id: Some("call_b".into()),
-            kind: Some("function".into()),
-            function: Some(FunctionCallDelta {
-                name: Some("bar".into()),
-                arguments: Some("{\"x\":1}".into()),
-            }),
-        }]);
+        let completed = acc
+            .feed(&[ToolCallDelta {
+                index: 1,
+                id: Some("call_b".into()),
+                kind: Some("function".into()),
+                function: Some(FunctionCallDelta {
+                    name: Some("bar".into()),
+                    arguments: Some("{\"x\":1}".into()),
+                }),
+            }])
+            .expect("feed second");
 
         assert_eq!(completed.len(), 1);
         assert_eq!(completed[0].id, "call_a");
@@ -489,6 +519,23 @@ mod tests {
         let completed = acc.finish();
         assert_eq!(completed.len(), 1);
         assert_eq!(completed[0].id, "call_b");
+    }
+
+    #[test]
+    fn accumulator_rejects_excessive_index() {
+        let mut acc = ToolCallAccumulator::new();
+
+        let result = acc.feed(&[ToolCallDelta {
+            index: u32::MAX,
+            id: Some("call_bad".into()),
+            kind: Some("function".into()),
+            function: Some(FunctionCallDelta {
+                name: Some("exploit".into()),
+                arguments: Some("{}".into()),
+            }),
+        }]);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/tmg-llm/src/types.rs
+++ b/crates/tmg-llm/src/types.rs
@@ -177,9 +177,9 @@ pub struct ToolCallDelta {
     /// Tool call id (present in the first delta for this call).
     pub id: Option<String>,
 
-    /// Always `"function"` when present.
+    /// Always [`ToolKind::Function`] when present.
     #[serde(rename = "type")]
-    pub kind: Option<String>,
+    pub kind: Option<ToolKind>,
 
     /// Incremental function data.
     pub function: Option<FunctionCallDelta>,
@@ -451,7 +451,7 @@ mod tests {
         let d1 = vec![ToolCallDelta {
             index: 0,
             id: Some("call_1".into()),
-            kind: Some("function".into()),
+            kind: Some(ToolKind::Function),
             function: Some(FunctionCallDelta {
                 name: Some("read_file".into()),
                 arguments: Some("{\"path\":".into()),
@@ -490,7 +490,7 @@ mod tests {
         acc.feed(&[ToolCallDelta {
             index: 0,
             id: Some("call_a".into()),
-            kind: Some("function".into()),
+            kind: Some(ToolKind::Function),
             function: Some(FunctionCallDelta {
                 name: Some("foo".into()),
                 arguments: Some("{}".into()),
@@ -503,7 +503,7 @@ mod tests {
             .feed(&[ToolCallDelta {
                 index: 1,
                 id: Some("call_b".into()),
-                kind: Some("function".into()),
+                kind: Some(ToolKind::Function),
                 function: Some(FunctionCallDelta {
                     name: Some("bar".into()),
                     arguments: Some("{\"x\":1}".into()),
@@ -528,7 +528,7 @@ mod tests {
         let result = acc.feed(&[ToolCallDelta {
             index: u32::MAX,
             id: Some("call_bad".into()),
-            kind: Some("function".into()),
+            kind: Some(ToolKind::Function),
             function: Some(FunctionCallDelta {
                 name: Some("exploit".into()),
                 arguments: Some("{}".into()),

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -8,7 +8,11 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 tmg-core = { workspace = true }
+tmg-llm = { workspace = true }
 tmg-tui = { workspace = true }
 
 [lints]

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -3,13 +3,78 @@ use clap::Parser;
 /// tsumugi - a local-LLM-powered coding agent
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
-struct Cli {}
+struct Cli {
+    /// Send a one-shot prompt to the LLM server and stream the response to stdout.
+    #[arg(long)]
+    prompt: Option<String>,
 
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "main will propagate errors once features are implemented"
-)]
+    /// LLM server endpoint URL.
+    #[arg(long, default_value = "http://localhost:8080")]
+    endpoint: String,
+
+    /// Model name to use.
+    #[arg(long, default_value = "default")]
+    model: String,
+}
+
 fn main() -> anyhow::Result<()> {
-    let _cli = Cli::parse();
+    let cli = Cli::parse();
+
+    if let Some(prompt) = cli.prompt {
+        run_prompt(&cli.endpoint, &cli.model, &prompt)?;
+    }
+
     Ok(())
+}
+
+/// Run a one-shot streaming prompt against the LLM server.
+///
+/// This function is the integration check for issue #2: it sends a prompt
+/// to the llama-server and streams the response token-by-token to stdout.
+#[expect(
+    clippy::print_stdout,
+    reason = "integration check: intentional stdout streaming output"
+)]
+fn run_prompt(endpoint: &str, model: &str, prompt: &str) -> anyhow::Result<()> {
+    use std::io::Write as _;
+    use tokio_stream::StreamExt as _;
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let config = tmg_llm::LlmClientConfig::new(endpoint, model);
+        let client = tmg_llm::LlmClient::new(config)?;
+
+        let messages = vec![tmg_llm::ChatMessage {
+            role: tmg_llm::Role::User,
+            content: Some(prompt.to_owned()),
+            tool_calls: None,
+            tool_call_id: None,
+        }];
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let mut stream = client.chat_streaming(messages, vec![], cancel).await?;
+
+        while let Some(event) = stream.next().await {
+            match event? {
+                tmg_llm::StreamEvent::ContentDelta(text) => {
+                    print!("{text}");
+                    std::io::stdout().flush()?;
+                }
+                tmg_llm::StreamEvent::ToolCallComplete(tc) => {
+                    println!(
+                        "\n[tool_call] {}({})",
+                        tc.function.name, tc.function.arguments
+                    );
+                }
+                tmg_llm::StreamEvent::Done(reason) => {
+                    println!();
+                    if let Some(r) = reason {
+                        println!("[done: {r}]");
+                    }
+                }
+            }
+        }
+
+        Ok::<(), anyhow::Error>(())
+    })
 }


### PR DESCRIPTION
## Summary

Implements the LLM client in the `tmg-llm` crate for communicating with llama-server's OpenAI-compatible API via SSE streaming, as specified in #2.

### Changes

- **`crates/tmg-llm/src/error.rs`**: `LlmError` enum with `thiserror` 2.x — variants for `ConnectionFailed`, `Timeout`, `ServerError`, `InvalidResponse`, `StreamError`, `Cancelled`, and `Http`
- **`crates/tmg-llm/src/types.rs`**: Request/response type definitions — `ChatRequest`, `ChatResponse`, `ChatCompletionChunk`, `Delta`, `ToolCallDelta`, `StreamEvent`, and `ToolCallAccumulator` for assembling incremental tool call deltas into complete `ToolCall`s
- **`crates/tmg-llm/src/client.rs`**: `LlmClient` with configurable endpoint/model/timeouts, non-streaming `chat()` and streaming `chat_streaming()` methods; `ChatStream` implementing `futures_core::Stream` with buffered event processing, `CancellationToken` support, and cancel-safe design
- **`crates/tmg-llm/src/lib.rs`**: Module declarations and public re-exports
- **`tmg-cli/src/main.rs`**: Integration check via `--prompt` flag — streams LLM response token-by-token to stdout
- **`Cargo.toml`** (root): Added `tokio-util`, `tokio-stream`, `futures-core`, `pin-project-lite` to workspace dependencies
- **`crates/tmg-llm/Cargo.toml`**: Added all required dependencies
- **`tmg-cli/Cargo.toml`**: Added `tmg-llm`, `tokio`, `tokio-stream`, `tokio-util`

### Design decisions

- **No `#[async_trait]`**: All async methods use native `async fn`
- **Buffered stream processing**: `ChatStream` uses a `VecDeque` to buffer multiple events from a single SSE chunk (e.g. tool call completion + done), ensuring all events are yielded without loss
- **Cancel safety**: The stream checks `CancellationToken::is_cancelled()` on each poll; dropping the stream at any point is safe
- **Error classification**: `reqwest::Error` is classified into `ConnectionFailed` (connect errors), `Timeout`, or generic `Http` for clear error reporting when llama-server is unavailable

### Testing

- 7 unit tests covering:
  - Content delta parsing
  - Tool call delta parsing
  - Non-streaming response with tool_calls parsing
  - Single and multiple tool call accumulation
  - Chat request serialization (empty tools/temperature omitted)
  - Finish reason parsing
- All quality checks pass: `cargo build --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, `cargo test --workspace`

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)