### PR TITLE
tmg-tui: Implement basic TUI chat interface (#4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +178,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,13 +284,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -214,6 +321,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -309,6 +428,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -498,6 +628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +652,28 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -539,6 +697,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -574,16 +741,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "lru-slab"
@@ -610,6 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -641,6 +833,35 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -781,6 +1002,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +1104,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +1162,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -961,6 +1231,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,10 +1290,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1146,6 +1465,15 @@ version = "0.1.0"
 [[package]]
 name = "tmg-tui"
 version = "0.1.0"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "thiserror",
+ "tmg-core",
+ "tmg-llm",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "tokio"
@@ -1283,6 +1611,35 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "untrusted"
@@ -1434,6 +1791,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -74,6 +74,14 @@ impl AgentLoop {
         })
     }
 
+    /// Replace the cancellation token used for future turns.
+    ///
+    /// This is useful for using a child token per conversation turn so
+    /// that cancelling one turn does not shut down the entire app.
+    pub fn set_cancel_token(&mut self, token: CancellationToken) {
+        self.cancel = token;
+    }
+
     /// Return a read-only view of the conversation history.
     pub fn history(&self) -> &[Message] {
         &self.history

--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -79,6 +79,23 @@ impl AgentLoop {
         &self.history
     }
 
+    /// Clear conversation history, retaining only the system prompt and
+    /// any injected prompt-file messages.
+    ///
+    /// This reloads prompt files from `project_root`/`cwd` so the
+    /// conversation restarts with a fresh context.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError::Io`] if a prompt file exists but cannot be read.
+    pub fn clear_history(&mut self, project_root: &Path, cwd: &Path) -> Result<(), CoreError> {
+        let mut history = vec![Message::system(DEFAULT_SYSTEM_PROMPT)];
+        let prompt_messages = prompt::load_prompt_files(project_root, cwd)?;
+        history.extend(prompt_messages);
+        self.history = history;
+        Ok(())
+    }
+
     /// Execute a single conversation turn.
     ///
     /// Adds the user message to history, streams the LLM response through

--- a/crates/tmg-tui/Cargo.toml
+++ b/crates/tmg-tui/Cargo.toml
@@ -10,7 +10,7 @@ tmg-core = { workspace = true }
 tmg-llm = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
-tokio = { workspace = true, features = ["signal"] }
+tokio = { workspace = true, features = ["signal", "sync"] }
 tokio-util = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/tmg-tui/Cargo.toml
+++ b/crates/tmg-tui/Cargo.toml
@@ -6,6 +6,13 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+tmg-core = { workspace = true }
+tmg-llm = { workspace = true }
+ratatui = { workspace = true }
+crossterm = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
+tokio-util = { workspace = true }
+thiserror = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -1,0 +1,365 @@
+//! Application state and business logic for the TUI.
+
+use std::path::PathBuf;
+
+use tmg_core::{AgentLoop, CoreError, StreamSink};
+use tmg_llm::Role;
+
+/// Represents a single entry in the chat display.
+#[derive(Debug, Clone)]
+pub struct ChatEntry {
+    /// The author role of this entry.
+    pub role: Role,
+    /// The text content.
+    pub text: String,
+}
+
+/// The main application state.
+pub struct App {
+    /// The agent loop driving LLM conversations.
+    agent: AgentLoop,
+
+    /// Chat entries displayed in the chat pane.
+    chat_entries: Vec<ChatEntry>,
+
+    /// The current text in the input area.
+    input: String,
+
+    /// Cursor position within the input string (byte offset).
+    cursor_pos: usize,
+
+    /// Vertical scroll offset for the chat pane.
+    chat_scroll: u16,
+
+    /// Whether the app should exit at the next opportunity.
+    should_exit: bool,
+
+    /// Whether the agent is currently streaming a response.
+    streaming: bool,
+
+    /// Model name for header display.
+    model_name: String,
+
+    /// Context usage for header display (dummy value for now).
+    context_usage: String,
+
+    /// Project root for prompt file reloading on clear.
+    project_root: PathBuf,
+
+    /// Current working directory for prompt file reloading on clear.
+    cwd: PathBuf,
+
+    /// Optional error message to display.
+    error_message: Option<String>,
+}
+
+impl App {
+    /// Create a new `App` with the given agent loop and model name.
+    pub fn new(agent: AgentLoop, model_name: &str, project_root: PathBuf, cwd: PathBuf) -> Self {
+        Self {
+            agent,
+            chat_entries: Vec::new(),
+            input: String::new(),
+            cursor_pos: 0,
+            chat_scroll: 0,
+            should_exit: false,
+            streaming: false,
+            model_name: model_name.to_owned(),
+            context_usage: "0 / ? tokens".to_owned(),
+            project_root,
+            cwd,
+            error_message: None,
+        }
+    }
+
+    /// Whether the application should exit.
+    pub fn should_exit(&self) -> bool {
+        self.should_exit
+    }
+
+    /// Request the application to exit.
+    pub fn request_exit(&mut self) {
+        self.should_exit = true;
+    }
+
+    /// Whether the agent is currently streaming a response.
+    pub fn is_streaming(&self) -> bool {
+        self.streaming
+    }
+
+    /// Return the model name for display.
+    pub fn model_name(&self) -> &str {
+        &self.model_name
+    }
+
+    /// Return the context usage string for display.
+    pub fn context_usage(&self) -> &str {
+        &self.context_usage
+    }
+
+    /// Return a reference to the chat entries.
+    pub fn chat_entries(&self) -> &[ChatEntry] {
+        &self.chat_entries
+    }
+
+    /// Return the current input text.
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+
+    /// Return the cursor position (byte offset).
+    pub fn cursor_pos(&self) -> usize {
+        self.cursor_pos
+    }
+
+    /// Return the chat scroll offset.
+    pub fn chat_scroll(&self) -> u16 {
+        self.chat_scroll
+    }
+
+    /// Set the chat scroll offset.
+    pub fn set_chat_scroll(&mut self, offset: u16) {
+        self.chat_scroll = offset;
+    }
+
+    /// Return the current error message, if any.
+    pub fn error_message(&self) -> Option<&str> {
+        self.error_message.as_deref()
+    }
+
+    /// Clear the error message.
+    pub fn clear_error(&mut self) {
+        self.error_message = None;
+    }
+
+    /// Insert a character at the cursor position.
+    pub fn insert_char(&mut self, ch: char) {
+        self.input.insert(self.cursor_pos, ch);
+        self.cursor_pos += ch.len_utf8();
+    }
+
+    /// Insert a newline at the cursor position.
+    pub fn insert_newline(&mut self) {
+        self.insert_char('\n');
+    }
+
+    /// Delete the character before the cursor (backspace).
+    pub fn delete_char_before_cursor(&mut self) {
+        if self.cursor_pos == 0 {
+            return;
+        }
+        // Find the previous char boundary.
+        let prev = self.input[..self.cursor_pos]
+            .char_indices()
+            .next_back()
+            .map_or(0, |(i, _)| i);
+        self.input.drain(prev..self.cursor_pos);
+        self.cursor_pos = prev;
+    }
+
+    /// Delete the character at the cursor position (delete key).
+    pub fn delete_char_at_cursor(&mut self) {
+        if self.cursor_pos >= self.input.len() {
+            return;
+        }
+        // Find the next char boundary.
+        let next = self.input[self.cursor_pos..]
+            .char_indices()
+            .nth(1)
+            .map_or(self.input.len(), |(i, _)| self.cursor_pos + i);
+        self.input.drain(self.cursor_pos..next);
+    }
+
+    /// Move cursor left by one character.
+    pub fn move_cursor_left(&mut self) {
+        if self.cursor_pos == 0 {
+            return;
+        }
+        self.cursor_pos = self.input[..self.cursor_pos]
+            .char_indices()
+            .next_back()
+            .map_or(0, |(i, _)| i);
+    }
+
+    /// Move cursor right by one character.
+    pub fn move_cursor_right(&mut self) {
+        if self.cursor_pos >= self.input.len() {
+            return;
+        }
+        self.cursor_pos = self.input[self.cursor_pos..]
+            .char_indices()
+            .nth(1)
+            .map_or(self.input.len(), |(i, _)| self.cursor_pos + i);
+    }
+
+    /// Move cursor to the beginning of the input.
+    pub fn move_cursor_home(&mut self) {
+        self.cursor_pos = 0;
+    }
+
+    /// Move cursor to the end of the input.
+    pub fn move_cursor_end(&mut self) {
+        self.cursor_pos = self.input.len();
+    }
+
+    /// Submit the current input. Returns `true` if a turn was initiated,
+    /// `false` if the input was empty or a slash command was handled.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `CoreError` if slash command processing fails.
+    pub fn submit_input(&mut self) -> Result<Option<String>, CoreError> {
+        let text = self.input.trim().to_owned();
+        self.input.clear();
+        self.cursor_pos = 0;
+
+        if text.is_empty() {
+            return Ok(None);
+        }
+
+        // Handle slash commands.
+        if let Some(cmd) = text.strip_prefix('/') {
+            self.handle_slash_command(cmd)?;
+            return Ok(None);
+        }
+
+        // Add user entry to chat.
+        self.chat_entries.push(ChatEntry {
+            role: Role::User,
+            text: text.clone(),
+        });
+
+        Ok(Some(text))
+    }
+
+    /// Handle a slash command. Returns `Ok(())` if handled.
+    fn handle_slash_command(&mut self, cmd: &str) -> Result<(), CoreError> {
+        match cmd.trim() {
+            "exit" | "quit" => {
+                self.should_exit = true;
+            }
+            "clear" => {
+                self.chat_entries.clear();
+                self.chat_scroll = 0;
+                self.agent.clear_history(&self.project_root, &self.cwd)?;
+            }
+            other => {
+                self.error_message = Some(format!("Unknown command: /{other}"));
+            }
+        }
+        Ok(())
+    }
+
+    /// Execute a conversation turn with the given user input.
+    ///
+    /// This is called from the event loop after `submit_input` returns
+    /// `Some(text)`. The streaming response is delivered via a
+    /// [`TuiStreamSink`] that appends tokens to the last chat entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CoreError` on LLM failure or cancellation.
+    pub async fn run_turn(&mut self, user_input: &str) -> Result<(), CoreError> {
+        // Prepare an assistant entry for streaming output.
+        self.chat_entries.push(ChatEntry {
+            role: Role::Assistant,
+            text: String::new(),
+        });
+        self.streaming = true;
+
+        let mut sink = TuiStreamSink {
+            entries: &mut self.chat_entries,
+        };
+
+        let result = self.agent.turn(user_input, &mut sink).await;
+        self.streaming = false;
+
+        // Update context usage with conversation turn count (dummy).
+        let user_turns = self
+            .agent
+            .history()
+            .iter()
+            .filter(|m| m.role() == Role::User)
+            .count();
+        self.context_usage = format!("{user_turns} turns");
+
+        result
+    }
+
+    /// Set an error message to display in the TUI.
+    pub fn set_error(&mut self, msg: String) {
+        self.error_message = Some(msg);
+    }
+
+    /// Scroll the chat pane up by the given number of lines.
+    pub fn scroll_up(&mut self, lines: u16) {
+        self.chat_scroll = self.chat_scroll.saturating_add(lines);
+    }
+
+    /// Scroll the chat pane down by the given number of lines.
+    pub fn scroll_down(&mut self, lines: u16) {
+        self.chat_scroll = self.chat_scroll.saturating_sub(lines);
+    }
+}
+
+/// A [`StreamSink`] that appends tokens to the last chat entry.
+struct TuiStreamSink<'a> {
+    entries: &'a mut Vec<ChatEntry>,
+}
+
+impl StreamSink for TuiStreamSink<'_> {
+    fn on_token(&mut self, token: &str) -> Result<(), CoreError> {
+        if let Some(last) = self.entries.last_mut() {
+            last.text.push_str(token);
+        }
+        Ok(())
+    }
+
+    fn on_done(&mut self) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn insert_and_delete_chars() {
+        // We can't easily create an AgentLoop without an LlmClient,
+        // so we test the input manipulation methods via a helper.
+        let mut input = String::new();
+        let mut cursor: usize = 0;
+
+        // Simulate insert_char
+        input.insert(cursor, 'H');
+        cursor += 'H'.len_utf8();
+        input.insert(cursor, 'i');
+        cursor += 'i'.len_utf8();
+
+        assert_eq!(input, "Hi");
+        assert_eq!(cursor, 2);
+
+        // Simulate backspace
+        let prev = input[..cursor]
+            .char_indices()
+            .next_back()
+            .map_or(0, |(i, _)| i);
+        input.drain(prev..cursor);
+        cursor = prev;
+
+        assert_eq!(input, "H");
+        assert_eq!(cursor, 1);
+    }
+
+    #[test]
+    fn slash_command_parsing() {
+        // Test that slash commands are recognized
+        let text = "/clear";
+        assert!(text.strip_prefix('/').is_some());
+
+        let text = "/exit";
+        assert_eq!(text.strip_prefix('/'), Some("exit"));
+
+        let text = "hello";
+        assert!(text.strip_prefix('/').is_none());
+    }
+}

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -4,6 +4,9 @@ use std::path::PathBuf;
 
 use tmg_core::{AgentLoop, CoreError, StreamSink};
 use tmg_llm::Role;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 /// Represents a single entry in the chat display.
 #[derive(Debug, Clone)]
@@ -14,10 +17,46 @@ pub struct ChatEntry {
     pub text: String,
 }
 
+/// Messages sent from the background turn task to the event loop.
+pub enum TurnMessage {
+    /// An incremental token from the LLM stream.
+    Token(String),
+    /// The turn completed successfully. Contains the `AgentLoop` back
+    /// and the turn count for context display.
+    Done {
+        /// The agent loop returned after the turn completes.
+        agent: AgentLoop,
+        /// Number of user turns so far (for context usage display).
+        user_turns: usize,
+    },
+    /// The turn failed with an error. Contains the `AgentLoop` back.
+    Error {
+        /// The agent loop returned after the turn fails.
+        agent: AgentLoop,
+        /// The error message.
+        message: String,
+        /// Whether the error was a cancellation.
+        cancelled: bool,
+    },
+}
+
+/// Handle for a running conversation turn background task.
+struct TurnHandle {
+    /// Receiver for turn messages (tokens, done, error).
+    rx: mpsc::Receiver<TurnMessage>,
+    /// Child cancellation token for this specific turn.
+    turn_cancel: CancellationToken,
+    /// Join handle for the spawned task.
+    _join: JoinHandle<()>,
+}
+
 /// The main application state.
 pub struct App {
     /// The agent loop driving LLM conversations.
-    agent: AgentLoop,
+    ///
+    /// This is `None` while a turn is running in a background task
+    /// (the task temporarily takes ownership).
+    agent: Option<AgentLoop>,
 
     /// Chat entries displayed in the chat pane.
     chat_entries: Vec<ChatEntry>,
@@ -51,13 +90,16 @@ pub struct App {
 
     /// Optional error message to display.
     error_message: Option<String>,
+
+    /// Handle for the currently running turn, if any.
+    turn_handle: Option<TurnHandle>,
 }
 
 impl App {
     /// Create a new `App` with the given agent loop and model name.
     pub fn new(agent: AgentLoop, model_name: &str, project_root: PathBuf, cwd: PathBuf) -> Self {
         Self {
-            agent,
+            agent: Some(agent),
             chat_entries: Vec::new(),
             input: String::new(),
             cursor_pos: 0,
@@ -69,6 +111,7 @@ impl App {
             project_root,
             cwd,
             error_message: None,
+            turn_handle: None,
         }
     }
 
@@ -202,8 +245,9 @@ impl App {
         self.cursor_pos = self.input.len();
     }
 
-    /// Submit the current input. Returns `true` if a turn was initiated,
-    /// `false` if the input was empty or a slash command was handled.
+    /// Submit the current input. Returns `Some(text)` if a conversation
+    /// turn should be started, `None` if the input was empty or a slash
+    /// command was handled.
     ///
     /// # Errors
     ///
@@ -241,7 +285,9 @@ impl App {
             "clear" => {
                 self.chat_entries.clear();
                 self.chat_scroll = 0;
-                self.agent.clear_history(&self.project_root, &self.cwd)?;
+                if let Some(agent) = &mut self.agent {
+                    agent.clear_history(&self.project_root, &self.cwd)?;
+                }
             }
             other => {
                 self.error_message = Some(format!("Unknown command: /{other}"));
@@ -250,16 +296,31 @@ impl App {
         Ok(())
     }
 
-    /// Execute a conversation turn with the given user input.
+    /// Start a conversation turn in a background task.
     ///
-    /// This is called from the event loop after `submit_input` returns
-    /// `Some(text)`. The streaming response is delivered via a
-    /// [`TuiStreamSink`] that appends tokens to the last chat entry.
+    /// The turn runs on a spawned tokio task. Streaming tokens are sent
+    /// through an `mpsc` channel that the event loop drains on each
+    /// tick. A child `CancellationToken` is used so that cancelling a
+    /// turn does not shut down the entire application.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns `CoreError` on LLM failure or cancellation.
-    pub async fn run_turn(&mut self, user_input: &str) -> Result<(), CoreError> {
+    /// Panics if called while the agent is `None` (i.e., another turn
+    /// is already running). This is guarded by `is_streaming()` checks
+    /// in the event loop.
+    pub fn start_turn(&mut self, user_input: String, parent_cancel: &CancellationToken) {
+        let Some(mut agent) = self.agent.take() else {
+            // Should not happen: the event loop checks `is_streaming()`
+            // before calling `start_turn`.
+            return;
+        };
+
+        // Create a child token for this turn.
+        let turn_cancel = parent_cancel.child_token();
+
+        // Set the child token on the agent so `chat_streaming` uses it.
+        agent.set_cancel_token(turn_cancel.clone());
+
         // Prepare an assistant entry for streaming output.
         self.chat_entries.push(ChatEntry {
             role: Role::Assistant,
@@ -267,23 +328,117 @@ impl App {
         });
         self.streaming = true;
 
-        let mut sink = TuiStreamSink {
-            entries: &mut self.chat_entries,
+        let (tx, rx) = mpsc::channel::<TurnMessage>(256);
+
+        let join = tokio::spawn(async move {
+            let mut sink = ChannelStreamSink { tx: tx.clone() };
+            let result = agent.turn(&user_input, &mut sink).await;
+
+            match result {
+                Ok(()) => {
+                    let user_turns = agent
+                        .history()
+                        .iter()
+                        .filter(|m| m.role() == Role::User)
+                        .count();
+                    // Ignore send errors — the receiver may have been
+                    // dropped if the app is shutting down.
+                    let _ = tx.send(TurnMessage::Done { agent, user_turns }).await;
+                }
+                Err(CoreError::Cancelled) => {
+                    let _ = tx
+                        .send(TurnMessage::Error {
+                            agent,
+                            message: "Request cancelled".to_owned(),
+                            cancelled: true,
+                        })
+                        .await;
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(TurnMessage::Error {
+                            agent,
+                            message: e.to_string(),
+                            cancelled: false,
+                        })
+                        .await;
+                }
+            }
+        });
+
+        self.turn_handle = Some(TurnHandle {
+            rx,
+            turn_cancel,
+            _join: join,
+        });
+    }
+
+    /// Drain pending turn messages from the background task channel.
+    ///
+    /// Returns `true` if a redraw is needed (i.e., at least one message
+    /// was received).
+    pub fn drain_turn_messages(&mut self) -> bool {
+        let Some(handle) = &mut self.turn_handle else {
+            return false;
         };
 
-        let result = self.agent.turn(user_input, &mut sink).await;
-        self.streaming = false;
+        let mut changed = false;
 
-        // Update context usage with conversation turn count (dummy).
-        let user_turns = self
-            .agent
-            .history()
-            .iter()
-            .filter(|m| m.role() == Role::User)
-            .count();
-        self.context_usage = format!("{user_turns} turns");
+        loop {
+            match handle.rx.try_recv() {
+                Ok(TurnMessage::Token(token)) => {
+                    if let Some(last) = self.chat_entries.last_mut() {
+                        last.text.push_str(&token);
+                    }
+                    changed = true;
+                }
+                Ok(TurnMessage::Done { agent, user_turns }) => {
+                    self.agent = Some(agent);
+                    self.streaming = false;
+                    self.turn_handle = None;
+                    self.context_usage = format!("{user_turns} turns");
+                    self.set_chat_scroll(0);
+                    return true;
+                }
+                Ok(TurnMessage::Error {
+                    agent,
+                    message,
+                    cancelled,
+                }) => {
+                    self.agent = Some(agent);
+                    self.streaming = false;
+                    self.turn_handle = None;
+                    self.error_message = Some(message);
+                    if cancelled {
+                        // Remove the empty/partial assistant entry on cancellation.
+                        if let Some(last) = self.chat_entries.last() {
+                            if last.role == Role::Assistant && last.text.is_empty() {
+                                self.chat_entries.pop();
+                            }
+                        }
+                    }
+                    self.set_chat_scroll(0);
+                    return true;
+                }
+                Err(mpsc::error::TryRecvError::Empty) => {
+                    return changed;
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    // The task ended without sending Done/Error (should
+                    // not happen, but handle gracefully).
+                    self.streaming = false;
+                    self.turn_handle = None;
+                    return true;
+                }
+            }
+        }
+    }
 
-        result
+    /// Cancel the currently running turn, if any.
+    pub fn cancel_turn(&mut self) {
+        if let Some(handle) = &self.turn_handle {
+            handle.turn_cancel.cancel();
+        }
     }
 
     /// Set an error message to display in the TUI.
@@ -302,17 +457,19 @@ impl App {
     }
 }
 
-/// A [`StreamSink`] that appends tokens to the last chat entry.
-struct TuiStreamSink<'a> {
-    entries: &'a mut Vec<ChatEntry>,
+/// A [`StreamSink`] that sends tokens through an `mpsc` channel.
+struct ChannelStreamSink {
+    tx: mpsc::Sender<TurnMessage>,
 }
 
-impl StreamSink for TuiStreamSink<'_> {
+impl StreamSink for ChannelStreamSink {
     fn on_token(&mut self, token: &str) -> Result<(), CoreError> {
-        if let Some(last) = self.entries.last_mut() {
-            last.text.push_str(token);
-        }
-        Ok(())
+        // Use blocking_send since StreamSink::on_token is not async.
+        // This will block briefly if the channel is full, which provides
+        // natural back-pressure.
+        self.tx
+            .blocking_send(TurnMessage::Token(token.to_owned()))
+            .map_err(|_| CoreError::Cancelled)
     }
 
     fn on_done(&mut self) -> Result<(), CoreError> {

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -424,10 +424,14 @@ impl App {
                     return changed;
                 }
                 Err(mpsc::error::TryRecvError::Disconnected) => {
-                    // The task ended without sending Done/Error (should
-                    // not happen, but handle gracefully).
+                    // The task ended without sending Done/Error — this
+                    // means it panicked or was dropped unexpectedly.
+                    // Reset streaming state and surface an error so the
+                    // user knows recovery requires a restart.
                     self.streaming = false;
                     self.turn_handle = None;
+                    self.error_message =
+                        Some("Background task ended unexpectedly; please restart.".to_owned());
                     return true;
                 }
             }
@@ -464,11 +468,8 @@ struct ChannelStreamSink {
 
 impl StreamSink for ChannelStreamSink {
     fn on_token(&mut self, token: &str) -> Result<(), CoreError> {
-        // Use blocking_send since StreamSink::on_token is not async.
-        // This will block briefly if the channel is full, which provides
-        // natural back-pressure.
         self.tx
-            .blocking_send(TurnMessage::Token(token.to_owned()))
+            .try_send(TurnMessage::Token(token.to_owned()))
             .map_err(|_| CoreError::Cancelled)
     }
 

--- a/crates/tmg-tui/src/error.rs
+++ b/crates/tmg-tui/src/error.rs
@@ -1,0 +1,17 @@
+//! Error types for the TUI crate.
+
+/// Errors produced by the TUI layer.
+#[derive(Debug, thiserror::Error)]
+pub enum TuiError {
+    /// An I/O error (e.g. terminal setup/teardown).
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// An error originating from the core orchestration layer.
+    #[error("core error: {0}")]
+    Core(#[from] tmg_core::CoreError),
+
+    /// The TUI session was cancelled (e.g. Ctrl+C / `CancellationToken`).
+    #[error("session cancelled")]
+    Cancelled,
+}

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -1,0 +1,199 @@
+//! Event loop: polls terminal events and drives the application.
+
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::DefaultTerminal;
+use tokio_util::sync::CancellationToken;
+
+use crate::app::App;
+use crate::error::TuiError;
+use crate::ui;
+
+/// The main event loop tick interval.
+///
+/// This controls how often the TUI checks for new terminal events
+/// and redraws the screen during streaming.
+const TICK_RATE: Duration = Duration::from_millis(33); // ~30 fps
+
+/// Run the TUI event loop.
+///
+/// This function takes ownership of the terminal and drives the
+/// application until exit is requested or the cancellation token
+/// fires.
+///
+/// # Cancel safety
+///
+/// The `tokio::select!` in this loop uses only cancel-safe futures:
+/// - `cancel.cancelled()` is cancel-safe (it is a future that
+///   completes when the token is cancelled).
+/// - `tokio::task::spawn_blocking` for event polling returns a
+///   `JoinHandle` which is cancel-safe.
+///
+/// # Errors
+///
+/// Returns `TuiError` on I/O failure or agent errors.
+pub async fn run_event_loop(
+    terminal: &mut DefaultTerminal,
+    app: &mut App,
+    cancel: CancellationToken,
+) -> Result<(), TuiError> {
+    loop {
+        // Draw the current state.
+        terminal.draw(|frame| ui::draw(frame, app))?;
+
+        if app.should_exit() {
+            return Ok(());
+        }
+
+        // Poll for events with cancellation support.
+        tokio::select! {
+            () = cancel.cancelled() => {
+                app.request_exit();
+                return Ok(());
+            }
+            maybe_event = poll_event() => {
+                match maybe_event {
+                    Ok(Some(event)) => {
+                        handle_event(app, event, &cancel).await?;
+                    }
+                    Ok(None) => {
+                        // No event within tick rate, continue (allows redraw during streaming).
+                    }
+                    Err(e) => {
+                        return Err(TuiError::Io(e));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Poll for a terminal event with a timeout.
+///
+/// This uses `spawn_blocking` to avoid blocking the async runtime.
+///
+/// # Cancel safety
+///
+/// Returns a `JoinHandle` future which is cancel-safe.
+async fn poll_event() -> Result<Option<Event>, std::io::Error> {
+    tokio::task::spawn_blocking(move || {
+        if event::poll(TICK_RATE)? {
+            Ok(Some(event::read()?))
+        } else {
+            Ok(None)
+        }
+    })
+    .await
+    .map_err(std::io::Error::other)?
+}
+
+/// Handle a single terminal event.
+async fn handle_event(
+    app: &mut App,
+    event: Event,
+    cancel: &CancellationToken,
+) -> Result<(), TuiError> {
+    // Terminal resize and other events are handled automatically by
+    // ratatui on the next draw call.
+    if let Event::Key(key_event) = event {
+        handle_key(app, key_event, cancel).await?;
+    }
+    Ok(())
+}
+
+/// Handle a key event.
+async fn handle_key(
+    app: &mut App,
+    key: KeyEvent,
+    cancel: &CancellationToken,
+) -> Result<(), TuiError> {
+    // Clear error on any keypress.
+    app.clear_error();
+
+    // Don't accept input while streaming (except Ctrl+C to cancel).
+    if app.is_streaming() {
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            cancel.cancel();
+        }
+        return Ok(());
+    }
+
+    match (key.code, key.modifiers) {
+        // Ctrl+C: exit.
+        (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
+            app.request_exit();
+        }
+        // Ctrl+Enter: submit input.
+        (KeyCode::Enter, m) if m.contains(KeyModifiers::CONTROL) => {
+            submit_and_run_turn(app).await?;
+        }
+        // Enter alone: insert newline.
+        (KeyCode::Enter, _) => {
+            app.insert_newline();
+        }
+        // Backspace: delete char before cursor.
+        (KeyCode::Backspace, _) => {
+            app.delete_char_before_cursor();
+        }
+        // Delete: delete char at cursor.
+        (KeyCode::Delete, _) => {
+            app.delete_char_at_cursor();
+        }
+        // Arrow keys: cursor movement.
+        (KeyCode::Left, _) => {
+            app.move_cursor_left();
+        }
+        (KeyCode::Right, _) => {
+            app.move_cursor_right();
+        }
+        // Home / End.
+        (KeyCode::Home, _) => {
+            app.move_cursor_home();
+        }
+        (KeyCode::End, _) => {
+            app.move_cursor_end();
+        }
+        // Page Up / Page Down for scrolling.
+        (KeyCode::PageUp, _) => {
+            app.scroll_up(10);
+        }
+        (KeyCode::PageDown, _) => {
+            app.scroll_down(10);
+        }
+        // Regular character input.
+        (KeyCode::Char(ch), m) if !m.contains(KeyModifiers::CONTROL) => {
+            app.insert_char(ch);
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+/// Submit input and execute a conversation turn.
+async fn submit_and_run_turn(app: &mut App) -> Result<(), TuiError> {
+    let user_input = match app.submit_input() {
+        Ok(Some(text)) => text,
+        Ok(None) => return Ok(()),
+        Err(e) => {
+            app.set_error(e.to_string());
+            return Ok(());
+        }
+    };
+
+    match app.run_turn(&user_input).await {
+        Ok(()) => {}
+        Err(tmg_core::CoreError::Cancelled) => {
+            app.set_error("Request cancelled".to_owned());
+        }
+        Err(e) => {
+            app.set_error(e.to_string());
+        }
+    }
+
+    // Auto-scroll to bottom after turn.
+    app.set_chat_scroll(0);
+
+    Ok(())
+}

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -39,6 +39,9 @@ pub async fn run_event_loop(
     cancel: CancellationToken,
 ) -> Result<(), TuiError> {
     loop {
+        // Drain any pending turn messages before drawing.
+        app.drain_turn_messages();
+
         // Draw the current state.
         terminal.draw(|frame| ui::draw(frame, app))?;
 
@@ -55,10 +58,11 @@ pub async fn run_event_loop(
             maybe_event = poll_event() => {
                 match maybe_event {
                     Ok(Some(event)) => {
-                        handle_event(app, event, &cancel).await?;
+                        handle_event(app, &event, &cancel);
                     }
                     Ok(None) => {
-                        // No event within tick rate, continue (allows redraw during streaming).
+                        // No event within tick rate, continue
+                        // (allows redraw with new streaming tokens).
                     }
                     Err(e) => {
                         return Err(TuiError::Io(e));
@@ -89,44 +93,36 @@ async fn poll_event() -> Result<Option<Event>, std::io::Error> {
 }
 
 /// Handle a single terminal event.
-async fn handle_event(
-    app: &mut App,
-    event: Event,
-    cancel: &CancellationToken,
-) -> Result<(), TuiError> {
+fn handle_event(app: &mut App, event: &Event, cancel: &CancellationToken) {
     // Terminal resize and other events are handled automatically by
     // ratatui on the next draw call.
     if let Event::Key(key_event) = event {
-        handle_key(app, key_event, cancel).await?;
+        handle_key(app, *key_event, cancel);
     }
-    Ok(())
 }
 
 /// Handle a key event.
-async fn handle_key(
-    app: &mut App,
-    key: KeyEvent,
-    cancel: &CancellationToken,
-) -> Result<(), TuiError> {
+fn handle_key(app: &mut App, key: KeyEvent, cancel: &CancellationToken) {
     // Clear error on any keypress.
     app.clear_error();
 
-    // Don't accept input while streaming (except Ctrl+C to cancel).
+    // While streaming, only Ctrl+C cancels the current turn.
     if app.is_streaming() {
         if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-            cancel.cancel();
+            app.cancel_turn();
         }
-        return Ok(());
+        return;
     }
 
     match (key.code, key.modifiers) {
-        // Ctrl+C: exit.
+        // Ctrl+C: exit (only when not streaming).
         (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
+            cancel.cancel();
             app.request_exit();
         }
-        // Ctrl+Enter: submit input.
+        // Ctrl+Enter: submit input and start turn.
         (KeyCode::Enter, m) if m.contains(KeyModifiers::CONTROL) => {
-            submit_and_run_turn(app).await?;
+            submit_and_start_turn(app, cancel);
         }
         // Enter alone: insert newline.
         (KeyCode::Enter, _) => {
@@ -167,33 +163,18 @@ async fn handle_key(
         }
         _ => {}
     }
-
-    Ok(())
 }
 
-/// Submit input and execute a conversation turn.
-async fn submit_and_run_turn(app: &mut App) -> Result<(), TuiError> {
+/// Submit input and start a background conversation turn.
+fn submit_and_start_turn(app: &mut App, cancel: &CancellationToken) {
     let user_input = match app.submit_input() {
         Ok(Some(text)) => text,
-        Ok(None) => return Ok(()),
+        Ok(None) => return,
         Err(e) => {
             app.set_error(e.to_string());
-            return Ok(());
+            return;
         }
     };
 
-    match app.run_turn(&user_input).await {
-        Ok(()) => {}
-        Err(tmg_core::CoreError::Cancelled) => {
-            app.set_error("Request cancelled".to_owned());
-        }
-        Err(e) => {
-            app.set_error(e.to_string());
-        }
-    }
-
-    // Auto-scroll to bottom after turn.
-    app.set_chat_scroll(0);
-
-    Ok(())
+    app.start_turn(user_input, cancel);
 }

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -19,7 +19,8 @@ use tokio_util::sync::CancellationToken;
 /// Run the TUI application.
 ///
 /// Sets up the terminal, creates the application state, and runs the
-/// event loop. The terminal is restored on exit (including on error).
+/// event loop. The terminal is restored on exit (including on error
+/// or panic).
 ///
 /// # Arguments
 ///
@@ -39,6 +40,15 @@ pub async fn run(
     project_root: PathBuf,
     cwd: PathBuf,
 ) -> Result<(), TuiError> {
+    // Install a panic hook that restores the terminal before printing
+    // the panic message.  Without this, a panic during TUI operation
+    // leaves the terminal in raw mode, making the shell unusable.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        ratatui::restore();
+        original_hook(info);
+    }));
+
     let mut terminal = ratatui::init();
     let mut app = App::new(agent, model_name, project_root, cwd);
 

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -1,1 +1,50 @@
-// tmg-tui: Terminal UI built with ratatui and crossterm.
+//! tmg-tui: Terminal UI built with ratatui and crossterm.
+//!
+//! Provides a chat interface for interactive conversations with a
+//! local LLM via the tsumugi agent loop.
+
+pub mod app;
+pub mod error;
+pub mod event;
+pub mod ui;
+
+pub use app::App;
+pub use error::TuiError;
+
+use std::path::PathBuf;
+
+use tmg_core::AgentLoop;
+use tokio_util::sync::CancellationToken;
+
+/// Run the TUI application.
+///
+/// Sets up the terminal, creates the application state, and runs the
+/// event loop. The terminal is restored on exit (including on error).
+///
+/// # Arguments
+///
+/// * `agent` - The agent loop to drive conversations.
+/// * `model_name` - Model name to display in the header.
+/// * `cancel` - Cancellation token for graceful shutdown.
+/// * `project_root` - Project root directory for prompt file loading.
+/// * `cwd` - Current working directory for prompt file loading.
+///
+/// # Errors
+///
+/// Returns `TuiError` on terminal I/O failure or agent errors.
+pub async fn run(
+    agent: AgentLoop,
+    model_name: &str,
+    cancel: CancellationToken,
+    project_root: PathBuf,
+    cwd: PathBuf,
+) -> Result<(), TuiError> {
+    let mut terminal = ratatui::init();
+    let mut app = App::new(agent, model_name, project_root, cwd);
+
+    let result = event::run_event_loop(&mut terminal, &mut app, cancel).await;
+
+    ratatui::restore();
+
+    result
+}

--- a/crates/tmg-tui/src/ui.rs
+++ b/crates/tmg-tui/src/ui.rs
@@ -88,22 +88,23 @@ fn draw_chat_pane(frame: &mut Frame, app: &App, area: Rect) {
                     .add_modifier(Modifier::BOLD),
             ),
             tmg_llm::Role::Assistant => ("Agent: ", Style::default().fg(Color::Blue)),
-            _ => ("", Style::default().fg(Color::DarkGray)),
+            tmg_llm::Role::System | tmg_llm::Role::Tool => {
+                ("", Style::default().fg(Color::DarkGray))
+            }
         };
 
-        // First line with prefix.
-        let content_lines: Vec<&str> = entry.text.split('\n').collect();
-        if let Some((first, rest)) = content_lines.split_first() {
+        // First line with prefix; remaining lines indented to align.
+        let mut content_lines = entry.text.split('\n');
+        if let Some(first) = content_lines.next() {
             lines.push(Line::from(vec![
                 Span::styled(prefix, style),
-                Span::styled((*first).to_owned(), style),
+                Span::styled(first, style),
             ]));
-            for line in rest {
-                // Indent continuation lines to align with content after prefix.
-                let indent = " ".repeat(prefix.len());
+            let indent = " ".repeat(prefix.len());
+            for line in content_lines {
                 lines.push(Line::from(vec![
-                    Span::raw(indent),
-                    Span::styled((*line).to_owned(), style),
+                    Span::raw(indent.clone()),
+                    Span::styled(line, style),
                 ]));
             }
         }

--- a/crates/tmg-tui/src/ui.rs
+++ b/crates/tmg-tui/src/ui.rs
@@ -1,0 +1,238 @@
+//! TUI rendering: layout and widget drawing.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{
+    Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap,
+};
+
+use crate::app::App;
+
+/// Render the full application UI into the given frame.
+pub fn draw(frame: &mut Frame, app: &App) {
+    let size = frame.area();
+
+    // Top-level layout: header, main area, input area.
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Header
+            Constraint::Min(5),    // Main area (chat + tool activity)
+            Constraint::Length(5), // Input area
+        ])
+        .split(size);
+
+    draw_header(frame, app, vertical[0]);
+    draw_main_area(frame, app, vertical[1]);
+    draw_input_area(frame, app, vertical[2]);
+
+    // Draw error overlay if present.
+    if let Some(err) = app.error_message() {
+        draw_error_overlay(frame, err, size);
+    }
+}
+
+/// Draw the header bar: model name and context usage.
+fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
+    let header_layout = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    let model_block = Block::default().borders(Borders::ALL).title(" Model ");
+    let model_text = Paragraph::new(Line::from(vec![Span::styled(
+        app.model_name(),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )]))
+    .block(model_block);
+    frame.render_widget(model_text, header_layout[0]);
+
+    let context_block = Block::default().borders(Borders::ALL).title(" Context ");
+    let context_text = Paragraph::new(Line::from(vec![Span::styled(
+        app.context_usage(),
+        Style::default().fg(Color::Yellow),
+    )]))
+    .block(context_block);
+    frame.render_widget(context_text, header_layout[1]);
+}
+
+/// Draw the main area: chat pane (left) and tool activity pane (right).
+fn draw_main_area(frame: &mut Frame, app: &App, area: Rect) {
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
+        .split(area);
+
+    draw_chat_pane(frame, app, horizontal[0]);
+    draw_tool_pane(frame, horizontal[1]);
+}
+
+/// Draw the chat pane showing conversation entries.
+fn draw_chat_pane(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title(" Chat ");
+
+    let inner = block.inner(area);
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    for entry in app.chat_entries() {
+        let (prefix, style) = match entry.role {
+            tmg_llm::Role::User => (
+                "You: ",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            tmg_llm::Role::Assistant => ("Agent: ", Style::default().fg(Color::Blue)),
+            _ => ("", Style::default().fg(Color::DarkGray)),
+        };
+
+        // First line with prefix.
+        let content_lines: Vec<&str> = entry.text.split('\n').collect();
+        if let Some((first, rest)) = content_lines.split_first() {
+            lines.push(Line::from(vec![
+                Span::styled(prefix, style),
+                Span::styled((*first).to_owned(), style),
+            ]));
+            for line in rest {
+                // Indent continuation lines to align with content after prefix.
+                let indent = " ".repeat(prefix.len());
+                lines.push(Line::from(vec![
+                    Span::raw(indent),
+                    Span::styled((*line).to_owned(), style),
+                ]));
+            }
+        }
+
+        // Add a blank line between entries.
+        lines.push(Line::from(""));
+    }
+
+    // Show streaming indicator.
+    if app.is_streaming() {
+        lines.push(Line::from(Span::styled(
+            "...",
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
+        )));
+    }
+
+    // Saturate to u16::MAX if line count exceeds display capacity.
+    let total_lines = u16::try_from(lines.len()).unwrap_or(u16::MAX);
+    let visible_height = inner.height;
+
+    // Auto-scroll to bottom when new content arrives.
+    let scroll = if total_lines > visible_height {
+        total_lines
+            .saturating_sub(visible_height)
+            .saturating_sub(app.chat_scroll())
+    } else {
+        0
+    };
+
+    let chat = Paragraph::new(Text::from(lines))
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
+
+    frame.render_widget(chat, area);
+
+    // Scrollbar.
+    if total_lines > visible_height {
+        let mut scrollbar_state = ScrollbarState::new(usize::from(total_lines))
+            .position(usize::from(scroll))
+            .viewport_content_length(usize::from(visible_height));
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
+        frame.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
+    }
+}
+
+/// Draw the tool activity pane (frame only, content in future issues).
+fn draw_tool_pane(frame: &mut Frame, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Tools ")
+        .style(Style::default().fg(Color::DarkGray));
+    let placeholder = Paragraph::new(Text::from(vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  (no tool activity)",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ]))
+    .block(block);
+    frame.render_widget(placeholder, area);
+}
+
+/// Draw the input area at the bottom.
+fn draw_input_area(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Input (Ctrl+Enter to send) ");
+
+    let input_text = if app.input().is_empty() && !app.is_streaming() {
+        Text::from(Span::styled(
+            "Type a message...",
+            Style::default().fg(Color::DarkGray),
+        ))
+    } else {
+        Text::from(app.input())
+    };
+
+    let input_widget = Paragraph::new(input_text)
+        .block(block)
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(input_widget, area);
+
+    // Set cursor position if not streaming.
+    if !app.is_streaming() {
+        let inner = Block::default().borders(Borders::ALL).inner(area);
+
+        // Calculate cursor position within the input text.
+        let text_before_cursor = &app.input()[..app.cursor_pos()];
+        let cursor_line =
+            u16::try_from(text_before_cursor.matches('\n').count()).unwrap_or(u16::MAX);
+        let last_newline_pos = text_before_cursor.rfind('\n').map_or(0, |p| p + 1);
+        let cursor_col = u16::try_from(text_before_cursor[last_newline_pos..].chars().count())
+            .unwrap_or(u16::MAX);
+
+        frame.set_cursor_position((inner.x + cursor_col, inner.y + cursor_line));
+    }
+}
+
+/// Draw an error overlay at the bottom of the screen.
+fn draw_error_overlay(frame: &mut Frame, message: &str, area: Rect) {
+    let error_height = 3;
+    if area.height < error_height {
+        return;
+    }
+
+    let error_area = Rect {
+        x: area.x + 2,
+        y: area.height.saturating_sub(error_height + 1),
+        width: area.width.saturating_sub(4),
+        height: error_height,
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Error ")
+        .style(Style::default().fg(Color::Red));
+
+    let error_text = Paragraph::new(Span::styled(message, Style::default().fg(Color::Red)))
+        .block(block)
+        .wrap(Wrap { trim: true });
+
+    // Clear the background area first.
+    frame.render_widget(
+        Block::default().style(Style::default().bg(Color::Black)),
+        error_area,
+    );
+    frame.render_widget(error_text, error_area);
+}

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -23,7 +23,7 @@ fn main() -> anyhow::Result<()> {
     if let Some(prompt) = cli.prompt {
         run_prompt(&cli.endpoint, &cli.model, &prompt)?;
     } else {
-        run_interactive(&cli.endpoint, &cli.model)?;
+        run_tui(&cli.endpoint, &cli.model)?;
     }
 
     Ok(())
@@ -81,19 +81,12 @@ fn run_prompt(endpoint: &str, model: &str, prompt: &str) -> anyhow::Result<()> {
     })
 }
 
-/// Run an interactive multi-turn conversation loop.
+/// Run the TUI-based interactive session.
 ///
-/// Reads user input from stdin line-by-line, sends each line to the LLM
-/// via [`tmg_core::AgentLoop`], and streams the response to stdout.
-/// The loop exits on EOF (Ctrl-D) or when the `CancellationToken` is
-/// triggered (Ctrl-C).
-#[expect(
-    clippy::print_stderr,
-    reason = "CLI interactive mode: stderr used for user-facing prompts and status"
-)]
-fn run_interactive(endpoint: &str, model: &str) -> anyhow::Result<()> {
-    use std::io::{BufRead as _, Write as _};
-
+/// Launches a ratatui terminal interface with a chat pane, header,
+/// and input area. The TUI handles multi-turn conversations with
+/// streaming LLM responses.
+fn run_tui(endpoint: &str, model: &str) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let config = tmg_llm::LlmClientConfig::new(endpoint, model);
@@ -113,71 +106,10 @@ fn run_interactive(endpoint: &str, model: &str) -> anyhow::Result<()> {
         // Use cwd as project root for now (could be improved with git root detection).
         let project_root = cwd.clone();
 
-        let mut agent = tmg_core::AgentLoop::new(client, cancel.clone(), &project_root, &cwd)?;
+        let agent = tmg_core::AgentLoop::new(client, cancel.clone(), &project_root, &cwd)?;
 
-        let stdin = std::io::stdin();
-        let mut reader = stdin.lock();
-
-        let mut sink = StdoutSink;
-
-        loop {
-            if cancel.is_cancelled() {
-                eprintln!("\n[cancelled]");
-                break;
-            }
-
-            eprint!("> ");
-            std::io::stderr().flush()?;
-
-            let mut input = String::new();
-            let bytes_read = reader.read_line(&mut input)?;
-
-            // EOF (Ctrl-D)
-            if bytes_read == 0 {
-                eprintln!("\n[bye]");
-                break;
-            }
-
-            let trimmed = input.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-
-            match agent.turn(trimmed, &mut sink).await {
-                Ok(()) => {}
-                Err(tmg_core::CoreError::Cancelled) => {
-                    eprintln!("\n[cancelled]");
-                    break;
-                }
-                Err(e) => {
-                    return Err(anyhow::Error::from(e));
-                }
-            }
-        }
+        tmg_tui::run(agent, model, cancel, project_root, cwd).await?;
 
         Ok::<(), anyhow::Error>(())
     })
-}
-
-/// A [`tmg_core::StreamSink`] that writes tokens to stdout.
-struct StdoutSink;
-
-#[expect(
-    clippy::print_stdout,
-    reason = "CLI streaming output sink: intentional stdout writes"
-)]
-impl tmg_core::StreamSink for StdoutSink {
-    fn on_token(&mut self, token: &str) -> Result<(), tmg_core::CoreError> {
-        use std::io::Write as _;
-        print!("{token}");
-        std::io::stdout().flush()?;
-        Ok(())
-    }
-
-    fn on_done(&mut self) -> Result<(), tmg_core::CoreError> {
-        use std::io::Write as _;
-        println!();
-        std::io::stdout().flush()?;
-        Ok(())
-    }
 }


### PR DESCRIPTION
## Summary

- Implement a ratatui + crossterm TUI in `tmg-tui` with header, chat pane, tool activity pane (frame only), and input area
- Add event loop using `tokio::select!` with `CancellationToken` for graceful shutdown (Ctrl+C)
- Support multi-line input (Enter = newline, Ctrl+Enter = send), streaming LLM response display, and visual distinction between user/agent messages
- Implement slash commands: `/clear` (resets conversation history), `/exit` (quits session)
- Display errors in TUI overlay instead of panicking; define `TuiError` with `thiserror` 2.x
- Add `AgentLoop::clear_history()` to `tmg-core` for `/clear` support
- Update `tmg-cli` to launch the TUI instead of the previous stdin-based interactive loop

## Crates modified

- **tmg-tui**: New modules `app`, `error`, `event`, `ui` + public `run()` entry point
- **tmg-core**: Added `clear_history()` method to `AgentLoop`
- **tmg-cli**: Replaced `run_interactive()` with `run_tui()` using `tmg_tui::run()`

## Testing

- `cargo build --workspace` passes
- `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- `cargo fmt --all -- --check` passes
- `cargo test --workspace` passes (17 tests including 2 new TUI unit tests)
- Unit tests for input manipulation logic and slash command parsing

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)