### PR TITLE
Integrate tool dispatch into agent loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,6 +1455,7 @@ dependencies = [
  "clap",
  "tmg-core",
  "tmg-llm",
+ "tmg-tools",
  "tmg-tui",
  "tokio",
  "tokio-stream",
@@ -1466,8 +1467,10 @@ name = "tmg-core"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "serde_json",
  "thiserror",
  "tmg-llm",
+ "tmg-tools",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1504,6 +1507,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tmg-llm",
  "tokio",
 ]
 

--- a/crates/tmg-core/Cargo.toml
+++ b/crates/tmg-core/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 
 [dependencies]
 tmg-llm = { workspace = true }
+tmg-tools = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -234,7 +234,6 @@ impl AgentLoop {
 
         let mut response_text = String::new();
         let mut tool_calls = Vec::new();
-        let mut done_called = false;
 
         while let Some(event) = stream.next().await {
             match event {
@@ -246,7 +245,6 @@ impl AgentLoop {
                     tool_calls.push(tc);
                 }
                 Ok(StreamEvent::Done(_)) => {
-                    done_called = true;
                     break;
                 }
                 Err(tmg_llm::LlmError::Cancelled) => {
@@ -258,9 +256,7 @@ impl AgentLoop {
             }
         }
 
-        if !done_called {
-            sink.on_done()?;
-        }
+        sink.on_done()?;
 
         Ok((response_text, tool_calls))
     }

--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -1,11 +1,16 @@
-//! Minimal agent loop: text-only turn-based conversation with an LLM.
+//! Agent loop with tool dispatch: streams LLM responses, detects tool
+//! calls, executes them in parallel, feeds results back, and loops until
+//! the model produces a final text response.
 
 use std::path::Path;
+use std::sync::Arc;
 
+use tokio::task::JoinSet;
 use tokio_stream::StreamExt as _;
 use tokio_util::sync::CancellationToken;
 
-use tmg_llm::{LlmClient, StreamEvent};
+use tmg_llm::{LlmClient, StreamEvent, ToolCall, ToolDefinition};
+use tmg_tools::ToolRegistry;
 
 use crate::error::CoreError;
 use crate::message::Message;
@@ -14,31 +19,73 @@ use crate::prompt;
 /// The default system prompt injected at the start of every conversation.
 const DEFAULT_SYSTEM_PROMPT: &str = "\
 You are tsumugi, a helpful coding assistant running locally. \
-Answer concisely and accurately.";
+Answer concisely and accurately. You have access to tools for \
+reading, writing, and patching files, running shell commands, \
+listing directories, and searching with grep. Use them when \
+appropriate to answer the user's requests.";
 
-/// Callback invoked for each streamed content token.
+/// Maximum number of consecutive tool-call rounds before the loop is
+/// forcibly terminated. This prevents infinite loops when the model
+/// keeps requesting tools without producing a final text response.
+const MAX_TOOL_ROUNDS: usize = 20;
+
+// ---------------------------------------------------------------------------
+// StreamSink trait
+// ---------------------------------------------------------------------------
+
+/// Callback invoked for streamed events during a conversation turn.
 ///
-/// Implementations should write the token to the appropriate output
-/// (stdout, TUI widget, etc.). Returning an error aborts the current turn.
+/// Implementations should write tokens and tool activity to the
+/// appropriate output (stdout, TUI widget, etc.). Returning an error
+/// aborts the current turn.
 pub trait StreamSink {
     /// Called for each incremental text token from the LLM.
     fn on_token(&mut self, token: &str) -> Result<(), CoreError>;
 
-    /// Called when the LLM response stream has completed for the current turn.
+    /// Called when the LLM response stream has completed for the
+    /// current round (there may be more rounds if tool calls follow).
     fn on_done(&mut self) -> Result<(), CoreError> {
+        Ok(())
+    }
+
+    /// Called when a tool call is about to be dispatched.
+    fn on_tool_call(&mut self, _name: &str, _arguments: &str) -> Result<(), CoreError> {
+        Ok(())
+    }
+
+    /// Called when a tool call has completed with a result.
+    fn on_tool_result(
+        &mut self,
+        _name: &str,
+        _output: &str,
+        _is_error: bool,
+    ) -> Result<(), CoreError> {
         Ok(())
     }
 }
 
-/// A minimal text-only agent loop.
+// ---------------------------------------------------------------------------
+// AgentLoop
+// ---------------------------------------------------------------------------
+
+/// An agent loop that manages conversation history, streams LLM
+/// responses, dispatches tool calls, and loops until the model is done.
 ///
-/// Manages conversation history and sends it to the LLM on each turn.
-/// Tool calls are not handled in this initial implementation.
+/// Tool calls within a single LLM response are executed in parallel
+/// using a [`JoinSet`]. The loop continues sending tool results back
+/// to the LLM until it produces a final text-only response (or the
+/// maximum round count is reached).
 pub struct AgentLoop {
     /// The LLM client used to send requests.
     client: LlmClient,
 
-    /// Conversation history (system prompt + user/assistant messages).
+    /// The tool registry for looking up and executing tools.
+    registry: Arc<ToolRegistry>,
+
+    /// Pre-computed tool definitions for the `tools` field in requests.
+    tool_defs: Vec<ToolDefinition>,
+
+    /// Conversation history (system prompt + user/assistant/tool messages).
     history: Vec<Message>,
 
     /// Cancellation token for graceful shutdown.
@@ -46,9 +93,9 @@ pub struct AgentLoop {
 }
 
 impl AgentLoop {
-    /// Create a new agent loop.
+    /// Create a new agent loop with tool support.
     ///
-    /// Loads TSUMUGI.md / AGENTS.md prompt files from the global config
+    /// Loads TSUMUGI.md / AGENTS.MD prompt files from the global config
     /// directory and from `project_root` down to `cwd`, injecting them
     /// as initial user-role messages after the system prompt.
     ///
@@ -57,6 +104,7 @@ impl AgentLoop {
     /// Returns [`CoreError::Io`] if a prompt file exists but cannot be read.
     pub fn new(
         client: LlmClient,
+        registry: ToolRegistry,
         cancel: CancellationToken,
         project_root: &Path,
         cwd: &Path,
@@ -67,8 +115,13 @@ impl AgentLoop {
         let prompt_messages = prompt::load_prompt_files(project_root, cwd)?;
         history.extend(prompt_messages);
 
+        let tool_defs = registry.tool_definitions();
+        let registry = Arc::new(registry);
+
         Ok(Self {
             client,
+            registry,
+            tool_defs,
             history,
             cancel,
         })
@@ -104,21 +157,24 @@ impl AgentLoop {
         Ok(())
     }
 
-    /// Execute a single conversation turn.
+    /// Execute a single conversation turn with tool dispatch.
     ///
-    /// Adds the user message to history, streams the LLM response through
-    /// the provided [`StreamSink`], assembles the full response, and appends
-    /// it to history as an assistant message.
+    /// Adds the user message to history, then enters a loop:
+    /// 1. Stream the LLM response, collecting text and tool calls.
+    /// 2. If tool calls are present, execute them in parallel via
+    ///    `JoinSet`, add results to history, and go to step 1.
+    /// 3. If no tool calls, append the text response and return.
     ///
     /// # Errors
     ///
-    /// Returns [`CoreError`] on LLM communication failure, cancellation,
-    /// or if the sink returns an error.
+    /// Returns [`CoreError`] on LLM communication failure, tool
+    /// execution failure, cancellation, or if the sink returns an error.
     ///
     /// # Cancel safety
     ///
-    /// If the `CancellationToken` is triggered during streaming, the partial
-    /// response is discarded and [`CoreError::Cancelled`] is returned.
+    /// If the `CancellationToken` is triggered during streaming or tool
+    /// execution, the partial state is discarded and
+    /// [`CoreError::Cancelled`] is returned.
     pub async fn turn(
         &mut self,
         user_input: &str,
@@ -127,16 +183,57 @@ impl AgentLoop {
         // Add user message to history.
         self.history.push(Message::user(user_input));
 
-        // Build the messages for the LLM request.
+        for _round in 0..MAX_TOOL_ROUNDS {
+            if self.cancel.is_cancelled() {
+                return Err(CoreError::Cancelled);
+            }
+
+            let (response_text, tool_calls) = self.stream_one_round(sink).await?;
+
+            if tool_calls.is_empty() {
+                // No tool calls: final text response.
+                if !response_text.is_empty() {
+                    self.history.push(Message::assistant(response_text));
+                }
+                return Ok(());
+            }
+
+            // We have tool calls. Record the assistant message with tool
+            // calls in history, then execute them.
+            self.history.push(Message::assistant_with_tool_calls(
+                response_text,
+                tool_calls.clone(),
+            ));
+
+            self.dispatch_tool_calls(&tool_calls, sink).await?;
+
+            // Loop: send tool results back to the LLM.
+        }
+
+        // Safety valve: too many tool rounds.
+        self.history.push(Message::assistant(
+            "[Agent loop terminated: maximum tool-call rounds reached]".to_owned(),
+        ));
+        sink.on_done()?;
+
+        Ok(())
+    }
+
+    /// Stream one round of LLM output, returning the accumulated text
+    /// and any completed tool calls.
+    async fn stream_one_round(
+        &self,
+        sink: &mut impl StreamSink,
+    ) -> Result<(String, Vec<ToolCall>), CoreError> {
         let chat_messages: Vec<_> = self.history.iter().map(Message::to_chat_message).collect();
 
-        // Send streaming request.
         let mut stream = self
             .client
-            .chat_streaming(chat_messages, vec![], self.cancel.clone())
+            .chat_streaming(chat_messages, self.tool_defs.clone(), self.cancel.clone())
             .await?;
 
         let mut response_text = String::new();
+        let mut tool_calls = Vec::new();
         let mut done_called = false;
 
         while let Some(event) = stream.next().await {
@@ -145,13 +242,12 @@ impl AgentLoop {
                     response_text.push_str(&token);
                     sink.on_token(&token)?;
                 }
+                Ok(StreamEvent::ToolCallComplete(tc)) => {
+                    tool_calls.push(tc);
+                }
                 Ok(StreamEvent::Done(_)) => {
-                    sink.on_done()?;
                     done_called = true;
                     break;
-                }
-                Ok(StreamEvent::ToolCallComplete(_)) => {
-                    // Tool calls are not handled in this minimal loop.
                 }
                 Err(tmg_llm::LlmError::Cancelled) => {
                     return Err(CoreError::Cancelled);
@@ -162,14 +258,99 @@ impl AgentLoop {
             }
         }
 
-        // Ensure on_done is called even if the stream ends without a Done event.
         if !done_called {
             sink.on_done()?;
         }
 
-        // Append assistant response to history.
-        if !response_text.is_empty() {
-            self.history.push(Message::assistant(response_text));
+        Ok((response_text, tool_calls))
+    }
+
+    /// Execute tool calls in parallel via `JoinSet`, notifying the sink,
+    /// and appending tool-result messages to history.
+    ///
+    /// On error (including cancellation), remaining tasks are dropped
+    /// (the `JoinSet` is dropped, aborting outstanding tasks).
+    async fn dispatch_tool_calls(
+        &mut self,
+        tool_calls: &[ToolCall],
+        sink: &mut impl StreamSink,
+    ) -> Result<(), CoreError> {
+        // Notify sink of each tool call before dispatching.
+        for tc in tool_calls {
+            sink.on_tool_call(&tc.function.name, &tc.function.arguments)?;
+        }
+
+        // Spawn each tool call in a JoinSet for parallel execution.
+        let mut join_set = JoinSet::new();
+        for tc in tool_calls {
+            let registry = Arc::clone(&self.registry);
+            let name = tc.function.name.clone();
+            let arguments_str = tc.function.arguments.clone();
+            let call_id = tc.id.clone();
+            let cancel = self.cancel.clone();
+
+            join_set.spawn(async move {
+                // Check cancellation before executing.
+                if cancel.is_cancelled() {
+                    return (call_id, name, Err(CoreError::Cancelled));
+                }
+
+                // Parse the arguments JSON.
+                let params: serde_json::Value = match serde_json::from_str(&arguments_str) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let result =
+                            tmg_tools::ToolResult::error(format!("invalid JSON arguments: {e}"));
+                        return (call_id, name, Ok(result));
+                    }
+                };
+
+                let result = registry.execute(&name, params).await;
+                match result {
+                    Ok(tool_result) => (call_id, name, Ok(tool_result)),
+                    Err(e) => {
+                        // Tool errors are reported as error results to the
+                        // LLM rather than aborting the entire turn, so the
+                        // model can attempt recovery.
+                        let error_result = tmg_tools::ToolResult::error(e.to_string());
+                        (call_id, name, Ok(error_result))
+                    }
+                }
+            });
+        }
+
+        // Collect results in completion order.
+        // We store (call_id, tool_name, ToolResult) and sort by original
+        // order at the end to maintain deterministic history.
+        let mut results: Vec<(String, String, tmg_tools::ToolResult)> =
+            Vec::with_capacity(tool_calls.len());
+
+        while let Some(join_result) = join_set.join_next().await {
+            let (call_id, name, tool_result) = join_result.map_err(|e| {
+                CoreError::Io(std::io::Error::other(format!("task join error: {e}")))
+            })?;
+
+            let tool_result = tool_result?;
+
+            sink.on_tool_result(&name, &tool_result.output, tool_result.is_error)?;
+
+            results.push((call_id, name, tool_result));
+        }
+
+        // Sort results to match the original tool_calls order so history
+        // is deterministic regardless of execution order.
+        let call_order: Vec<&str> = tool_calls.iter().map(|tc| tc.id.as_str()).collect();
+        results.sort_by_key(|(id, _, _)| {
+            call_order
+                .iter()
+                .position(|&cid| cid == id)
+                .unwrap_or(usize::MAX)
+        });
+
+        // Append tool-result messages to history.
+        for (call_id, _name, tool_result) in results {
+            self.history
+                .push(Message::tool_result(call_id, tool_result.output));
         }
 
         Ok(())
@@ -201,5 +382,56 @@ mod tests {
         assert_eq!(chat.content.as_deref(), Some("test"));
         assert!(chat.tool_calls.is_none());
         assert!(chat.tool_call_id.is_none());
+    }
+
+    #[test]
+    fn message_with_tool_calls() {
+        let tool_call = ToolCall {
+            id: "call_1".to_owned(),
+            kind: tmg_llm::ToolKind::Function,
+            function: tmg_llm::FunctionCall {
+                name: "file_read".to_owned(),
+                arguments: r#"{"path": "/tmp/test"}"#.to_owned(),
+            },
+        };
+
+        let msg = Message::assistant_with_tool_calls("thinking...", vec![tool_call.clone()]);
+        assert_eq!(msg.role(), tmg_llm::Role::Assistant);
+        assert_eq!(msg.content(), "thinking...");
+        assert_eq!(msg.tool_calls().map(<[tmg_llm::ToolCall]>::len), Some(1));
+
+        let chat = msg.to_chat_message();
+        assert_eq!(chat.content.as_deref(), Some("thinking..."));
+        assert!(chat.tool_calls.is_some());
+    }
+
+    #[test]
+    fn tool_result_message() {
+        let msg = Message::tool_result("call_1", "file contents here");
+        assert_eq!(msg.role(), tmg_llm::Role::Tool);
+        assert_eq!(msg.content(), "file contents here");
+
+        let chat = msg.to_chat_message();
+        assert_eq!(chat.role, tmg_llm::Role::Tool);
+        assert_eq!(chat.tool_call_id.as_deref(), Some("call_1"));
+    }
+
+    #[test]
+    fn empty_content_message_serializes_as_none() {
+        let msg = Message::assistant_with_tool_calls(
+            "",
+            vec![ToolCall {
+                id: "call_x".to_owned(),
+                kind: tmg_llm::ToolKind::Function,
+                function: tmg_llm::FunctionCall {
+                    name: "test".to_owned(),
+                    arguments: "{}".to_owned(),
+                },
+            }],
+        );
+
+        let chat = msg.to_chat_message();
+        assert!(chat.content.is_none());
+        assert!(chat.tool_calls.is_some());
     }
 }

--- a/crates/tmg-core/src/error.rs
+++ b/crates/tmg-core/src/error.rs
@@ -7,6 +7,10 @@ pub enum CoreError {
     #[error("llm error: {0}")]
     Llm(#[from] tmg_llm::LlmError),
 
+    /// An error originating from tool execution.
+    #[error("tool error: {0}")]
+    Tool(#[from] tmg_tools::ToolError),
+
     /// An I/O error (e.g. reading prompt files).
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/tmg-core/src/message.rs
+++ b/crates/tmg-core/src/message.rs
@@ -1,18 +1,30 @@
 //! Conversation message types for the agent loop.
 
-use tmg_llm::{ChatMessage, Role};
+use tmg_llm::{ChatMessage, Role, ToolCall};
 
-/// A conversation message with a role and text content.
+/// A conversation message with a role and content.
 ///
 /// This is a simplified view used by the agent loop. It converts to/from
 /// the LLM layer's [`ChatMessage`] for wire transmission.
+///
+/// Supports text-only messages (system, user, plain assistant), assistant
+/// messages with tool calls, and tool-result messages.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Message {
     /// The author role of this message.
     pub(crate) role: Role,
 
-    /// The text content of this message.
+    /// The text content of this message (may be empty for tool-call-only
+    /// assistant messages).
     pub(crate) content: String,
+
+    /// Tool calls requested by the assistant (non-empty only for
+    /// `Role::Assistant` messages that triggered tool use).
+    pub(crate) tool_calls: Option<Vec<ToolCall>>,
+
+    /// For `Role::Tool` messages: the id of the tool call this message
+    /// responds to.
+    pub(crate) tool_call_id: Option<String>,
 }
 
 impl Message {
@@ -21,6 +33,8 @@ impl Message {
         Self {
             role: Role::System,
             content: content.into(),
+            tool_calls: None,
+            tool_call_id: None,
         }
     }
 
@@ -29,14 +43,42 @@ impl Message {
         Self {
             role: Role::User,
             content: content.into(),
+            tool_calls: None,
+            tool_call_id: None,
         }
     }
 
-    /// Create a new assistant message.
+    /// Create a new assistant message (text only).
     pub fn assistant(content: impl Into<String>) -> Self {
         Self {
             role: Role::Assistant,
             content: content.into(),
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+
+    /// Create an assistant message that contains tool calls (and
+    /// optionally some text content).
+    pub fn assistant_with_tool_calls(
+        content: impl Into<String>,
+        tool_calls: Vec<ToolCall>,
+    ) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: content.into(),
+            tool_calls: Some(tool_calls),
+            tool_call_id: None,
+        }
+    }
+
+    /// Create a tool-result message responding to a specific tool call.
+    pub fn tool_result(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Tool,
+            content: content.into(),
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.into()),
         }
     }
 
@@ -50,23 +92,38 @@ impl Message {
         &self.content
     }
 
-    /// Create a [`ChatMessage`] by borrowing self, cloning only the content string.
+    /// Return the tool calls, if any.
+    pub fn tool_calls(&self) -> Option<&[ToolCall]> {
+        self.tool_calls.as_deref()
+    }
+
+    /// Create a [`ChatMessage`] by borrowing self, cloning strings.
     pub fn to_chat_message(&self) -> ChatMessage {
+        let content = if self.content.is_empty() {
+            None
+        } else {
+            Some(self.content.clone())
+        };
         ChatMessage {
             role: self.role,
-            content: Some(self.content.clone()),
-            tool_calls: None,
-            tool_call_id: None,
+            content,
+            tool_calls: self.tool_calls.clone(),
+            tool_call_id: self.tool_call_id.clone(),
         }
     }
 
     /// Convert this message into a [`ChatMessage`] for the LLM API.
     pub fn into_chat_message(self) -> ChatMessage {
+        let content = if self.content.is_empty() {
+            None
+        } else {
+            Some(self.content)
+        };
         ChatMessage {
             role: self.role,
-            content: Some(self.content),
-            tool_calls: None,
-            tool_call_id: None,
+            content,
+            tool_calls: self.tool_calls,
+            tool_call_id: self.tool_call_id,
         }
     }
 }

--- a/crates/tmg-llm/src/lib.rs
+++ b/crates/tmg-llm/src/lib.rs
@@ -7,6 +7,6 @@ pub mod types;
 pub use client::{ChatStream, LlmClient, LlmClientConfig};
 pub use error::LlmError;
 pub use types::{
-    ChatMessage, ChatRequest, ChatResponse, Role, StreamEvent, ToolCall, ToolCallAccumulator,
-    ToolCallIndexError, ToolDefinition, ToolKind,
+    ChatMessage, ChatRequest, ChatResponse, FunctionCall, FunctionDefinition, Role, StreamEvent,
+    ToolCall, ToolCallAccumulator, ToolCallIndexError, ToolDefinition, ToolKind,
 };

--- a/crates/tmg-tools/Cargo.toml
+++ b/crates/tmg-tools/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+tmg-llm = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/tmg-tools/src/types.rs
+++ b/crates/tmg-tools/src/types.rs
@@ -176,6 +176,29 @@ impl ToolRegistry {
     pub fn tool_names(&self) -> impl Iterator<Item = &str> {
         self.tools.keys().map(String::as_str)
     }
+
+    /// Return tool definitions in the format expected by the LLM chat
+    /// completions API `tools` field.
+    ///
+    /// Each entry wraps a tool's name, description, and parameter schema
+    /// in a [`tmg_llm::ToolDefinition`].
+    pub fn tool_definitions(&self) -> Vec<tmg_llm::ToolDefinition> {
+        let mut defs: Vec<tmg_llm::ToolDefinition> = self
+            .tools
+            .values()
+            .map(|tool| tmg_llm::ToolDefinition {
+                kind: tmg_llm::ToolKind::Function,
+                function: tmg_llm::FunctionDefinition {
+                    name: tool.name().to_owned(),
+                    description: Some(tool.description().to_owned()),
+                    parameters: Some(tool.parameters_schema()),
+                },
+            })
+            .collect();
+        // Sort by name for deterministic ordering.
+        defs.sort_by(|a, b| a.function.name.cmp(&b.function.name));
+        defs
+    }
 }
 
 impl Default for ToolRegistry {

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -522,18 +522,23 @@ impl App {
 }
 
 /// Truncate a string for display, replacing middle with ellipsis if
-/// it exceeds `max_len` characters.
+/// it exceeds `max_len` characters (measured in `char` count, not bytes).
 fn truncate_for_display(s: &str, max_len: usize) -> String {
     let first_line = s.lines().next().unwrap_or(s);
-    if first_line.len() <= max_len {
+    if first_line.chars().count() <= max_len {
         return first_line.to_owned();
     }
     let half = max_len / 2;
-    format!(
-        "{}...{}",
-        &first_line[..half],
-        &first_line[first_line.len() - half..]
-    )
+    let start: String = first_line.chars().take(half).collect();
+    let end: String = first_line
+        .chars()
+        .rev()
+        .take(half)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    format!("{start}...{end}")
 }
 
 /// A [`StreamSink`] that sends tokens and tool activity through an

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -17,10 +17,37 @@ pub struct ChatEntry {
     pub text: String,
 }
 
+/// A single log entry in the tool activity pane.
+#[derive(Debug, Clone)]
+pub struct ToolActivityEntry {
+    /// The tool name.
+    pub tool_name: String,
+    /// A summary of the tool activity (call parameters or result excerpt).
+    pub summary: String,
+    /// Whether this entry represents an error.
+    pub is_error: bool,
+}
+
 /// Messages sent from the background turn task to the event loop.
 pub enum TurnMessage {
     /// An incremental token from the LLM stream.
     Token(String),
+    /// A tool call is being dispatched.
+    ToolCall {
+        /// The tool name.
+        name: String,
+        /// The tool call arguments (JSON string).
+        arguments: String,
+    },
+    /// A tool call completed with a result.
+    ToolResult {
+        /// The tool name.
+        name: String,
+        /// The tool output (may be truncated for display).
+        output: String,
+        /// Whether the tool reported an error.
+        is_error: bool,
+    },
     /// The turn completed successfully. Contains the `AgentLoop` back
     /// and the turn count for context display.
     Done {
@@ -60,6 +87,9 @@ pub struct App {
 
     /// Chat entries displayed in the chat pane.
     chat_entries: Vec<ChatEntry>,
+
+    /// Tool activity log displayed in the tool pane.
+    tool_activity: Vec<ToolActivityEntry>,
 
     /// The current text in the input area.
     input: String,
@@ -101,6 +131,7 @@ impl App {
         Self {
             agent: Some(agent),
             chat_entries: Vec::new(),
+            tool_activity: Vec::new(),
             input: String::new(),
             cursor_pos: 0,
             chat_scroll: 0,
@@ -143,6 +174,11 @@ impl App {
     /// Return a reference to the chat entries.
     pub fn chat_entries(&self) -> &[ChatEntry] {
         &self.chat_entries
+    }
+
+    /// Return a reference to the tool activity log.
+    pub fn tool_activity(&self) -> &[ToolActivityEntry] {
+        &self.tool_activity
     }
 
     /// Return the current input text.
@@ -284,6 +320,7 @@ impl App {
             }
             "clear" => {
                 self.chat_entries.clear();
+                self.tool_activity.clear();
                 self.chat_scroll = 0;
                 if let Some(agent) = &mut self.agent {
                     agent.clear_history(&self.project_root, &self.cwd)?;
@@ -298,10 +335,10 @@ impl App {
 
     /// Start a conversation turn in a background task.
     ///
-    /// The turn runs on a spawned tokio task. Streaming tokens are sent
-    /// through an `mpsc` channel that the event loop drains on each
-    /// tick. A child `CancellationToken` is used so that cancelling a
-    /// turn does not shut down the entire application.
+    /// The turn runs on a spawned tokio task. Streaming tokens and tool
+    /// activity are sent through an `mpsc` channel that the event loop
+    /// drains on each tick. A child `CancellationToken` is used so that
+    /// cancelling a turn does not shut down the entire application.
     ///
     /// # Panics
     ///
@@ -341,7 +378,7 @@ impl App {
                         .iter()
                         .filter(|m| m.role() == Role::User)
                         .count();
-                    // Ignore send errors — the receiver may have been
+                    // Ignore send errors -- the receiver may have been
                     // dropped if the app is shutting down.
                     let _ = tx.send(TurnMessage::Done { agent, user_turns }).await;
                 }
@@ -392,6 +429,29 @@ impl App {
                     }
                     changed = true;
                 }
+                Ok(TurnMessage::ToolCall { name, arguments }) => {
+                    // Truncate arguments for display.
+                    let summary = truncate_for_display(&arguments, 120);
+                    self.tool_activity.push(ToolActivityEntry {
+                        tool_name: name,
+                        summary: format!("calling: {summary}"),
+                        is_error: false,
+                    });
+                    changed = true;
+                }
+                Ok(TurnMessage::ToolResult {
+                    name,
+                    output,
+                    is_error,
+                }) => {
+                    let summary = truncate_for_display(&output, 200);
+                    self.tool_activity.push(ToolActivityEntry {
+                        tool_name: name,
+                        summary,
+                        is_error,
+                    });
+                    changed = true;
+                }
                 Ok(TurnMessage::Done { agent, user_turns }) => {
                     self.agent = Some(agent);
                     self.streaming = false;
@@ -424,7 +484,7 @@ impl App {
                     return changed;
                 }
                 Err(mpsc::error::TryRecvError::Disconnected) => {
-                    // The task ended without sending Done/Error — this
+                    // The task ended without sending Done/Error -- this
                     // means it panicked or was dropped unexpectedly.
                     // Reset streaming state and surface an error so the
                     // user knows recovery requires a restart.
@@ -461,7 +521,23 @@ impl App {
     }
 }
 
-/// A [`StreamSink`] that sends tokens through an `mpsc` channel.
+/// Truncate a string for display, replacing middle with ellipsis if
+/// it exceeds `max_len` characters.
+fn truncate_for_display(s: &str, max_len: usize) -> String {
+    let first_line = s.lines().next().unwrap_or(s);
+    if first_line.len() <= max_len {
+        return first_line.to_owned();
+    }
+    let half = max_len / 2;
+    format!(
+        "{}...{}",
+        &first_line[..half],
+        &first_line[first_line.len() - half..]
+    )
+}
+
+/// A [`StreamSink`] that sends tokens and tool activity through an
+/// `mpsc` channel.
 struct ChannelStreamSink {
     tx: mpsc::Sender<TurnMessage>,
 }
@@ -476,10 +552,36 @@ impl StreamSink for ChannelStreamSink {
     fn on_done(&mut self) -> Result<(), CoreError> {
         Ok(())
     }
+
+    fn on_tool_call(&mut self, name: &str, arguments: &str) -> Result<(), CoreError> {
+        self.tx
+            .try_send(TurnMessage::ToolCall {
+                name: name.to_owned(),
+                arguments: arguments.to_owned(),
+            })
+            .map_err(|_| CoreError::Cancelled)
+    }
+
+    fn on_tool_result(
+        &mut self,
+        name: &str,
+        output: &str,
+        is_error: bool,
+    ) -> Result<(), CoreError> {
+        self.tx
+            .try_send(TurnMessage::ToolResult {
+                name: name.to_owned(),
+                output: output.to_owned(),
+                is_error,
+            })
+            .map_err(|_| CoreError::Cancelled)
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn insert_and_delete_chars() {
         // We can't easily create an AgentLoop without an LlmClient,
@@ -519,5 +621,26 @@ mod tests {
 
         let text = "hello";
         assert!(text.strip_prefix('/').is_none());
+    }
+
+    #[test]
+    fn truncate_for_display_short() {
+        let result = truncate_for_display("hello", 10);
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn truncate_for_display_long() {
+        let long = "a".repeat(300);
+        let result = truncate_for_display(&long, 20);
+        assert!(result.len() < 30);
+        assert!(result.contains("..."));
+    }
+
+    #[test]
+    fn truncate_for_display_multiline() {
+        let text = "first line\nsecond line\nthird line";
+        let result = truncate_for_display(text, 100);
+        assert_eq!(result, "first line");
     }
 }

--- a/crates/tmg-tui/src/ui.rs
+++ b/crates/tmg-tui/src/ui.rs
@@ -68,7 +68,7 @@ fn draw_main_area(frame: &mut Frame, app: &App, area: Rect) {
         .split(area);
 
     draw_chat_pane(frame, app, horizontal[0]);
-    draw_tool_pane(frame, horizontal[1]);
+    draw_tool_pane(frame, app, horizontal[1]);
 }
 
 /// Draw the chat pane showing conversation entries.
@@ -153,21 +153,71 @@ fn draw_chat_pane(frame: &mut Frame, app: &App, area: Rect) {
     }
 }
 
-/// Draw the tool activity pane (frame only, content in future issues).
-fn draw_tool_pane(frame: &mut Frame, area: Rect) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .title(" Tools ")
-        .style(Style::default().fg(Color::DarkGray));
-    let placeholder = Paragraph::new(Text::from(vec![
-        Line::from(""),
-        Line::from(Span::styled(
-            "  (no tool activity)",
-            Style::default().fg(Color::DarkGray),
-        )),
-    ]))
-    .block(block);
-    frame.render_widget(placeholder, area);
+/// Draw the tool activity pane showing tool call logs.
+fn draw_tool_pane(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title(" Tools ");
+
+    let activity = app.tool_activity();
+
+    if activity.is_empty() {
+        let placeholder_block = block.style(Style::default().fg(Color::DarkGray));
+        let placeholder = Paragraph::new(Text::from(vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "  (no tool activity)",
+                Style::default().fg(Color::DarkGray),
+            )),
+        ]))
+        .block(placeholder_block);
+        frame.render_widget(placeholder, area);
+        return;
+    }
+
+    let inner = block.inner(area);
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    for entry in activity {
+        let name_style = if entry.is_error {
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD)
+        };
+
+        let summary_style = if entry.is_error {
+            Style::default().fg(Color::Red)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        lines.push(Line::from(vec![Span::styled(
+            format!("[{}]", entry.tool_name),
+            name_style,
+        )]));
+
+        // Wrap the summary across multiple lines if needed.
+        for line in entry.summary.lines() {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(line, summary_style),
+            ]));
+        }
+
+        lines.push(Line::from(""));
+    }
+
+    // Auto-scroll to bottom to show latest activity.
+    let total_lines = u16::try_from(lines.len()).unwrap_or(u16::MAX);
+    let visible_height = inner.height;
+    let scroll = total_lines.saturating_sub(visible_height);
+
+    let tool_log = Paragraph::new(Text::from(lines))
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
+
+    frame.render_widget(tool_log, area);
 }
 
 /// Draw the input area at the bottom.

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -13,6 +13,7 @@ tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tmg-core = { workspace = true }
 tmg-llm = { workspace = true }
+tmg-tools = { workspace = true }
 tmg-tui = { workspace = true }
 
 [lints]

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -106,7 +106,9 @@ fn run_tui(endpoint: &str, model: &str) -> anyhow::Result<()> {
         // Use cwd as project root for now (could be improved with git root detection).
         let project_root = cwd.clone();
 
-        let agent = tmg_core::AgentLoop::new(client, cancel.clone(), &project_root, &cwd)?;
+        let registry = tmg_tools::default_registry();
+        let agent =
+            tmg_core::AgentLoop::new(client, registry, cancel.clone(), &project_root, &cwd)?;
 
         tmg_tui::run(agent, model, cancel, project_root, cwd).await?;
 


### PR DESCRIPTION
## Summary

- Extend `AgentLoop` to accept a `ToolRegistry`, detect `tool_calls` in LLM responses, execute them in parallel via `JoinSet`, feed results back as `tool`-role messages, and loop until the model produces a final text response (capped at 20 rounds)
- Extend `Message` type with `tool_calls` and `tool_call_id` fields; add `StreamSink::on_tool_call`/`on_tool_result` callbacks for tool activity notifications
- Add `ToolRegistry::tool_definitions()` to produce `Vec<ToolDefinition>` for the chat completion request `tools` field
- Implement TUI Tool Activity Pane: displays tool call logs with tool name, parameter summary, and result excerpts (auto-scrolls to latest)
- Wire `CancellationToken` through tool dispatch -- cancelling a turn aborts outstanding tool tasks via `JoinSet` drop

## Crates modified

| Crate | Changes |
|-------|---------|
| `tmg-core` | `AgentLoop` tool dispatch loop, `Message` tool call/result variants, `StreamSink` tool callbacks, `CoreError::Tool` |
| `tmg-tools` | `ToolRegistry::tool_definitions()`, new dep on `tmg-llm` |
| `tmg-llm` | Re-export `FunctionCall`, `FunctionDefinition` |
| `tmg-tui` | `ToolActivityEntry`, tool pane rendering, `TurnMessage::ToolCall`/`ToolResult` variants |
| `tmg-cli` | Pass `default_registry()` to `AgentLoop::new()` |

## Testing

- All 66 existing tests pass (unit + integration)
- New unit tests for `Message::assistant_with_tool_calls`, `Message::tool_result`, empty-content serialization
- New tests for `truncate_for_display` helper
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Test plan

- [ ] "Read src/main.rs" -> LLM calls `file_read` and shows content
- [ ] "Create hello.txt" -> LLM calls `file_write` to create file
- [ ] "Run cargo test" -> LLM calls `shell_exec`, results displayed
- [ ] Tool Activity Pane shows tool call logs during all above
- [ ] Multiple tool_calls in one turn run in parallel via JoinSet
- [ ] Ctrl+C during tool execution cancels cleanly
- [ ] Multi-turn file operation dialogue works end-to-end with llama-server

Closes #6

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>