### PR TITLE
tmg-tools: Implement Tool trait and built-in tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1052,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1499,13 @@ version = "0.1.0"
 [[package]]
 name = "tmg-tools"
 version = "0.1.0"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "tmg-tui"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ clap = { version = "4", features = ["derive"] }
 thiserror = "2"
 anyhow = "1"
 
+# Regex
+regex = "1"
+
 # Platform directories
 dirs = "6"
 

--- a/crates/tmg-tools/Cargo.toml
+++ b/crates/tmg-tools/Cargo.toml
@@ -6,6 +6,14 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["process", "time", "fs", "io-util"] }
+regex = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "time", "fs", "io-util"] }
 
 [lints]
 workspace = true

--- a/crates/tmg-tools/src/error.rs
+++ b/crates/tmg-tools/src/error.rs
@@ -33,6 +33,7 @@ pub enum ToolError {
         /// Description of what the tool was doing when the error occurred.
         context: String,
         /// The underlying I/O error.
+        #[source]
         source: std::io::Error,
     },
 
@@ -57,6 +58,7 @@ pub enum ToolError {
         /// Description of what was being serialized.
         context: String,
         /// The underlying `serde_json` error.
+        #[source]
         source: serde_json::Error,
     },
 }

--- a/crates/tmg-tools/src/error.rs
+++ b/crates/tmg-tools/src/error.rs
@@ -1,0 +1,87 @@
+//! Error types for the tools crate.
+
+/// The maximum length for tool output before truncation.
+pub const MAX_OUTPUT_LENGTH: usize = 128 * 1024;
+
+/// Errors that can occur during tool execution.
+#[derive(Debug, thiserror::Error)]
+pub enum ToolError {
+    /// The requested tool was not found in the registry.
+    #[error("tool not found: {name}")]
+    NotFound {
+        /// The name that was looked up.
+        name: String,
+    },
+
+    /// Invalid parameters were supplied to the tool.
+    #[error("invalid parameters: {message}")]
+    InvalidParams {
+        /// A human-readable description of what was wrong.
+        message: String,
+    },
+
+    /// A path traversal attack was detected.
+    #[error("path traversal rejected: {path}")]
+    PathTraversal {
+        /// The offending path string.
+        path: String,
+    },
+
+    /// An I/O error occurred during tool execution.
+    #[error("{context}: {source}")]
+    Io {
+        /// Description of what the tool was doing when the error occurred.
+        context: String,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A regex compilation error.
+    #[error("invalid regex pattern: {source}")]
+    Regex {
+        /// The underlying regex error.
+        #[from]
+        source: regex::Error,
+    },
+
+    /// A timeout was exceeded (e.g. `shell_exec`).
+    #[error("command timed out after {seconds}s")]
+    Timeout {
+        /// The timeout duration in seconds.
+        seconds: u64,
+    },
+
+    /// JSON serialization/deserialization error.
+    #[error("json error: {context}: {source}")]
+    Json {
+        /// Description of what was being serialized.
+        context: String,
+        /// The underlying `serde_json` error.
+        source: serde_json::Error,
+    },
+}
+
+impl ToolError {
+    /// Create an I/O error with context.
+    pub fn io(context: impl Into<String>, source: std::io::Error) -> Self {
+        Self::Io {
+            context: context.into(),
+            source,
+        }
+    }
+
+    /// Create an invalid-params error.
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self::InvalidParams {
+            message: message.into(),
+        }
+    }
+
+    /// Create a JSON error with context.
+    pub fn json(context: impl Into<String>, source: serde_json::Error) -> Self {
+        Self::Json {
+            context: context.into(),
+            source,
+        }
+    }
+}

--- a/crates/tmg-tools/src/lib.rs
+++ b/crates/tmg-tools/src/lib.rs
@@ -1,1 +1,14 @@
-// tmg-tools: Tool definitions and implementations for the coding agent.
+//! tmg-tools: Tool definitions and implementations for the coding agent.
+//!
+//! This crate provides the [`Tool`] trait, a [`ToolRegistry`] for looking up
+//! tools by name, and built-in tool implementations for file operations,
+//! directory listing, grep search, and shell command execution.
+
+pub mod error;
+mod path_util;
+pub mod tools;
+pub mod types;
+
+pub use error::ToolError;
+pub use tools::default_registry;
+pub use types::{Tool, ToolRegistry, ToolResult};

--- a/crates/tmg-tools/src/path_util.rs
+++ b/crates/tmg-tools/src/path_util.rs
@@ -6,8 +6,10 @@ use crate::error::ToolError;
 
 /// Validate that `path` does not contain path traversal components (e.g. `..`).
 ///
-/// Returns the canonicalized path on success. Rejects paths containing `..`
-/// components, which could be used to escape a sandboxed directory.
+/// Returns the path as-is on success. This function rejects paths containing
+/// `..` components (which could be used to escape a sandboxed directory) but
+/// does **not** canonicalize or resolve symlinks. Symlink resolution is
+/// delegated to the sandbox layer.
 pub fn validate_path(path: impl AsRef<Path>) -> Result<PathBuf, ToolError> {
     let path = path.as_ref();
 

--- a/crates/tmg-tools/src/path_util.rs
+++ b/crates/tmg-tools/src/path_util.rs
@@ -1,0 +1,62 @@
+//! Path validation utilities for preventing path traversal attacks.
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::error::ToolError;
+
+/// Validate that `path` does not contain path traversal components (e.g. `..`).
+///
+/// Returns the canonicalized path on success. Rejects paths containing `..`
+/// components, which could be used to escape a sandboxed directory.
+pub fn validate_path(path: impl AsRef<Path>) -> Result<PathBuf, ToolError> {
+    let path = path.as_ref();
+
+    // Reject any `..` components.
+    for component in path.components() {
+        if let Component::ParentDir = component {
+            return Err(ToolError::PathTraversal {
+                path: path.display().to_string(),
+            });
+        }
+    }
+
+    Ok(path.to_path_buf())
+}
+
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_absolute_path() {
+        let result = validate_path("/tmp/test/file.txt");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_relative_path() {
+        let result = validate_path("src/main.rs");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rejects_parent_dir() {
+        let result = validate_path("/tmp/../etc/passwd");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, ToolError::PathTraversal { .. }));
+    }
+
+    #[test]
+    fn rejects_relative_parent_dir() {
+        let result = validate_path("../secret");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn allows_current_dir_component() {
+        let result = validate_path("./src/main.rs");
+        assert!(result.is_ok());
+    }
+}

--- a/crates/tmg-tools/src/tools/file_patch.rs
+++ b/crates/tmg-tools/src/tools/file_patch.rs
@@ -1,0 +1,195 @@
+//! `file_patch` tool: search/replace partial file editing.
+
+use crate::error::ToolError;
+use crate::path_util::validate_path;
+use crate::types::{Tool, ToolResult};
+
+/// Apply a search/replace patch to a file.
+pub struct FilePatchTool;
+
+impl Tool for FilePatchTool {
+    fn name(&self) -> &'static str {
+        "file_patch"
+    }
+
+    fn description(&self) -> &'static str {
+        "Apply a search/replace edit to a file. The `old_string` must match exactly \
+         one location in the file. It will be replaced with `new_string`."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "The path to the file to edit."
+                },
+                "old_string": {
+                    "type": "string",
+                    "description": "The exact string to search for in the file. Must match exactly once."
+                },
+                "new_string": {
+                    "type": "string",
+                    "description": "The string to replace `old_string` with. Use empty string to delete."
+                }
+            },
+            "required": ["path", "old_string", "new_string"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute(
+        &self,
+        params: serde_json::Value,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<ToolResult, ToolError>> + Send + '_>,
+    > {
+        Box::pin(self.execute_inner(params))
+    }
+}
+
+impl FilePatchTool {
+    async fn execute_inner(&self, params: serde_json::Value) -> Result<ToolResult, ToolError> {
+        let Some(path_str) = params.get("path").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: path",
+            ));
+        };
+        let Some(old_string) = params.get("old_string").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: old_string",
+            ));
+        };
+        let Some(new_string) = params.get("new_string").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: new_string",
+            ));
+        };
+
+        let path = validate_path(path_str)?;
+
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .map_err(|e| ToolError::io(format!("reading file '{}'", path.display()), e))?;
+
+        let match_count = content.matches(old_string).count();
+
+        if match_count == 0 {
+            return Ok(ToolResult::error(format!(
+                "old_string not found in '{}'",
+                path.display()
+            )));
+        }
+
+        if match_count > 1 {
+            return Ok(ToolResult::error(format!(
+                "old_string matches {match_count} locations in '{}'. It must match exactly once.",
+                path.display()
+            )));
+        }
+
+        let new_content = content.replacen(old_string, new_string, 1);
+
+        tokio::fs::write(&path, &new_content)
+            .await
+            .map_err(|e| ToolError::io(format!("writing file '{}'", path.display()), e))?;
+
+        Ok(ToolResult::success(format!(
+            "Successfully patched '{}'",
+            path.display()
+        )))
+    }
+}
+
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn patch_single_match() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_file_patch");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("test.txt");
+        std::fs::write(&file, "hello world\nfoo bar\n").ok();
+
+        let tool = FilePatchTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": file.to_str().unwrap(),
+                "old_string": "foo bar",
+                "new_string": "baz qux"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert_eq!(content, "hello world\nbaz qux\n");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn patch_no_match() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_file_patch_no_match");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("test.txt");
+        std::fs::write(&file, "hello world\n").ok();
+
+        let tool = FilePatchTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": file.to_str().unwrap(),
+                "old_string": "nonexistent",
+                "new_string": "replacement"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("not found"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn patch_multiple_matches() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_file_patch_multi");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("test.txt");
+        std::fs::write(&file, "aaa\naaa\naaa\n").ok();
+
+        let tool = FilePatchTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": file.to_str().unwrap(),
+                "old_string": "aaa",
+                "new_string": "bbb"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("3 locations"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn patch_missing_file() {
+        let tool = FilePatchTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": "/tmp/tmg_nonexistent_patch_xyz.txt",
+                "old_string": "a",
+                "new_string": "b"
+            }))
+            .await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/tmg-tools/src/tools/file_read.rs
+++ b/crates/tmg-tools/src/tools/file_read.rs
@@ -67,6 +67,12 @@ impl FileReadTool {
             .and_then(serde_json::Value::as_u64)
             .and_then(|n| usize::try_from(n).ok());
 
+        if start_line == Some(0) {
+            return Err(ToolError::invalid_params(
+                "start_line is 1-based and must be >= 1",
+            ));
+        }
+
         let end_line = params
             .get("end_line")
             .and_then(serde_json::Value::as_u64)
@@ -172,6 +178,28 @@ mod tests {
         let tool = FileReadTool;
         let result = tool.execute(serde_json::json!({})).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_start_line_zero_rejected() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_file_read_zero");
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("test.txt");
+        std::fs::write(&file, "line1\nline2\n").ok();
+
+        let tool = FileReadTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": file.to_str().unwrap(),
+                "start_line": 0
+            }))
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("1-based"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]

--- a/crates/tmg-tools/src/tools/file_read.rs
+++ b/crates/tmg-tools/src/tools/file_read.rs
@@ -1,0 +1,187 @@
+//! `file_read` tool: read file contents with optional line range.
+
+use crate::error::ToolError;
+use crate::path_util::validate_path;
+use crate::types::{Tool, ToolResult};
+
+/// Read the contents of a file, optionally restricting to a line range.
+pub struct FileReadTool;
+
+impl Tool for FileReadTool {
+    fn name(&self) -> &'static str {
+        "file_read"
+    }
+
+    fn description(&self) -> &'static str {
+        "Read the contents of a file. Optionally specify a line range (1-based, inclusive)."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "The path to the file to read."
+                },
+                "start_line": {
+                    "type": "integer",
+                    "description": "The 1-based start line (inclusive). Omit to read from the beginning."
+                },
+                "end_line": {
+                    "type": "integer",
+                    "description": "The 1-based end line (inclusive). Omit to read to the end."
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute(
+        &self,
+        params: serde_json::Value,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<ToolResult, ToolError>> + Send + '_>,
+    > {
+        Box::pin(self.execute_inner(params))
+    }
+}
+
+impl FileReadTool {
+    async fn execute_inner(&self, params: serde_json::Value) -> Result<ToolResult, ToolError> {
+        let Some(path_str) = params.get("path").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: path",
+            ));
+        };
+
+        let path = validate_path(path_str)?;
+
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .map_err(|e| ToolError::io(format!("reading file '{}'", path.display()), e))?;
+
+        let start_line = params
+            .get("start_line")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok());
+
+        let end_line = params
+            .get("end_line")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok());
+
+        let lines: Vec<&str> = content.lines().collect();
+        let total_lines = lines.len();
+
+        let start = start_line.unwrap_or(1).saturating_sub(1);
+        let end = end_line.unwrap_or(total_lines).min(total_lines);
+
+        if start >= total_lines {
+            return Ok(ToolResult::success(format!(
+                "(file has {total_lines} lines, requested start line {} is out of range)",
+                start + 1,
+            )));
+        }
+
+        let selected: Vec<String> = lines[start..end]
+            .iter()
+            .enumerate()
+            .map(|(i, line)| format!("{:>6}\t{line}", start + i + 1))
+            .collect();
+
+        let mut output = selected.join("\n");
+        if start > 0 || end < total_lines {
+            output = format!(
+                "(showing lines {}-{} of {total_lines})\n{output}",
+                start + 1,
+                end,
+            );
+        }
+
+        Ok(ToolResult::success(output))
+    }
+}
+
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn read_entire_file() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_file_read");
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("test.txt");
+        std::fs::write(&file, "line1\nline2\nline3\n").ok();
+
+        let tool = FileReadTool;
+        let result = tool
+            .execute(serde_json::json!({ "path": file.to_str().unwrap() }))
+            .await;
+
+        let result = result.unwrap();
+        assert!(!result.is_error);
+        assert!(result.output.contains("line1"));
+        assert!(result.output.contains("line3"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn read_line_range() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_file_read_range");
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("test.txt");
+        std::fs::write(&file, "line1\nline2\nline3\nline4\nline5\n").ok();
+
+        let tool = FileReadTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": file.to_str().unwrap(),
+                "start_line": 2,
+                "end_line": 4
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("line2"));
+        assert!(result.output.contains("line4"));
+        assert!(!result.output.contains("\tline1"));
+        assert!(!result.output.contains("\tline5"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn read_missing_file() {
+        let tool = FileReadTool;
+        let result = tool
+            .execute(serde_json::json!({ "path": "/tmp/tmg_nonexistent_file_xyz.txt" }))
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("reading file"));
+    }
+
+    #[tokio::test]
+    async fn read_missing_path_param() {
+        let tool = FileReadTool;
+        let result = tool.execute(serde_json::json!({})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_path_traversal() {
+        let tool = FileReadTool;
+        let result = tool
+            .execute(serde_json::json!({ "path": "/tmp/../etc/passwd" }))
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("traversal"));
+    }
+}

--- a/crates/tmg-tools/src/tools/file_write.rs
+++ b/crates/tmg-tools/src/tools/file_write.rs
@@ -1,0 +1,157 @@
+//! `file_write` tool: create or overwrite a file.
+
+use std::path::Path;
+
+use crate::error::ToolError;
+use crate::path_util::validate_path;
+use crate::types::{Tool, ToolResult};
+
+/// Create or overwrite a file with the given content.
+pub struct FileWriteTool;
+
+impl Tool for FileWriteTool {
+    fn name(&self) -> &'static str {
+        "file_write"
+    }
+
+    fn description(&self) -> &'static str {
+        "Create or overwrite a file with the specified content. Parent directories are created automatically."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "The path of the file to create or overwrite."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The content to write to the file."
+                }
+            },
+            "required": ["path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute(
+        &self,
+        params: serde_json::Value,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<ToolResult, ToolError>> + Send + '_>,
+    > {
+        Box::pin(self.execute_inner(params))
+    }
+}
+
+impl FileWriteTool {
+    async fn execute_inner(&self, params: serde_json::Value) -> Result<ToolResult, ToolError> {
+        let Some(path_str) = params.get("path").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: path",
+            ));
+        };
+        let Some(content) = params.get("content").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: content",
+            ));
+        };
+
+        let path = validate_path(path_str)?;
+
+        // Create parent directories if they don't exist.
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            ensure_parent_dirs(parent).await?;
+        }
+
+        tokio::fs::write(&path, content)
+            .await
+            .map_err(|e| ToolError::io(format!("writing file '{}'", path.display()), e))?;
+
+        let bytes = content.len();
+        Ok(ToolResult::success(format!(
+            "Successfully wrote {bytes} bytes to '{}'",
+            path.display()
+        )))
+    }
+}
+
+/// Create parent directories, reporting a useful error on failure.
+async fn ensure_parent_dirs(parent: &Path) -> Result<(), ToolError> {
+    tokio::fs::create_dir_all(parent)
+        .await
+        .map_err(|e| ToolError::io(format!("creating directories '{}'", parent.display()), e))
+}
+
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn write_new_file() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_file_write");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("new.txt");
+
+        let tool = FileWriteTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": file.to_str().unwrap(),
+                "content": "hello world"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("11 bytes"));
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn write_creates_parent_dirs() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_file_write_nested");
+        let _ = std::fs::remove_dir_all(&dir);
+        let file = dir.join("a").join("b").join("c.txt");
+
+        let tool = FileWriteTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": file.to_str().unwrap(),
+                "content": "nested"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "nested");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn write_missing_content_param() {
+        let tool = FileWriteTool;
+        let result = tool
+            .execute(serde_json::json!({ "path": "/tmp/test.txt" }))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn write_path_traversal() {
+        let tool = FileWriteTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": "/tmp/../etc/shadow",
+                "content": "pwned"
+            }))
+            .await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/tmg-tools/src/tools/grep_search.rs
+++ b/crates/tmg-tools/src/tools/grep_search.rs
@@ -1,0 +1,358 @@
+//! `grep_search` tool: pattern search across files.
+
+use std::fmt::Write;
+use std::path::{Path, PathBuf};
+
+use crate::error::ToolError;
+use crate::path_util::validate_path;
+use crate::types::{Tool, ToolResult};
+
+/// Maximum number of matching lines to return.
+const MAX_MATCHES: usize = 500;
+
+/// Search files for a regex pattern.
+pub struct GrepSearchTool;
+
+impl Tool for GrepSearchTool {
+    fn name(&self) -> &'static str {
+        "grep_search"
+    }
+
+    fn description(&self) -> &'static str {
+        "Search files for lines matching a regex pattern. Returns matching lines with \
+         file paths and line numbers."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "The regex pattern to search for."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "The directory or file to search in. Defaults to current directory."
+                },
+                "include": {
+                    "type": "string",
+                    "description": "File name filter (glob pattern, e.g. '*.rs'). Only files matching this pattern are searched."
+                }
+            },
+            "required": ["pattern"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute(
+        &self,
+        params: serde_json::Value,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<ToolResult, ToolError>> + Send + '_>,
+    > {
+        Box::pin(self.execute_inner(params))
+    }
+}
+
+impl GrepSearchTool {
+    async fn execute_inner(&self, params: serde_json::Value) -> Result<ToolResult, ToolError> {
+        let Some(pattern_str) = params.get("pattern").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: pattern",
+            ));
+        };
+
+        let regex = regex::Regex::new(pattern_str)?;
+
+        let search_path = match params.get("path").and_then(serde_json::Value::as_str) {
+            Some(p) => validate_path(p)?,
+            None => PathBuf::from("."),
+        };
+
+        let include_filter = params
+            .get("include")
+            .and_then(serde_json::Value::as_str)
+            .map(String::from);
+
+        // Run the search in a blocking task since it does synchronous I/O.
+        let result = tokio::task::spawn_blocking(move || {
+            search_files(&search_path, &regex, include_filter.as_deref())
+        })
+        .await
+        .map_err(|e| ToolError::io("grep search task panicked", std::io::Error::other(e)))??;
+
+        Ok(result)
+    }
+}
+
+/// Perform the actual file search.
+fn search_files(
+    root: &Path,
+    regex: &regex::Regex,
+    include: Option<&str>,
+) -> Result<ToolResult, ToolError> {
+    let mut matches = Vec::new();
+    let mut truncated = false;
+
+    if root.is_file() {
+        search_single_file(root, regex, &mut matches, &mut truncated);
+    } else if root.is_dir() {
+        walk_and_search(root, regex, include, &mut matches, &mut truncated)?;
+    } else {
+        return Err(ToolError::io(
+            format!("'{}' is not a file or directory", root.display()),
+            std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+        ));
+    }
+
+    if matches.is_empty() {
+        return Ok(ToolResult::success("No matches found."));
+    }
+
+    let mut output = matches.join("\n");
+    if truncated {
+        let _ = write!(output, "\n... (truncated at {MAX_MATCHES} matches)");
+    }
+
+    Ok(ToolResult::success(output))
+}
+
+/// Walk a directory and search matching files.
+fn walk_and_search(
+    dir: &Path,
+    regex: &regex::Regex,
+    include: Option<&str>,
+    matches: &mut Vec<String>,
+    truncated: &mut bool,
+) -> Result<(), ToolError> {
+    if *truncated {
+        return Ok(());
+    }
+
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return Ok(()),
+        Err(e) => {
+            return Err(ToolError::io(
+                format!("reading directory '{}'", dir.display()),
+                e,
+            ));
+        }
+    };
+
+    let mut entries: Vec<PathBuf> = Vec::new();
+    for entry in read_dir {
+        let Ok(entry) = entry else { continue };
+        entries.push(entry.path());
+    }
+    entries.sort();
+
+    for entry in &entries {
+        if *truncated {
+            break;
+        }
+
+        let name = entry
+            .file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_default();
+
+        // Skip hidden files/directories.
+        if name.starts_with('.') {
+            continue;
+        }
+
+        if entry.is_dir() {
+            walk_and_search(entry, regex, include, matches, truncated)?;
+        } else if entry.is_file() && matches_include_filter(&name, include) {
+            search_single_file(entry, regex, matches, truncated);
+        }
+    }
+
+    Ok(())
+}
+
+/// Check if a filename matches the include glob pattern.
+///
+/// Uses a simple glob matching: `*` matches any sequence of non-separator chars.
+fn matches_include_filter(filename: &str, include: Option<&str>) -> bool {
+    let Some(pattern) = include else {
+        return true;
+    };
+    simple_glob_match(pattern, filename)
+}
+
+/// A minimal glob matcher supporting `*` as a wildcard.
+fn simple_glob_match(pattern: &str, text: &str) -> bool {
+    let parts: Vec<&str> = pattern.split('*').collect();
+
+    if parts.len() == 1 {
+        // No wildcard, exact match.
+        return pattern == text;
+    }
+
+    let mut pos = 0;
+
+    // First part must be a prefix.
+    let Some(first) = parts.first() else {
+        return true;
+    };
+    if !first.is_empty() {
+        if !text.starts_with(*first) {
+            return false;
+        }
+        pos = first.len();
+    }
+
+    // Last part must be a suffix.
+    let Some(last) = parts.last() else {
+        return true;
+    };
+    if !last.is_empty() && !text[pos..].ends_with(*last) {
+        return false;
+    }
+    let end = if last.is_empty() {
+        text.len()
+    } else {
+        text.len() - last.len()
+    };
+
+    // Middle parts must appear in order.
+    for part in &parts[1..parts.len() - 1] {
+        if part.is_empty() {
+            continue;
+        }
+        let Some(idx) = text[pos..end].find(*part) else {
+            return false;
+        };
+        pos += idx + part.len();
+    }
+
+    true
+}
+
+/// Search a single file for matching lines.
+fn search_single_file(
+    path: &Path,
+    regex: &regex::Regex,
+    matches: &mut Vec<String>,
+    truncated: &mut bool,
+) {
+    // Skip binary or unreadable files.
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return;
+    };
+
+    for (line_no, line) in content.lines().enumerate() {
+        if regex.is_match(line) {
+            matches.push(format!("{}:{}: {line}", path.display(), line_no + 1));
+            if matches.len() >= MAX_MATCHES {
+                *truncated = true;
+                return;
+            }
+        }
+    }
+}
+
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn grep_basic_search() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_grep");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).ok();
+        std::fs::write(dir.join("a.txt"), "hello world\nfoo bar\nhello again\n").ok();
+        std::fs::write(dir.join("b.txt"), "no match here\n").ok();
+
+        let tool = GrepSearchTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "pattern": "hello",
+                "path": dir.to_str().unwrap()
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("hello world"));
+        assert!(result.output.contains("hello again"));
+        assert!(!result.output.contains("no match"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn grep_with_include_filter() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_grep_include");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).ok();
+        std::fs::write(dir.join("a.rs"), "fn main() {}\n").ok();
+        std::fs::write(dir.join("b.txt"), "fn main() {}\n").ok();
+
+        let tool = GrepSearchTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "pattern": "fn main",
+                "path": dir.to_str().unwrap(),
+                "include": "*.rs"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("a.rs"));
+        assert!(!result.output.contains("b.txt"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn grep_no_matches() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_grep_none");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).ok();
+        std::fs::write(dir.join("a.txt"), "hello\n").ok();
+
+        let tool = GrepSearchTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "pattern": "zzzzz",
+                "path": dir.to_str().unwrap()
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("No matches"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn grep_invalid_regex() {
+        let tool = GrepSearchTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "pattern": "[invalid",
+                "path": "/tmp"
+            }))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn glob_matching() {
+        assert!(simple_glob_match("*.rs", "main.rs"));
+        assert!(simple_glob_match("*.rs", "lib.rs"));
+        assert!(!simple_glob_match("*.rs", "main.txt"));
+        assert!(simple_glob_match("test_*", "test_foo"));
+        assert!(!simple_glob_match("test_*", "foo_test"));
+        assert!(simple_glob_match("*", "anything"));
+        assert!(simple_glob_match("exact", "exact"));
+        assert!(!simple_glob_match("exact", "other"));
+    }
+}

--- a/crates/tmg-tools/src/tools/grep_search.rs
+++ b/crates/tmg-tools/src/tools/grep_search.rs
@@ -10,6 +10,9 @@ use crate::types::{Tool, ToolResult};
 /// Maximum number of matching lines to return.
 const MAX_MATCHES: usize = 500;
 
+/// Maximum directory recursion depth to prevent infinite loops from symlinks.
+const MAX_DEPTH: usize = 32;
+
 /// Search files for a regex pattern.
 pub struct GrepSearchTool;
 
@@ -98,7 +101,7 @@ fn search_files(
     if root.is_file() {
         search_single_file(root, regex, &mut matches, &mut truncated);
     } else if root.is_dir() {
-        walk_and_search(root, regex, include, &mut matches, &mut truncated)?;
+        walk_and_search(root, regex, include, &mut matches, &mut truncated, 0)?;
     } else {
         return Err(ToolError::io(
             format!("'{}' is not a file or directory", root.display()),
@@ -125,8 +128,9 @@ fn walk_and_search(
     include: Option<&str>,
     matches: &mut Vec<String>,
     truncated: &mut bool,
+    depth: usize,
 ) -> Result<(), ToolError> {
-    if *truncated {
+    if *truncated || depth > MAX_DEPTH {
         return Ok(());
     }
 
@@ -141,32 +145,36 @@ fn walk_and_search(
         }
     };
 
-    let mut entries: Vec<PathBuf> = Vec::new();
+    let mut entries: Vec<std::fs::DirEntry> = Vec::new();
     for entry in read_dir {
         let Ok(entry) = entry else { continue };
-        entries.push(entry.path());
+        entries.push(entry);
     }
-    entries.sort();
+    entries.sort_by_key(std::fs::DirEntry::file_name);
 
     for entry in &entries {
         if *truncated {
             break;
         }
 
-        let name = entry
-            .file_name()
-            .map(|n| n.to_string_lossy())
-            .unwrap_or_default();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
 
         // Skip hidden files/directories.
         if name.starts_with('.') {
             continue;
         }
 
-        if entry.is_dir() {
-            walk_and_search(entry, regex, include, matches, truncated)?;
-        } else if entry.is_file() && matches_include_filter(&name, include) {
-            search_single_file(entry, regex, matches, truncated);
+        // Use entry.file_type() which does not follow symlinks, preventing
+        // infinite loops caused by symlink cycles.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+
+        if file_type.is_dir() {
+            walk_and_search(&entry.path(), regex, include, matches, truncated, depth + 1)?;
+        } else if file_type.is_file() && matches_include_filter(&name, include) {
+            search_single_file(&entry.path(), regex, matches, truncated);
         }
     }
 
@@ -217,6 +225,10 @@ fn simple_glob_match(pattern: &str, text: &str) -> bool {
     } else {
         text.len() - last.len()
     };
+
+    if pos > end {
+        return false;
+    }
 
     // Middle parts must appear in order.
     for part in &parts[1..parts.len() - 1] {
@@ -354,5 +366,7 @@ mod tests {
         assert!(simple_glob_match("*", "anything"));
         assert!(simple_glob_match("exact", "exact"));
         assert!(!simple_glob_match("exact", "other"));
+        // Bounds check: long pattern match against short string.
+        assert!(!simple_glob_match("*longmatch", "short"));
     }
 }

--- a/crates/tmg-tools/src/tools/list_dir.rs
+++ b/crates/tmg-tools/src/tools/list_dir.rs
@@ -1,0 +1,241 @@
+//! `list_dir` tool: directory tree display with optional depth limit.
+
+use std::fmt::Write;
+use std::path::{Path, PathBuf};
+
+use crate::error::ToolError;
+use crate::path_util::validate_path;
+use crate::types::{Tool, ToolResult};
+
+/// Default maximum depth for directory traversal.
+const DEFAULT_MAX_DEPTH: usize = 3;
+
+/// Maximum number of entries to display before truncating.
+const MAX_ENTRIES: usize = 1000;
+
+/// List the contents of a directory as a tree.
+pub struct ListDirTool;
+
+impl Tool for ListDirTool {
+    fn name(&self) -> &'static str {
+        "list_dir"
+    }
+
+    fn description(&self) -> &'static str {
+        "List the contents of a directory in a tree format. Optionally specify a depth limit."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "The path to the directory to list."
+                },
+                "depth": {
+                    "type": "integer",
+                    "description": "Maximum depth to recurse (default: 3). Use 1 for immediate children only."
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute(
+        &self,
+        params: serde_json::Value,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<ToolResult, ToolError>> + Send + '_>,
+    > {
+        Box::pin(self.execute_inner(params))
+    }
+}
+
+impl ListDirTool {
+    async fn execute_inner(&self, params: serde_json::Value) -> Result<ToolResult, ToolError> {
+        let Some(path_str) = params.get("path").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: path",
+            ));
+        };
+
+        let max_depth = params
+            .get("depth")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|d| usize::try_from(d).ok())
+            .unwrap_or(DEFAULT_MAX_DEPTH);
+
+        let path = validate_path(path_str)?;
+
+        // Use blocking I/O for the directory walk since std::fs::read_dir is
+        // synchronous and we may read many entries.
+        let tree = tokio::task::spawn_blocking(move || build_tree(&path, max_depth))
+            .await
+            .map_err(|e| {
+                ToolError::io("directory listing task panicked", std::io::Error::other(e))
+            })??;
+
+        Ok(ToolResult::success(tree))
+    }
+}
+
+/// Build a tree representation of the directory.
+fn build_tree(root: &Path, max_depth: usize) -> Result<String, ToolError> {
+    let mut entries = Vec::new();
+    let mut count = 0;
+    let mut truncated = false;
+
+    collect_entries(root, 0, max_depth, &mut entries, &mut count, &mut truncated)?;
+
+    let mut output = format!("{}/\n", root.display());
+    for (indent, name, is_dir) in &entries {
+        let prefix = "  ".repeat(*indent);
+        let suffix = if *is_dir { "/" } else { "" };
+        let _ = writeln!(output, "{prefix}{name}{suffix}");
+    }
+
+    if truncated {
+        let _ = writeln!(output, "... (truncated at {MAX_ENTRIES} entries)");
+    }
+
+    Ok(output)
+}
+
+/// Recursively collect directory entries.
+fn collect_entries(
+    dir: &Path,
+    depth: usize,
+    max_depth: usize,
+    entries: &mut Vec<(usize, String, bool)>,
+    count: &mut usize,
+    truncated: &mut bool,
+) -> Result<(), ToolError> {
+    if depth >= max_depth || *truncated {
+        return Ok(());
+    }
+
+    let read_dir = std::fs::read_dir(dir)
+        .map_err(|e| ToolError::io(format!("reading directory '{}'", dir.display()), e))?;
+
+    let mut children: Vec<PathBuf> = Vec::new();
+    for entry in read_dir {
+        let entry =
+            entry.map_err(|e| ToolError::io(format!("reading entry in '{}'", dir.display()), e))?;
+        children.push(entry.path());
+    }
+
+    // Sort entries for deterministic output.
+    children.sort();
+
+    for child in &children {
+        if *count >= MAX_ENTRIES {
+            *truncated = true;
+            return Ok(());
+        }
+
+        let name = child
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        // Skip hidden files/directories.
+        if name.starts_with('.') {
+            continue;
+        }
+
+        let is_dir = child.is_dir();
+        entries.push((depth + 1, name, is_dir));
+        *count += 1;
+
+        if is_dir {
+            collect_entries(child, depth + 1, max_depth, entries, count, truncated)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn list_dir_basic() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_list_dir");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("sub")).ok();
+        std::fs::write(dir.join("file.txt"), "content").ok();
+        std::fs::write(dir.join("sub").join("nested.txt"), "nested").ok();
+
+        let tool = ListDirTool;
+        let result = tool
+            .execute(serde_json::json!({ "path": dir.to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("file.txt"));
+        assert!(result.output.contains("sub/"));
+        assert!(result.output.contains("nested.txt"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn list_dir_depth_1() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_list_dir_depth");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("sub").join("deep")).ok();
+        std::fs::write(dir.join("top.txt"), "top").ok();
+        std::fs::write(dir.join("sub").join("deep").join("deep.txt"), "deep").ok();
+
+        let tool = ListDirTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "path": dir.to_str().unwrap(),
+                "depth": 1
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("top.txt"));
+        assert!(result.output.contains("sub/"));
+        // deep.txt should NOT appear at depth 1.
+        assert!(!result.output.contains("deep.txt"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn list_dir_nonexistent() {
+        let tool = ListDirTool;
+        let result = tool
+            .execute(serde_json::json!({ "path": "/tmp/tmg_nonexistent_dir_xyz" }))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn list_dir_hidden_files_skipped() {
+        let dir = std::env::temp_dir().join("tmg_tools_test_list_dir_hidden");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).ok();
+        std::fs::write(dir.join(".hidden"), "hidden").ok();
+        std::fs::write(dir.join("visible.txt"), "visible").ok();
+
+        let tool = ListDirTool;
+        let result = tool
+            .execute(serde_json::json!({ "path": dir.to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert!(!result.output.contains(".hidden"));
+        assert!(result.output.contains("visible.txt"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/tmg-tools/src/tools/mod.rs
+++ b/crates/tmg-tools/src/tools/mod.rs
@@ -1,0 +1,29 @@
+//! Built-in tool implementations.
+
+mod file_patch;
+mod file_read;
+mod file_write;
+mod grep_search;
+mod list_dir;
+mod shell_exec;
+
+pub use file_patch::FilePatchTool;
+pub use file_read::FileReadTool;
+pub use file_write::FileWriteTool;
+pub use grep_search::GrepSearchTool;
+pub use list_dir::ListDirTool;
+pub use shell_exec::ShellExecTool;
+
+use crate::types::ToolRegistry;
+
+/// Create a [`ToolRegistry`] pre-populated with all built-in tools.
+pub fn default_registry() -> ToolRegistry {
+    let mut registry = ToolRegistry::new();
+    registry.register(FileReadTool);
+    registry.register(FileWriteTool);
+    registry.register(FilePatchTool);
+    registry.register(GrepSearchTool);
+    registry.register(ListDirTool);
+    registry.register(ShellExecTool);
+    registry
+}

--- a/crates/tmg-tools/src/tools/shell_exec.rs
+++ b/crates/tmg-tools/src/tools/shell_exec.rs
@@ -65,7 +65,7 @@ impl ShellExecTool {
 
         let timeout = Duration::from_secs(timeout_secs);
 
-        let mut child = tokio::process::Command::new("sh")
+        let child = tokio::process::Command::new("sh")
             .arg("-c")
             .arg(command)
             .stdout(std::process::Stdio::piped())
@@ -74,25 +74,13 @@ impl ShellExecTool {
             .spawn()
             .map_err(|e| ToolError::io("spawning shell command", e))?;
 
-        // Take stdout/stderr handles before waiting, so we can still kill on timeout.
-        let stdout_handle = child.stdout.take();
-        let stderr_handle = child.stderr.take();
-
-        let wait_result = tokio::time::timeout(timeout, child.wait()).await;
+        let wait_result = tokio::time::timeout(timeout, child.wait_with_output()).await;
 
         match wait_result {
-            Ok(Ok(status)) => {
-                let stdout = if let Some(handle) = stdout_handle {
-                    read_pipe(handle).await
-                } else {
-                    String::new()
-                };
-                let stderr = if let Some(handle) = stderr_handle {
-                    read_pipe(handle).await
-                } else {
-                    String::new()
-                };
-                let exit_code = status.code().unwrap_or(-1);
+            Ok(Ok(output)) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+                let exit_code = output.status.code().unwrap_or(-1);
 
                 let mut text = String::new();
                 let _ = writeln!(text, "Exit code: {exit_code}");
@@ -104,7 +92,7 @@ impl ShellExecTool {
                     let _ = write!(text, "\n--- stderr ---\n{stderr}");
                 }
 
-                if status.success() {
+                if output.status.success() {
                     Ok(ToolResult::success(text))
                 } else {
                     Ok(ToolResult::error(text))
@@ -112,25 +100,14 @@ impl ShellExecTool {
             }
             Ok(Err(e)) => Err(ToolError::io("waiting for command", e)),
             Err(_) => {
-                // Timeout exceeded: kill the process.
-                // `kill_on_drop(true)` ensures cleanup when `child` is dropped.
-                let _ = child.kill().await;
+                // Timeout exceeded. The child process was consumed by
+                // `wait_with_output`, which handles cleanup internally.
                 Err(ToolError::Timeout {
                     seconds: timeout_secs,
                 })
             }
         }
     }
-}
-
-/// Read all bytes from a pipe handle into a string.
-async fn read_pipe(handle: impl tokio::io::AsyncRead + Unpin) -> String {
-    use tokio::io::AsyncReadExt;
-    let mut buf = Vec::new();
-    let mut reader = handle;
-    // Ignore read errors; return whatever was read.
-    let _ = reader.read_to_end(&mut buf).await;
-    String::from_utf8_lossy(&buf).into_owned()
 }
 
 #[expect(clippy::unwrap_used, reason = "test assertions")]

--- a/crates/tmg-tools/src/tools/shell_exec.rs
+++ b/crates/tmg-tools/src/tools/shell_exec.rs
@@ -1,0 +1,200 @@
+//! `shell_exec` tool: command execution with timeout support.
+
+use std::fmt::Write;
+use std::time::Duration;
+
+use crate::error::ToolError;
+use crate::types::{Tool, ToolResult};
+
+/// Default timeout in seconds for shell commands.
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// Execute a shell command with timeout support.
+pub struct ShellExecTool;
+
+impl Tool for ShellExecTool {
+    fn name(&self) -> &'static str {
+        "shell_exec"
+    }
+
+    fn description(&self) -> &'static str {
+        "Execute a shell command and return its output. The command is run via `sh -c`. \
+         A timeout can be specified (default: 30 seconds)."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to execute."
+                },
+                "timeout_secs": {
+                    "type": "integer",
+                    "description": "Maximum execution time in seconds (default: 30)."
+                }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute(
+        &self,
+        params: serde_json::Value,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<ToolResult, ToolError>> + Send + '_>,
+    > {
+        Box::pin(self.execute_inner(params))
+    }
+}
+
+impl ShellExecTool {
+    async fn execute_inner(&self, params: serde_json::Value) -> Result<ToolResult, ToolError> {
+        let Some(command) = params.get("command").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: command",
+            ));
+        };
+
+        let timeout_secs = params
+            .get("timeout_secs")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+
+        let timeout = Duration::from_secs(timeout_secs);
+
+        let mut child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| ToolError::io("spawning shell command", e))?;
+
+        // Take stdout/stderr handles before waiting, so we can still kill on timeout.
+        let stdout_handle = child.stdout.take();
+        let stderr_handle = child.stderr.take();
+
+        let wait_result = tokio::time::timeout(timeout, child.wait()).await;
+
+        match wait_result {
+            Ok(Ok(status)) => {
+                let stdout = if let Some(handle) = stdout_handle {
+                    read_pipe(handle).await
+                } else {
+                    String::new()
+                };
+                let stderr = if let Some(handle) = stderr_handle {
+                    read_pipe(handle).await
+                } else {
+                    String::new()
+                };
+                let exit_code = status.code().unwrap_or(-1);
+
+                let mut text = String::new();
+                let _ = writeln!(text, "Exit code: {exit_code}");
+
+                if !stdout.is_empty() {
+                    let _ = write!(text, "\n--- stdout ---\n{stdout}");
+                }
+                if !stderr.is_empty() {
+                    let _ = write!(text, "\n--- stderr ---\n{stderr}");
+                }
+
+                if status.success() {
+                    Ok(ToolResult::success(text))
+                } else {
+                    Ok(ToolResult::error(text))
+                }
+            }
+            Ok(Err(e)) => Err(ToolError::io("waiting for command", e)),
+            Err(_) => {
+                // Timeout exceeded: kill the process.
+                // `kill_on_drop(true)` ensures cleanup when `child` is dropped.
+                let _ = child.kill().await;
+                Err(ToolError::Timeout {
+                    seconds: timeout_secs,
+                })
+            }
+        }
+    }
+}
+
+/// Read all bytes from a pipe handle into a string.
+async fn read_pipe(handle: impl tokio::io::AsyncRead + Unpin) -> String {
+    use tokio::io::AsyncReadExt;
+    let mut buf = Vec::new();
+    let mut reader = handle;
+    // Ignore read errors; return whatever was read.
+    let _ = reader.read_to_end(&mut buf).await;
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn exec_simple_command() {
+        let tool = ShellExecTool;
+        let result = tool
+            .execute(serde_json::json!({ "command": "echo hello" }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("hello"));
+        assert!(result.output.contains("Exit code: 0"));
+    }
+
+    #[tokio::test]
+    async fn exec_failing_command() {
+        let tool = ShellExecTool;
+        let result = tool
+            .execute(serde_json::json!({ "command": "exit 1" }))
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("Exit code: 1"));
+    }
+
+    #[tokio::test]
+    async fn exec_timeout() {
+        let tool = ShellExecTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "command": "sleep 60",
+                "timeout_secs": 1
+            }))
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("timed out"));
+    }
+
+    #[tokio::test]
+    async fn exec_stderr_output() {
+        let tool = ShellExecTool;
+        let result = tool
+            .execute(serde_json::json!({ "command": "echo error >&2" }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error); // exit code 0
+        assert!(result.output.contains("stderr"));
+        assert!(result.output.contains("error"));
+    }
+
+    #[tokio::test]
+    async fn exec_missing_command_param() {
+        let tool = ShellExecTool;
+        let result = tool.execute(serde_json::json!({})).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/tmg-tools/src/types.rs
+++ b/crates/tmg-tools/src/types.rs
@@ -54,6 +54,9 @@ impl ToolResult {
 }
 
 /// Find the largest byte index <= `index` that is a char boundary.
+///
+/// This is a polyfill for [`str::floor_char_boundary`] which is stable since
+/// Rust 1.91.0. Replace with the std method once MSRV is raised.
 fn floor_char_boundary(s: &str, index: usize) -> usize {
     if index >= s.len() {
         return s.len();
@@ -66,6 +69,9 @@ fn floor_char_boundary(s: &str, index: usize) -> usize {
 }
 
 /// Find the smallest byte index >= `index` that is a char boundary.
+///
+/// This is a polyfill for [`str::ceil_char_boundary`] which is stable since
+/// Rust 1.91.0. Replace with the std method once MSRV is raised.
 fn ceil_char_boundary(s: &str, index: usize) -> usize {
     if index >= s.len() {
         return s.len();

--- a/crates/tmg-tools/src/types.rs
+++ b/crates/tmg-tools/src/types.rs
@@ -1,0 +1,205 @@
+//! Core types: `Tool` trait, `ToolResult`, and `ToolRegistry`.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::error::{MAX_OUTPUT_LENGTH, ToolError};
+
+/// The result of a tool execution.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolResult {
+    /// The textual output of the tool.
+    pub output: String,
+    /// Whether this result represents an error condition reported by the tool
+    /// itself (as opposed to a `ToolError` which prevents execution entirely).
+    pub is_error: bool,
+}
+
+impl ToolResult {
+    /// Create a successful result.
+    pub fn success(output: impl Into<String>) -> Self {
+        let output = Self::maybe_truncate(output.into());
+        Self {
+            output,
+            is_error: false,
+        }
+    }
+
+    /// Create an error result (tool executed but produced an error output).
+    pub fn error(output: impl Into<String>) -> Self {
+        let output = Self::maybe_truncate(output.into());
+        Self {
+            output,
+            is_error: true,
+        }
+    }
+
+    /// Truncate the output if it exceeds the maximum length.
+    fn maybe_truncate(output: String) -> String {
+        if output.len() <= MAX_OUTPUT_LENGTH {
+            return output;
+        }
+        let half = MAX_OUTPUT_LENGTH / 2;
+        let truncated_bytes = output.len() - MAX_OUTPUT_LENGTH;
+        // Find char boundaries near the cut points.
+        let start_end = floor_char_boundary(&output, half);
+        let tail_start = ceil_char_boundary(&output, output.len() - half);
+        format!(
+            "{}\n\n... ({truncated_bytes} bytes truncated) ...\n\n{}",
+            &output[..start_end],
+            &output[tail_start..],
+        )
+    }
+}
+
+/// Find the largest byte index <= `index` that is a char boundary.
+fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut i = index;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+/// Find the smallest byte index >= `index` that is a char boundary.
+fn ceil_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut i = index;
+    while i < s.len() && !s.is_char_boundary(i) {
+        i += 1;
+    }
+    i
+}
+
+/// A tool that the coding agent can invoke.
+///
+/// Implementations must provide a name, description, JSON Schema for
+/// parameters, and an async `execute` method.
+pub trait Tool: Send + Sync {
+    /// The unique name of this tool (e.g. `"file_read"`).
+    fn name(&self) -> &'static str;
+
+    /// A human-readable description of what this tool does.
+    fn description(&self) -> &'static str;
+
+    /// JSON Schema describing the parameters this tool accepts.
+    fn parameters_schema(&self) -> serde_json::Value;
+
+    /// Execute the tool with the given JSON parameters.
+    ///
+    /// Returns a boxed future to allow dyn-compatible trait objects in the
+    /// registry. This is _not_ using the `#[async_trait]` macro; implementors
+    /// can write `async fn` bodies and wrap them with [`Box::pin`].
+    fn execute(
+        &self,
+        params: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult, ToolError>> + Send + '_>>;
+}
+
+/// A registry of available tools, supporting lookup by name and batch schema
+/// retrieval.
+pub struct ToolRegistry {
+    tools: HashMap<String, Box<dyn Tool>>,
+}
+
+impl ToolRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            tools: HashMap::new(),
+        }
+    }
+
+    /// Register a tool. If a tool with the same name already exists, it is
+    /// replaced.
+    pub fn register(&mut self, tool: impl Tool + 'static) {
+        self.tools.insert(tool.name().to_owned(), Box::new(tool));
+    }
+
+    /// Look up a tool by name.
+    pub fn get(&self, name: &str) -> Option<&dyn Tool> {
+        self.tools.get(name).map(AsRef::as_ref)
+    }
+
+    /// Execute a tool by name with the given parameters.
+    pub async fn execute(
+        &self,
+        name: &str,
+        params: serde_json::Value,
+    ) -> Result<ToolResult, ToolError> {
+        let Some(tool) = self.tools.get(name) else {
+            return Err(ToolError::NotFound {
+                name: name.to_owned(),
+            });
+        };
+        tool.execute(params).await
+    }
+
+    /// Return the JSON Schema definitions for all registered tools.
+    ///
+    /// The returned value is a JSON array of objects, each containing
+    /// `name`, `description`, and `parameters`.
+    pub fn all_schemas(&self) -> serde_json::Value {
+        let mut schemas: Vec<serde_json::Value> = self
+            .tools
+            .values()
+            .map(|tool| {
+                serde_json::json!({
+                    "name": tool.name(),
+                    "description": tool.description(),
+                    "parameters": tool.parameters_schema(),
+                })
+            })
+            .collect();
+        // Sort by name for deterministic output.
+        schemas.sort_by(|a, b| {
+            let a_name = a.get("name").and_then(serde_json::Value::as_str);
+            let b_name = b.get("name").and_then(serde_json::Value::as_str);
+            a_name.cmp(&b_name)
+        });
+        serde_json::Value::Array(schemas)
+    }
+
+    /// Return an iterator over all tool names.
+    pub fn tool_names(&self) -> impl Iterator<Item = &str> {
+        self.tools.keys().map(String::as_str)
+    }
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_result_truncation() {
+        // Small output should not be truncated.
+        let result = ToolResult::success("hello");
+        assert_eq!(result.output, "hello");
+        assert!(!result.is_error);
+
+        // Large output should be truncated.
+        let large = "a".repeat(MAX_OUTPUT_LENGTH + 1000);
+        let result = ToolResult::success(large);
+        assert!(result.output.len() < MAX_OUTPUT_LENGTH + 100);
+        assert!(result.output.contains("bytes truncated"));
+    }
+
+    #[test]
+    fn tool_result_error() {
+        let result = ToolResult::error("something went wrong");
+        assert!(result.is_error);
+        assert_eq!(result.output, "something went wrong");
+    }
+}

--- a/crates/tmg-tools/tests/registry_integration.rs
+++ b/crates/tmg-tools/tests/registry_integration.rs
@@ -1,0 +1,220 @@
+//! Integration test: register tools, dispatch by name, execute, verify results.
+
+#![expect(clippy::unwrap_used, reason = "integration test assertions")]
+
+use tmg_tools::{ToolRegistry, default_registry};
+
+#[tokio::test]
+async fn dispatch_file_write_then_read() {
+    let registry = default_registry();
+
+    let dir = std::env::temp_dir().join("tmg_tools_integration_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("hello.txt");
+
+    // Write a file via registry dispatch.
+    let write_result = registry
+        .execute(
+            "file_write",
+            serde_json::json!({
+                "path": file.to_str().unwrap(),
+                "content": "integration test content"
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert!(!write_result.is_error);
+    assert!(write_result.output.contains("Successfully wrote"));
+
+    // Read it back via registry dispatch.
+    let read_result = registry
+        .execute(
+            "file_read",
+            serde_json::json!({ "path": file.to_str().unwrap() }),
+        )
+        .await
+        .unwrap();
+
+    assert!(!read_result.is_error);
+    assert!(read_result.output.contains("integration test content"));
+
+    // Patch the file via registry dispatch.
+    let patch_result = registry
+        .execute(
+            "file_patch",
+            serde_json::json!({
+                "path": file.to_str().unwrap(),
+                "old_string": "integration test",
+                "new_string": "patched"
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert!(!patch_result.is_error);
+
+    // Verify patch via re-read.
+    let read_result2 = registry
+        .execute(
+            "file_read",
+            serde_json::json!({ "path": file.to_str().unwrap() }),
+        )
+        .await
+        .unwrap();
+
+    assert!(read_result2.output.contains("patched content"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn dispatch_list_dir() {
+    let registry = default_registry();
+
+    let dir = std::env::temp_dir().join("tmg_tools_integration_list");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("subdir")).unwrap();
+    std::fs::write(dir.join("file.txt"), "content").unwrap();
+
+    let result = registry
+        .execute(
+            "list_dir",
+            serde_json::json!({ "path": dir.to_str().unwrap() }),
+        )
+        .await
+        .unwrap();
+
+    assert!(!result.is_error);
+    assert!(result.output.contains("file.txt"));
+    assert!(result.output.contains("subdir/"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn dispatch_grep_search() {
+    let registry = default_registry();
+
+    let dir = std::env::temp_dir().join("tmg_tools_integration_grep");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("test.rs"), "fn main() {\n    println!(\"hello\");\n}\n").unwrap();
+
+    let result = registry
+        .execute(
+            "grep_search",
+            serde_json::json!({
+                "pattern": "fn main",
+                "path": dir.to_str().unwrap()
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert!(!result.is_error);
+    assert!(result.output.contains("fn main"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn dispatch_shell_exec() {
+    let registry = default_registry();
+
+    let result = registry
+        .execute(
+            "shell_exec",
+            serde_json::json!({ "command": "echo integration_test" }),
+        )
+        .await
+        .unwrap();
+
+    assert!(!result.is_error);
+    assert!(result.output.contains("integration_test"));
+}
+
+#[tokio::test]
+async fn dispatch_nonexistent_tool() {
+    let registry = default_registry();
+
+    let result = registry
+        .execute("nonexistent_tool", serde_json::json!({}))
+        .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn all_schemas_returns_all_tools() {
+    let registry = default_registry();
+    let schemas = registry.all_schemas();
+
+    let arr = schemas.as_array().unwrap();
+    assert_eq!(arr.len(), 6);
+
+    let names: Vec<&str> = arr
+        .iter()
+        .filter_map(|s| s.get("name").and_then(serde_json::Value::as_str))
+        .collect();
+
+    assert!(names.contains(&"file_read"));
+    assert!(names.contains(&"file_write"));
+    assert!(names.contains(&"file_patch"));
+    assert!(names.contains(&"list_dir"));
+    assert!(names.contains(&"grep_search"));
+    assert!(names.contains(&"shell_exec"));
+
+    // Each schema should have parameters.
+    for schema in arr {
+        assert!(schema.get("parameters").is_some());
+        assert!(schema.get("description").is_some());
+    }
+}
+
+#[test]
+fn registry_get_by_name() {
+    let registry = default_registry();
+
+    assert!(registry.get("file_read").is_some());
+    assert!(registry.get("nonexistent").is_none());
+}
+
+#[test]
+fn custom_tool_registration() {
+    use std::future::Future;
+    use std::pin::Pin;
+    use tmg_tools::{Tool, ToolError, ToolResult};
+
+    struct CustomTool;
+
+    impl Tool for CustomTool {
+        fn name(&self) -> &'static str {
+            "custom"
+        }
+
+        fn description(&self) -> &'static str {
+            "A custom test tool."
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object" })
+        }
+
+        fn execute(
+            &self,
+            _params: serde_json::Value,
+        ) -> Pin<Box<dyn Future<Output = Result<ToolResult, ToolError>> + Send + '_>> {
+            Box::pin(async { Ok(ToolResult::success("custom output")) })
+        }
+    }
+
+    let mut registry = ToolRegistry::new();
+    registry.register(CustomTool);
+
+    assert!(registry.get("custom").is_some());
+    assert_eq!(registry.get("custom").unwrap().name(), "custom");
+}

--- a/crates/tmg-tools/tests/registry_integration.rs
+++ b/crates/tmg-tools/tests/registry_integration.rs
@@ -100,7 +100,11 @@ async fn dispatch_grep_search() {
     let dir = std::env::temp_dir().join("tmg_tools_integration_grep");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(dir.join("test.rs"), "fn main() {\n    println!(\"hello\");\n}\n").unwrap();
+    std::fs::write(
+        dir.join("test.rs"),
+        "fn main() {\n    println!(\"hello\");\n}\n",
+    )
+    .unwrap();
 
     let result = registry
         .execute(


### PR DESCRIPTION
## Summary

Closes #5

- Define `Tool` trait with `name()`, `description()`, `parameters_schema()`, and `execute()` (returns `Pin<Box<dyn Future>>` for dyn-compatibility without `#[async_trait]`)
- Implement `ToolResult` (output + is_error flag) with automatic truncation for large outputs (128KB limit)
- Implement `ToolError` enum with `thiserror` 2.x, including variants for NotFound, InvalidParams, PathTraversal, Io, Regex, Timeout, and Json
- Implement `ToolRegistry` for lookup by name and batch JSON Schema retrieval
- Implement 6 built-in tools: `file_read`, `file_write`, `file_patch`, `list_dir`, `grep_search`, `shell_exec`
- Path traversal attack prevention via component-level validation (rejects `..` components)
- `shell_exec` uses `kill_on_drop(true)` + `tokio::time::timeout` for reliable process cleanup on timeout

## Crates modified

- `tmg-tools` (primary implementation)
- Root `Cargo.toml` (added `regex` to workspace dependencies)

## Testing

- 34 unit tests covering normal and error cases for each tool, path validation, and result truncation
- 8 integration tests covering full registry dispatch flow (register -> lookup by name -> execute -> verify results), custom tool registration, schema retrieval, and error handling for nonexistent tools
- All 42 tests pass
- Full workspace build, clippy (zero warnings), and format checks pass

## Test plan

- [x] Each tool works with correct params and returns expected results
- [x] Error cases (missing file, invalid params) return `ToolError` with context details
- [x] `shell_exec` respects timeout and kills process on exceed
- [x] `ToolRegistry` returns all tools' JSON Schema definitions
- [x] Integration: register tools in ToolRegistry, dispatch by name -> execute -> get results
- [x] Unit tests: normal and error cases for each tool pass
- [x] No `#[async_trait]` used

🤖 Generated with [Claude Code](https://claude.com/claude-code)