### PR TITLE
tmg-core: Implement minimal agent loop (text-only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +186,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -534,6 +565,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libredox"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +635,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "percent-encoding"
@@ -732,6 +778,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -904,6 +961,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1107,14 @@ dependencies = [
 [[package]]
 name = "tmg-core"
 version = "0.1.0"
+dependencies = [
+ "dirs",
+ "thiserror",
+ "tmg-llm",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+]
 
 [[package]]
 name = "tmg-llm"
@@ -1082,6 +1157,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ clap = { version = "4", features = ["derive"] }
 thiserror = "2"
 anyhow = "1"
 
+# Platform directories
+dirs = "6"
+
 # Sandbox
 landlock = "0.4"
 

--- a/crates/tmg-core/Cargo.toml
+++ b/crates/tmg-core/Cargo.toml
@@ -6,6 +6,15 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+tmg-llm = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tokio-stream = { workspace = true }
+thiserror = { workspace = true }
+dirs = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [lints]
 workspace = true

--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -103,12 +103,7 @@ impl AgentLoop {
         self.history.push(Message::user(user_input));
 
         // Build the messages for the LLM request.
-        let chat_messages: Vec<_> = self
-            .history
-            .iter()
-            .cloned()
-            .map(Message::into_chat_message)
-            .collect();
+        let chat_messages: Vec<_> = self.history.iter().map(Message::to_chat_message).collect();
 
         // Send streaming request.
         let mut stream = self
@@ -117,6 +112,7 @@ impl AgentLoop {
             .await?;
 
         let mut response_text = String::new();
+        let mut done_called = false;
 
         while let Some(event) = stream.next().await {
             match event {
@@ -126,6 +122,7 @@ impl AgentLoop {
                 }
                 Ok(StreamEvent::Done(_)) => {
                     sink.on_done()?;
+                    done_called = true;
                     break;
                 }
                 Ok(StreamEvent::ToolCallComplete(_)) => {
@@ -138,6 +135,11 @@ impl AgentLoop {
                     return Err(CoreError::Llm(e));
                 }
             }
+        }
+
+        // Ensure on_done is called even if the stream ends without a Done event.
+        if !done_called {
+            sink.on_done()?;
         }
 
         // Append assistant response to history.
@@ -156,20 +158,20 @@ mod tests {
     #[test]
     fn message_constructors() {
         let sys = Message::system("hello");
-        assert_eq!(sys.role, tmg_llm::Role::System);
-        assert_eq!(sys.content, "hello");
+        assert_eq!(sys.role(), tmg_llm::Role::System);
+        assert_eq!(sys.content(), "hello");
 
         let usr = Message::user("world");
-        assert_eq!(usr.role, tmg_llm::Role::User);
+        assert_eq!(usr.role(), tmg_llm::Role::User);
 
         let asst = Message::assistant("response");
-        assert_eq!(asst.role, tmg_llm::Role::Assistant);
+        assert_eq!(asst.role(), tmg_llm::Role::Assistant);
     }
 
     #[test]
     fn message_to_chat_message() {
         let msg = Message::user("test");
-        let chat = msg.into_chat_message();
+        let chat = msg.to_chat_message();
         assert_eq!(chat.role, tmg_llm::Role::User);
         assert_eq!(chat.content.as_deref(), Some("test"));
         assert!(chat.tool_calls.is_none());

--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -1,0 +1,178 @@
+//! Minimal agent loop: text-only turn-based conversation with an LLM.
+
+use std::path::Path;
+
+use tokio_stream::StreamExt as _;
+use tokio_util::sync::CancellationToken;
+
+use tmg_llm::{LlmClient, StreamEvent};
+
+use crate::error::CoreError;
+use crate::message::Message;
+use crate::prompt;
+
+/// The default system prompt injected at the start of every conversation.
+const DEFAULT_SYSTEM_PROMPT: &str = "\
+You are tsumugi, a helpful coding assistant running locally. \
+Answer concisely and accurately.";
+
+/// Callback invoked for each streamed content token.
+///
+/// Implementations should write the token to the appropriate output
+/// (stdout, TUI widget, etc.). Returning an error aborts the current turn.
+pub trait StreamSink {
+    /// Called for each incremental text token from the LLM.
+    fn on_token(&mut self, token: &str) -> Result<(), CoreError>;
+
+    /// Called when the LLM response stream has completed for the current turn.
+    fn on_done(&mut self) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
+
+/// A minimal text-only agent loop.
+///
+/// Manages conversation history and sends it to the LLM on each turn.
+/// Tool calls are not handled in this initial implementation.
+pub struct AgentLoop {
+    /// The LLM client used to send requests.
+    client: LlmClient,
+
+    /// Conversation history (system prompt + user/assistant messages).
+    history: Vec<Message>,
+
+    /// Cancellation token for graceful shutdown.
+    cancel: CancellationToken,
+}
+
+impl AgentLoop {
+    /// Create a new agent loop.
+    ///
+    /// Loads TSUMUGI.md / AGENTS.md prompt files from the global config
+    /// directory and from `project_root` down to `cwd`, injecting them
+    /// as initial user-role messages after the system prompt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError::Io`] if a prompt file exists but cannot be read.
+    pub fn new(
+        client: LlmClient,
+        cancel: CancellationToken,
+        project_root: &Path,
+        cwd: &Path,
+    ) -> Result<Self, CoreError> {
+        let mut history = vec![Message::system(DEFAULT_SYSTEM_PROMPT)];
+
+        // Load prompt files and inject as initial messages.
+        let prompt_messages = prompt::load_prompt_files(project_root, cwd)?;
+        history.extend(prompt_messages);
+
+        Ok(Self {
+            client,
+            history,
+            cancel,
+        })
+    }
+
+    /// Return a read-only view of the conversation history.
+    pub fn history(&self) -> &[Message] {
+        &self.history
+    }
+
+    /// Execute a single conversation turn.
+    ///
+    /// Adds the user message to history, streams the LLM response through
+    /// the provided [`StreamSink`], assembles the full response, and appends
+    /// it to history as an assistant message.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] on LLM communication failure, cancellation,
+    /// or if the sink returns an error.
+    ///
+    /// # Cancel safety
+    ///
+    /// If the `CancellationToken` is triggered during streaming, the partial
+    /// response is discarded and [`CoreError::Cancelled`] is returned.
+    pub async fn turn(
+        &mut self,
+        user_input: &str,
+        sink: &mut impl StreamSink,
+    ) -> Result<(), CoreError> {
+        // Add user message to history.
+        self.history.push(Message::user(user_input));
+
+        // Build the messages for the LLM request.
+        let chat_messages: Vec<_> = self
+            .history
+            .iter()
+            .cloned()
+            .map(Message::into_chat_message)
+            .collect();
+
+        // Send streaming request.
+        let mut stream = self
+            .client
+            .chat_streaming(chat_messages, vec![], self.cancel.clone())
+            .await?;
+
+        let mut response_text = String::new();
+
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(StreamEvent::ContentDelta(token)) => {
+                    response_text.push_str(&token);
+                    sink.on_token(&token)?;
+                }
+                Ok(StreamEvent::Done(_)) => {
+                    sink.on_done()?;
+                    break;
+                }
+                Ok(StreamEvent::ToolCallComplete(_)) => {
+                    // Tool calls are not handled in this minimal loop.
+                }
+                Err(tmg_llm::LlmError::Cancelled) => {
+                    return Err(CoreError::Cancelled);
+                }
+                Err(e) => {
+                    return Err(CoreError::Llm(e));
+                }
+            }
+        }
+
+        // Append assistant response to history.
+        if !response_text.is_empty() {
+            self.history.push(Message::assistant(response_text));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_constructors() {
+        let sys = Message::system("hello");
+        assert_eq!(sys.role, tmg_llm::Role::System);
+        assert_eq!(sys.content, "hello");
+
+        let usr = Message::user("world");
+        assert_eq!(usr.role, tmg_llm::Role::User);
+
+        let asst = Message::assistant("response");
+        assert_eq!(asst.role, tmg_llm::Role::Assistant);
+    }
+
+    #[test]
+    fn message_to_chat_message() {
+        let msg = Message::user("test");
+        let chat = msg.into_chat_message();
+        assert_eq!(chat.role, tmg_llm::Role::User);
+        assert_eq!(chat.content.as_deref(), Some("test"));
+        assert!(chat.tool_calls.is_none());
+        assert!(chat.tool_call_id.is_none());
+    }
+}

--- a/crates/tmg-core/src/error.rs
+++ b/crates/tmg-core/src/error.rs
@@ -1,0 +1,17 @@
+//! Error types for the core crate.
+
+/// Errors produced by the core orchestration layer.
+#[derive(Debug, thiserror::Error)]
+pub enum CoreError {
+    /// An error originating from the LLM communication layer.
+    #[error("llm error: {0}")]
+    Llm(#[from] tmg_llm::LlmError),
+
+    /// An I/O error (e.g. reading prompt files).
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The agent loop was cancelled via `CancellationToken`.
+    #[error("agent loop cancelled")]
+    Cancelled,
+}

--- a/crates/tmg-core/src/lib.rs
+++ b/crates/tmg-core/src/lib.rs
@@ -1,1 +1,10 @@
-// tmg-core: Core domain types, traits, and orchestration logic for tsumugi.
+//! tmg-core: Core domain types, traits, and orchestration logic for tsumugi.
+
+pub mod agent_loop;
+pub mod error;
+pub mod message;
+pub mod prompt;
+
+pub use agent_loop::{AgentLoop, StreamSink};
+pub use error::CoreError;
+pub use message::Message;

--- a/crates/tmg-core/src/message.rs
+++ b/crates/tmg-core/src/message.rs
@@ -9,10 +9,10 @@ use tmg_llm::{ChatMessage, Role};
 #[derive(Debug, Clone, PartialEq)]
 pub struct Message {
     /// The author role of this message.
-    pub role: Role,
+    pub(crate) role: Role,
 
     /// The text content of this message.
-    pub content: String,
+    pub(crate) content: String,
 }
 
 impl Message {
@@ -37,6 +37,26 @@ impl Message {
         Self {
             role: Role::Assistant,
             content: content.into(),
+        }
+    }
+
+    /// Return the author role of this message.
+    pub fn role(&self) -> Role {
+        self.role
+    }
+
+    /// Return the text content of this message.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    /// Create a [`ChatMessage`] by borrowing self, cloning only the content string.
+    pub fn to_chat_message(&self) -> ChatMessage {
+        ChatMessage {
+            role: self.role,
+            content: Some(self.content.clone()),
+            tool_calls: None,
+            tool_call_id: None,
         }
     }
 

--- a/crates/tmg-core/src/message.rs
+++ b/crates/tmg-core/src/message.rs
@@ -1,0 +1,58 @@
+//! Conversation message types for the agent loop.
+
+use tmg_llm::{ChatMessage, Role};
+
+/// A conversation message with a role and text content.
+///
+/// This is a simplified view used by the agent loop. It converts to/from
+/// the LLM layer's [`ChatMessage`] for wire transmission.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Message {
+    /// The author role of this message.
+    pub role: Role,
+
+    /// The text content of this message.
+    pub content: String,
+}
+
+impl Message {
+    /// Create a new system message.
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::System,
+            content: content.into(),
+        }
+    }
+
+    /// Create a new user message.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: content.into(),
+        }
+    }
+
+    /// Create a new assistant message.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: content.into(),
+        }
+    }
+
+    /// Convert this message into a [`ChatMessage`] for the LLM API.
+    pub fn into_chat_message(self) -> ChatMessage {
+        ChatMessage {
+            role: self.role,
+            content: Some(self.content),
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+}
+
+impl From<Message> for ChatMessage {
+    fn from(msg: Message) -> Self {
+        msg.into_chat_message()
+    }
+}

--- a/crates/tmg-core/src/prompt.rs
+++ b/crates/tmg-core/src/prompt.rs
@@ -1,0 +1,157 @@
+//! System prompt assembly from TSUMUGI.md and AGENTS.md files.
+//!
+//! Loads prompt files from:
+//! - `~/.config/tsumugi/TSUMUGI.md` (global)
+//! - Each directory from project root down to the current working directory
+//! - Same paths for `AGENTS.md` (compatibility alias)
+//!
+//! Missing files are silently skipped. I/O errors on existing files are
+//! propagated with context.
+
+use std::path::{Path, PathBuf};
+
+use crate::message::Message;
+
+/// File names to search for prompt content.
+const PROMPT_FILE_NAMES: &[&str] = &["TSUMUGI.md", "AGENTS.md"];
+
+/// Load all prompt files and return them as user-role messages to inject
+/// at the start of the conversation.
+///
+/// The order is:
+/// 1. Global config directory (`~/.config/tsumugi/`)
+/// 2. Each directory from `project_root` down to `cwd` (inclusive)
+///
+/// Within each directory, `TSUMUGI.md` is loaded before `AGENTS.md`.
+///
+/// # Errors
+///
+/// Returns an I/O error if a file exists but cannot be read.
+pub fn load_prompt_files(project_root: &Path, cwd: &Path) -> Result<Vec<Message>, std::io::Error> {
+    let mut messages = Vec::new();
+
+    // 1. Global config directory
+    if let Some(config_dir) = dirs::config_dir() {
+        let global_dir = config_dir.join("tsumugi");
+        load_from_directory(&global_dir, &mut messages)?;
+    }
+
+    // 2. Walk from project_root down to cwd
+    let directories = directories_from_root_to_cwd(project_root, cwd);
+    for dir in &directories {
+        load_from_directory(dir, &mut messages)?;
+    }
+
+    Ok(messages)
+}
+
+/// Attempt to load prompt files from a single directory.
+///
+/// Missing files are silently skipped; other I/O errors are returned.
+fn load_from_directory(dir: &Path, messages: &mut Vec<Message>) -> Result<(), std::io::Error> {
+    for &filename in PROMPT_FILE_NAMES {
+        let path = dir.join(filename);
+        match std::fs::read_to_string(&path) {
+            Ok(content) if !content.trim().is_empty() => {
+                messages.push(Message::user(content));
+            }
+            Ok(_) => {
+                // Empty file, skip.
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // File does not exist, skip silently.
+            }
+            Err(e) => {
+                return Err(std::io::Error::other(format!(
+                    "failed to read {}: {e}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Compute the list of directories from `root` down to `target` (inclusive).
+///
+/// If `target` is not a descendant of `root`, only `root` is returned.
+fn directories_from_root_to_cwd(root: &Path, target: &Path) -> Vec<PathBuf> {
+    // Canonicalize-like normalization without following symlinks is tricky.
+    // We use the paths as-is and rely on `strip_prefix`.
+    let Ok(relative) = target.strip_prefix(root) else {
+        // target is not under root; just return root.
+        return vec![root.to_path_buf()];
+    };
+
+    let mut dirs = Vec::new();
+    let mut current = root.to_path_buf();
+    dirs.push(current.clone());
+
+    for component in relative.components() {
+        current.push(component);
+        dirs.push(current.clone());
+    }
+
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn directories_from_root_to_cwd_basic() {
+        let root = Path::new("/home/user/project");
+        let cwd = Path::new("/home/user/project/src/core");
+
+        let dirs = directories_from_root_to_cwd(root, cwd);
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("/home/user/project"),
+                PathBuf::from("/home/user/project/src"),
+                PathBuf::from("/home/user/project/src/core"),
+            ]
+        );
+    }
+
+    #[test]
+    fn directories_from_root_to_cwd_same_dir() {
+        let root = Path::new("/home/user/project");
+        let cwd = Path::new("/home/user/project");
+
+        let dirs = directories_from_root_to_cwd(root, cwd);
+        assert_eq!(dirs, vec![PathBuf::from("/home/user/project")]);
+    }
+
+    #[test]
+    fn directories_from_root_to_cwd_not_descendant() {
+        let root = Path::new("/home/user/project");
+        let cwd = Path::new("/tmp/other");
+
+        let dirs = directories_from_root_to_cwd(root, cwd);
+        assert_eq!(dirs, vec![PathBuf::from("/home/user/project")]);
+    }
+
+    #[test]
+    fn load_from_directory_missing_dir() {
+        let mut messages = Vec::new();
+        let result = load_from_directory(Path::new("/nonexistent/path"), &mut messages);
+        assert!(result.is_ok());
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn load_prompt_files_empty_dirs() {
+        // Use a temp dir with no prompt files
+        let tmp = std::env::temp_dir().join("tmg_test_prompt_empty");
+        let _ = std::fs::create_dir_all(&tmp);
+
+        let result = load_prompt_files(&tmp, &tmp);
+        assert!(result.is_ok());
+        // Should have no messages from the temp dir (global config may contribute)
+        // We just verify no error occurred.
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/crates/tmg-core/src/prompt.rs
+++ b/crates/tmg-core/src/prompt.rs
@@ -62,10 +62,10 @@ fn load_from_directory(dir: &Path, messages: &mut Vec<Message>) -> Result<(), st
                 // File does not exist, skip silently.
             }
             Err(e) => {
-                return Err(std::io::Error::other(format!(
-                    "failed to read {}: {e}",
-                    path.display()
-                )));
+                return Err(std::io::Error::new(
+                    e.kind(),
+                    format!("failed to read {}: {e}", path.display()),
+                ));
             }
         }
     }

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tmg-core = { workspace = true }

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -22,6 +22,8 @@ fn main() -> anyhow::Result<()> {
 
     if let Some(prompt) = cli.prompt {
         run_prompt(&cli.endpoint, &cli.model, &prompt)?;
+    } else {
+        run_interactive(&cli.endpoint, &cli.model)?;
     }
 
     Ok(())
@@ -77,4 +79,105 @@ fn run_prompt(endpoint: &str, model: &str, prompt: &str) -> anyhow::Result<()> {
 
         Ok::<(), anyhow::Error>(())
     })
+}
+
+/// Run an interactive multi-turn conversation loop.
+///
+/// Reads user input from stdin line-by-line, sends each line to the LLM
+/// via [`tmg_core::AgentLoop`], and streams the response to stdout.
+/// The loop exits on EOF (Ctrl-D) or when the `CancellationToken` is
+/// triggered (Ctrl-C).
+#[expect(
+    clippy::print_stderr,
+    reason = "CLI interactive mode: stderr used for user-facing prompts and status"
+)]
+fn run_interactive(endpoint: &str, model: &str) -> anyhow::Result<()> {
+    use std::io::{BufRead as _, Write as _};
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let config = tmg_llm::LlmClientConfig::new(endpoint, model);
+        let client = tmg_llm::LlmClient::new(config)?;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        // Set up Ctrl-C handler for graceful shutdown.
+        let cancel_for_handler = cancel.clone();
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                cancel_for_handler.cancel();
+            }
+        });
+
+        let cwd = std::env::current_dir()?;
+        // Use cwd as project root for now (could be improved with git root detection).
+        let project_root = cwd.clone();
+
+        let mut agent = tmg_core::AgentLoop::new(client, cancel.clone(), &project_root, &cwd)?;
+
+        let stdin = std::io::stdin();
+        let mut reader = stdin.lock();
+
+        let mut sink = StdoutSink;
+
+        loop {
+            if cancel.is_cancelled() {
+                eprintln!("\n[cancelled]");
+                break;
+            }
+
+            eprint!("> ");
+            std::io::stderr().flush()?;
+
+            let mut input = String::new();
+            let bytes_read = reader.read_line(&mut input)?;
+
+            // EOF (Ctrl-D)
+            if bytes_read == 0 {
+                eprintln!("\n[bye]");
+                break;
+            }
+
+            let trimmed = input.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            match agent.turn(trimmed, &mut sink).await {
+                Ok(()) => {}
+                Err(tmg_core::CoreError::Cancelled) => {
+                    eprintln!("\n[cancelled]");
+                    break;
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::from(e));
+                }
+            }
+        }
+
+        Ok::<(), anyhow::Error>(())
+    })
+}
+
+/// A [`tmg_core::StreamSink`] that writes tokens to stdout.
+struct StdoutSink;
+
+#[expect(
+    clippy::print_stdout,
+    reason = "CLI streaming output sink: intentional stdout writes"
+)]
+impl tmg_core::StreamSink for StdoutSink {
+    fn on_token(&mut self, token: &str) -> Result<(), tmg_core::CoreError> {
+        use std::io::Write as _;
+        print!("{token}");
+        std::io::stdout().flush()?;
+        Ok(())
+    }
+
+    fn on_done(&mut self) -> Result<(), tmg_core::CoreError> {
+        use std::io::Write as _;
+        println!();
+        std::io::stdout().flush()?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

- Implement `AgentLoop` struct in tmg-core with conversation history management, system prompt assembly from TSUMUGI.md/AGENTS.md files, streaming turn execution via `StreamSink` trait, and `CancellationToken`-based graceful shutdown
- Add `Message`, `CoreError`, and prompt file loading modules to tmg-core
- Update tmg-cli to support interactive multi-turn conversations (stdin input, stdout streaming output) when launched without `--prompt`

## Crates modified

- **tmg-core**: New modules `agent_loop`, `error`, `message`, `prompt` with 7 unit tests
- **tmg-cli**: Added `run_interactive()` and `StdoutSink` for CLI-based conversation
- **root Cargo.toml**: Added `dirs` workspace dependency for cross-platform config directory resolution

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes (15 tests: 7 new in tmg-core, 8 existing in tmg-llm)
- [ ] Integration: launch `tmg-cli` without `--prompt`, type 2+ turns of conversation against llama-server, verify streaming output and history retention
- [ ] Verify TSUMUGI.md at project root is picked up and included in prompts
- [ ] Verify Ctrl-C triggers graceful shutdown via CancellationToken

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)