### PR TITLE
Implement sandbox security in tmg-sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +469,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -664,6 +690,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "landlock"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,7 +829,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1251,6 +1298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1550,15 @@ dependencies = [
 [[package]]
 name = "tmg-sandbox"
 version = "0.1.0"
+dependencies = [
+ "landlock",
+ "libc",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "toml",
+]
 
 [[package]]
 name = "tmg-skills"
@@ -1584,6 +1649,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2024,6 +2130,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ dirs = "6"
 
 # Sandbox
 landlock = "0.4"
+libc = "0.2"
 
 # Workspace crates
 tmg-core = { path = "crates/tmg-core" }

--- a/crates/tmg-sandbox/Cargo.toml
+++ b/crates/tmg-sandbox/Cargo.toml
@@ -6,6 +6,18 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+thiserror = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true, features = ["process", "time", "io-util"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = { workspace = true }
+libc = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "time", "io-util"] }
+toml = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/tmg-sandbox/src/config.rs
+++ b/crates/tmg-sandbox/src/config.rs
@@ -1,0 +1,139 @@
+//! Sandbox configuration.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::mode::SandboxMode;
+
+/// Default timeout in seconds for shell command execution.
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// Default OOM score adjustment for child processes.
+///
+/// A higher score makes the process more likely to be killed by the
+/// kernel OOM killer. 500 is moderately aggressive.
+const DEFAULT_OOM_SCORE_ADJ: i32 = 500;
+
+/// Configuration for the sandbox environment.
+///
+/// This is typically deserialized from the `[sandbox]` section of
+/// `tsumugi.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxConfig {
+    /// The workspace directory that the agent operates within.
+    ///
+    /// This directory receives read (and optionally write) access
+    /// depending on the [`SandboxMode`].
+    pub workspace: PathBuf,
+
+    /// The sandbox operating mode.
+    #[serde(default)]
+    pub mode: SandboxMode,
+
+    /// Domains allowed for outbound network access.
+    ///
+    /// When non-empty on Linux, a network namespace is created and
+    /// iptables rules restrict outbound traffic to only these domains
+    /// (resolved to IP addresses at sandbox creation time).
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
+
+    /// Maximum execution time in seconds for shell commands.
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
+
+    /// OOM score adjustment for child processes (Linux only).
+    ///
+    /// Range: -1000 to 1000. Higher values make the process more
+    /// likely to be killed by the OOM killer.
+    #[serde(default = "default_oom_score_adj")]
+    pub oom_score_adj: i32,
+}
+
+const fn default_timeout_secs() -> u64 {
+    DEFAULT_TIMEOUT_SECS
+}
+
+const fn default_oom_score_adj() -> i32 {
+    DEFAULT_OOM_SCORE_ADJ
+}
+
+impl SandboxConfig {
+    /// Create a new sandbox configuration with the given workspace path.
+    ///
+    /// All other settings use their defaults (workspace-write mode,
+    /// no allowed domains, 30s timeout, OOM score 500).
+    pub fn new(workspace: impl Into<PathBuf>) -> Self {
+        Self {
+            workspace: workspace.into(),
+            mode: SandboxMode::default(),
+            allowed_domains: Vec::new(),
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+            oom_score_adj: DEFAULT_OOM_SCORE_ADJ,
+        }
+    }
+
+    /// Set the sandbox mode.
+    #[must_use]
+    pub fn with_mode(mut self, mode: SandboxMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Set the allowed domains for network access.
+    #[must_use]
+    pub fn with_allowed_domains(mut self, domains: Vec<String>) -> Self {
+        self.allowed_domains = domains;
+        self
+    }
+
+    /// Set the timeout for shell commands.
+    #[must_use]
+    pub fn with_timeout(mut self, seconds: u64) -> Self {
+        self.timeout_secs = seconds;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = SandboxConfig::new("/tmp/workspace");
+        assert_eq!(config.workspace, PathBuf::from("/tmp/workspace"));
+        assert_eq!(config.mode, SandboxMode::WorkspaceWrite);
+        assert!(config.allowed_domains.is_empty());
+        assert_eq!(config.timeout_secs, 30);
+        assert_eq!(config.oom_score_adj, 500);
+    }
+
+    #[test]
+    fn builder_methods() {
+        let config = SandboxConfig::new("/tmp/ws")
+            .with_mode(SandboxMode::ReadOnly)
+            .with_allowed_domains(vec!["example.com".to_owned()])
+            .with_timeout(60);
+
+        assert_eq!(config.mode, SandboxMode::ReadOnly);
+        assert_eq!(config.allowed_domains, vec!["example.com"]);
+        assert_eq!(config.timeout_secs, 60);
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let config = SandboxConfig::new("/tmp/ws")
+            .with_mode(SandboxMode::ReadOnly)
+            .with_allowed_domains(vec!["api.example.com".to_owned()]);
+
+        let toml_str =
+            toml::to_string(&config).unwrap_or_else(|_| String::from("serialize failed"));
+        let deserialized: SandboxConfig =
+            toml::from_str(&toml_str).unwrap_or_else(|_| SandboxConfig::new("/fallback"));
+
+        assert_eq!(deserialized.mode, SandboxMode::ReadOnly);
+        assert_eq!(deserialized.allowed_domains, vec!["api.example.com"]);
+    }
+}

--- a/crates/tmg-sandbox/src/context.rs
+++ b/crates/tmg-sandbox/src/context.rs
@@ -65,17 +65,33 @@ impl SandboxContext {
     ///
     /// On Linux, this:
     /// 1. Applies Landlock filesystem rules
-    /// 2. Creates a network namespace (if `allowed_domains` is configured)
-    /// 3. Applies iptables rules for the domain allowlist
+    /// 2. Creates an isolated network namespace that blocks all external
+    ///    network access
     ///
     /// On non-Linux platforms, this emits warnings and returns `Ok(())`.
     ///
     /// This method is idempotent: calling it multiple times has no
     /// additional effect after the first successful activation.
     ///
+    /// # Network isolation
+    ///
+    /// Network restriction is achieved by placing the process into a new,
+    /// empty network namespace via `unshare(CLONE_NEWNET)`. The new namespace
+    /// contains only a loopback interface with no external connectivity.
+    ///
+    /// The `allowed_domains` configuration field is accepted but **not yet
+    /// enforced** -- selective domain allowlisting requires veth pair setup
+    /// or Landlock v4+ network access rules, which are planned for future
+    /// work. Currently, when any network restriction is active, **all**
+    /// external network access is blocked.
+    ///
     /// # Errors
     ///
     /// Returns [`SandboxError`] if any OS-level restriction fails to apply.
+    #[expect(
+        clippy::unused_async,
+        reason = "kept async for API stability; future network allowlist implementation will require async"
+    )]
     pub async fn activate(&mut self) -> Result<(), SandboxError> {
         if self.activated {
             return Ok(());
@@ -89,11 +105,9 @@ impl SandboxContext {
         // Apply filesystem restrictions.
         platform::apply_landlock(&self.config)?;
 
-        // Apply network restrictions if domains are configured.
-        if !self.config.allowed_domains.is_empty() {
-            platform::create_network_namespace()?;
-            platform::apply_network_allowlist(&self.config.allowed_domains).await?;
-        }
+        // Apply network restrictions: create an empty network namespace
+        // that blocks all external connectivity.
+        platform::create_network_namespace()?;
 
         self.activated = true;
         Ok(())
@@ -114,15 +128,15 @@ impl SandboxContext {
         }
 
         let path = path.as_ref();
-        let canonical = normalize_path(path);
+        let canonical = normalize_path(path, &self.config.workspace);
 
         // Allow access to workspace directory.
         if canonical.starts_with(&self.config.workspace) {
             return Ok(());
         }
 
-        // Allow access to system paths.
-        for system_path in &["/usr", "/bin", "/lib", "/lib64"] {
+        // Allow access to system paths (platform-specific).
+        for system_path in system_read_paths() {
             if canonical.starts_with(system_path) {
                 return Ok(());
             }
@@ -159,7 +173,7 @@ impl SandboxContext {
         }
 
         // WorkspaceWrite mode: only allow writes within the workspace.
-        let canonical = normalize_path(path);
+        let canonical = normalize_path(path, &self.config.workspace);
         if canonical.starts_with(&self.config.workspace) {
             return Ok(());
         }
@@ -206,11 +220,41 @@ impl SandboxContext {
     }
 }
 
-/// Normalize a path by resolving `.` and `..` components without
-/// touching the filesystem (no symlink resolution).
+/// Normalize a path for sandbox access checks.
 ///
-/// This is a best-effort normalization for sandbox path checks.
-fn normalize_path(path: &Path) -> PathBuf {
+/// If `path` is relative, it is first joined with the given `base` directory
+/// (typically the workspace or current working directory) so that the resulting
+/// path is absolute and can be compared against the allowlist.
+///
+/// When the path exists on disk, [`std::fs::canonicalize`] is used so that
+/// symlinks are fully resolved. This prevents a symlink inside the workspace
+/// from pointing outside the sandbox boundary.
+///
+/// # Limitation
+///
+/// For paths that **do not yet exist** (e.g., a file about to be created),
+/// `canonicalize` cannot be used and we fall back to purely lexical
+/// normalization (resolving `.` and `..` components without filesystem
+/// access). A symlink in a *parent* directory of the not-yet-existing path
+/// will **not** be detected in this case, so the check is best-effort.
+fn normalize_path(path: &Path, base: &Path) -> PathBuf {
+    let absolute = if path.is_relative() {
+        base.join(path)
+    } else {
+        path.to_path_buf()
+    };
+
+    // Prefer canonicalize when the path exists -- it resolves symlinks.
+    if let Ok(canonical) = std::fs::canonicalize(&absolute) {
+        return canonical;
+    }
+
+    // Fallback: lexical normalization for paths that don't exist yet.
+    lexical_normalize(&absolute)
+}
+
+/// Resolve `.` and `..` components without touching the filesystem.
+fn lexical_normalize(path: &Path) -> PathBuf {
     use std::path::Component;
 
     let mut normalized = PathBuf::new();
@@ -224,6 +268,38 @@ fn normalize_path(path: &Path) -> PathBuf {
         }
     }
     normalized
+}
+
+/// System paths that are granted read-only access in software path checks.
+///
+/// On Linux, these correspond to the standard FHS directories containing
+/// system binaries and shared libraries. On macOS, Homebrew and system
+/// framework paths are included instead.
+#[cfg(target_os = "linux")]
+fn system_read_paths() -> &'static [&'static str] {
+    &["/usr", "/bin", "/lib", "/lib64"]
+}
+
+/// System paths that are granted read-only access in software path checks.
+///
+/// On macOS, these include Homebrew, system frameworks, and standard
+/// Unix directories.
+#[cfg(target_os = "macos")]
+fn system_read_paths() -> &'static [&'static str] {
+    &[
+        "/usr",
+        "/bin",
+        "/sbin",
+        "/opt/homebrew",
+        "/System",
+        "/Library",
+    ]
+}
+
+/// Fallback system path allowlist for other platforms.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn system_read_paths() -> &'static [&'static str] {
+    &["/usr", "/bin"]
 }
 
 /// Get the tsumugi configuration directory path (`~/.config/tsumugi/`).
@@ -285,11 +361,21 @@ mod tests {
         let ctx = SandboxContext::new(config);
 
         assert!(ctx.check_path_access("/usr/bin/ls").is_ok());
-        assert!(ctx.check_path_access("/bin/sh").is_ok());
-        assert!(
-            ctx.check_path_access("/lib/x86_64-linux-gnu/libc.so")
-                .is_ok()
-        );
+        #[cfg(target_os = "linux")]
+        {
+            assert!(ctx.check_path_access("/bin/sh").is_ok());
+            assert!(
+                ctx.check_path_access("/lib/x86_64-linux-gnu/libc.so")
+                    .is_ok()
+            );
+        }
+        #[cfg(target_os = "macos")]
+        {
+            assert!(ctx.check_path_access("/bin/sh").is_ok());
+            assert!(ctx.check_path_access("/opt/homebrew/bin/cargo").is_ok());
+            assert!(ctx.check_path_access("/System/Library/Frameworks").is_ok());
+            assert!(ctx.check_path_access("/Library/Developer").is_ok());
+        }
     }
 
     #[test]
@@ -350,14 +436,43 @@ mod tests {
 
     #[test]
     fn normalize_path_handles_parent_dir() {
-        let result = normalize_path(Path::new("/tmp/workspace/../secret"));
+        let base = Path::new("/tmp/workspace");
+        // Absolute path with `..` -- base is unused.
+        let result = normalize_path(Path::new("/tmp/workspace/../secret"), base);
         assert_eq!(result, PathBuf::from("/tmp/secret"));
     }
 
     #[test]
     fn normalize_path_handles_current_dir() {
-        let result = normalize_path(Path::new("/tmp/./workspace/./file"));
+        let base = Path::new("/tmp/workspace");
+        let result = normalize_path(Path::new("/tmp/./workspace/./file"), base);
         assert_eq!(result, PathBuf::from("/tmp/workspace/file"));
+    }
+
+    #[test]
+    fn normalize_path_resolves_relative_path() {
+        let base = Path::new("/tmp/workspace");
+        let result = normalize_path(Path::new("src/main.rs"), base);
+        assert_eq!(result, PathBuf::from("/tmp/workspace/src/main.rs"));
+    }
+
+    #[test]
+    fn relative_path_access_within_workspace() {
+        let config = test_config().with_mode(SandboxMode::WorkspaceWrite);
+        let ctx = SandboxContext::new(config);
+
+        // Relative paths should be resolved against the workspace.
+        assert!(ctx.check_path_access("src/main.rs").is_ok());
+        assert!(ctx.check_write_access("output.txt").is_ok());
+    }
+
+    #[test]
+    fn relative_path_traversal_denied() {
+        let config = test_config().with_mode(SandboxMode::WorkspaceWrite);
+        let ctx = SandboxContext::new(config);
+
+        // Relative path that escapes via `..` should be denied.
+        assert!(ctx.check_path_access("../../etc/passwd").is_err());
     }
 
     #[tokio::test]

--- a/crates/tmg-sandbox/src/context.rs
+++ b/crates/tmg-sandbox/src/context.rs
@@ -1,0 +1,400 @@
+//! `SandboxContext`: the main entry point for sandbox setup and enforcement.
+
+use std::path::{Path, PathBuf};
+
+use crate::config::SandboxConfig;
+use crate::error::SandboxError;
+use crate::mode::SandboxMode;
+use crate::platform;
+use crate::process::{self, CommandOutput};
+
+/// A configured sandbox environment.
+///
+/// `SandboxContext` holds the resolved sandbox configuration and provides
+/// methods to:
+///
+/// - Apply OS-level restrictions (Landlock, network namespace)
+/// - Validate filesystem access before tool execution
+/// - Run commands with timeout and OOM score enforcement
+///
+/// # Platform behavior
+///
+/// On Linux, calling [`activate`](SandboxContext::activate) applies Landlock
+/// filesystem restrictions and optionally creates a network namespace with
+/// domain-based allowlisting.
+///
+/// On non-Linux platforms, `activate` emits warnings and proceeds without
+/// OS-level restrictions. Path validation still functions as a software-level
+/// check.
+///
+/// # Example
+///
+/// ```no_run
+/// # use tmg_sandbox::{SandboxConfig, SandboxContext};
+/// # async fn example() -> Result<(), tmg_sandbox::SandboxError> {
+/// let config = SandboxConfig::new("/home/user/project");
+/// let mut ctx = SandboxContext::new(config);
+/// ctx.activate().await?;
+///
+/// // Run a command within sandbox constraints.
+/// let output = ctx.run_command("ls -la").await?;
+/// assert!(output.success());
+/// # Ok(())
+/// # }
+/// ```
+pub struct SandboxContext {
+    /// The sandbox configuration.
+    config: SandboxConfig,
+
+    /// Whether OS-level restrictions have been activated.
+    activated: bool,
+}
+
+impl SandboxContext {
+    /// Create a new sandbox context from the given configuration.
+    ///
+    /// The sandbox is not active until [`activate`](Self::activate) is called.
+    pub fn new(config: SandboxConfig) -> Self {
+        Self {
+            config,
+            activated: false,
+        }
+    }
+
+    /// Activate OS-level sandbox restrictions.
+    ///
+    /// On Linux, this:
+    /// 1. Applies Landlock filesystem rules
+    /// 2. Creates a network namespace (if `allowed_domains` is configured)
+    /// 3. Applies iptables rules for the domain allowlist
+    ///
+    /// On non-Linux platforms, this emits warnings and returns `Ok(())`.
+    ///
+    /// This method is idempotent: calling it multiple times has no
+    /// additional effect after the first successful activation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SandboxError`] if any OS-level restriction fails to apply.
+    pub async fn activate(&mut self) -> Result<(), SandboxError> {
+        if self.activated {
+            return Ok(());
+        }
+
+        if self.config.mode == SandboxMode::Full {
+            self.activated = true;
+            return Ok(());
+        }
+
+        // Apply filesystem restrictions.
+        platform::apply_landlock(&self.config)?;
+
+        // Apply network restrictions if domains are configured.
+        if !self.config.allowed_domains.is_empty() {
+            platform::create_network_namespace()?;
+            platform::apply_network_allowlist(&self.config.allowed_domains).await?;
+        }
+
+        self.activated = true;
+        Ok(())
+    }
+
+    /// Check whether a given path is accessible under the current sandbox mode.
+    ///
+    /// This performs a software-level check (not relying on Landlock):
+    /// - In `Full` mode, all paths are allowed.
+    /// - In `WorkspaceWrite` and `ReadOnly` modes, only paths within the
+    ///   workspace directory (and system paths) are allowed.
+    ///
+    /// This does **not** distinguish between read and write access; use
+    /// [`check_write_access`](Self::check_write_access) for write checks.
+    pub fn check_path_access(&self, path: impl AsRef<Path>) -> Result<(), SandboxError> {
+        if self.config.mode.is_unrestricted() {
+            return Ok(());
+        }
+
+        let path = path.as_ref();
+        let canonical = normalize_path(path);
+
+        // Allow access to workspace directory.
+        if canonical.starts_with(&self.config.workspace) {
+            return Ok(());
+        }
+
+        // Allow access to system paths.
+        for system_path in &["/usr", "/bin", "/lib", "/lib64"] {
+            if canonical.starts_with(system_path) {
+                return Ok(());
+            }
+        }
+
+        // Allow access to tsumugi config directory.
+        if let Some(config_dir) = tsumugi_config_dir() {
+            if canonical.starts_with(&config_dir) {
+                return Ok(());
+            }
+        }
+
+        Err(SandboxError::AccessDenied {
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Check whether writing to a given path is allowed under the current mode.
+    ///
+    /// - `Full` mode: all writes allowed.
+    /// - `WorkspaceWrite` mode: writes allowed only within the workspace.
+    /// - `ReadOnly` mode: no writes allowed anywhere.
+    pub fn check_write_access(&self, path: impl AsRef<Path>) -> Result<(), SandboxError> {
+        if self.config.mode.is_unrestricted() {
+            return Ok(());
+        }
+
+        let path = path.as_ref();
+
+        if !self.config.mode.allows_workspace_write() {
+            return Err(SandboxError::AccessDenied {
+                path: path.to_path_buf(),
+            });
+        }
+
+        // WorkspaceWrite mode: only allow writes within the workspace.
+        let canonical = normalize_path(path);
+        if canonical.starts_with(&self.config.workspace) {
+            return Ok(());
+        }
+
+        Err(SandboxError::AccessDenied {
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Run a shell command within sandbox constraints.
+    ///
+    /// The command is executed with:
+    /// - The configured timeout (default 30s)
+    /// - OOM score adjustment (Linux only)
+    /// - `kill_on_drop` for cleanup on cancellation
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SandboxError::Timeout`] if the command exceeds the timeout,
+    /// or [`SandboxError::Io`] if the command cannot be spawned.
+    pub async fn run_command(&self, command: &str) -> Result<CommandOutput, SandboxError> {
+        process::run_sandboxed_command(command, self.config.timeout_secs, self.config.oom_score_adj)
+            .await
+    }
+
+    /// Return a reference to the sandbox configuration.
+    pub fn config(&self) -> &SandboxConfig {
+        &self.config
+    }
+
+    /// Return the current sandbox mode.
+    pub fn mode(&self) -> SandboxMode {
+        self.config.mode
+    }
+
+    /// Return the workspace path.
+    pub fn workspace(&self) -> &Path {
+        &self.config.workspace
+    }
+
+    /// Return whether the sandbox has been activated.
+    pub fn is_activated(&self) -> bool {
+        self.activated
+    }
+}
+
+/// Normalize a path by resolving `.` and `..` components without
+/// touching the filesystem (no symlink resolution).
+///
+/// This is a best-effort normalization for sandbox path checks.
+fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::CurDir => {}
+            other => normalized.push(other),
+        }
+    }
+    normalized
+}
+
+/// Get the tsumugi configuration directory path (`~/.config/tsumugi/`).
+fn tsumugi_config_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| {
+        let mut path = PathBuf::from(home);
+        path.push(".config");
+        path.push("tsumugi");
+        path
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> SandboxConfig {
+        SandboxConfig::new("/tmp/workspace")
+    }
+
+    #[test]
+    fn full_mode_allows_everything() {
+        let config = test_config().with_mode(SandboxMode::Full);
+        let ctx = SandboxContext::new(config);
+
+        assert!(ctx.check_path_access("/etc/passwd").is_ok());
+        assert!(ctx.check_path_access("/root/.ssh/id_rsa").is_ok());
+        assert!(ctx.check_write_access("/etc/shadow").is_ok());
+    }
+
+    #[test]
+    fn workspace_write_allows_workspace_read() {
+        let config = test_config().with_mode(SandboxMode::WorkspaceWrite);
+        let ctx = SandboxContext::new(config);
+
+        assert!(ctx.check_path_access("/tmp/workspace/src/main.rs").is_ok());
+    }
+
+    #[test]
+    fn workspace_write_allows_workspace_write() {
+        let config = test_config().with_mode(SandboxMode::WorkspaceWrite);
+        let ctx = SandboxContext::new(config);
+
+        assert!(ctx.check_write_access("/tmp/workspace/output.txt").is_ok());
+    }
+
+    #[test]
+    fn workspace_write_denies_outside_write() {
+        let config = test_config().with_mode(SandboxMode::WorkspaceWrite);
+        let ctx = SandboxContext::new(config);
+
+        assert!(ctx.check_write_access("/etc/passwd").is_err());
+        assert!(ctx.check_write_access("/root/file.txt").is_err());
+    }
+
+    #[test]
+    fn workspace_write_allows_system_path_read() {
+        let config = test_config().with_mode(SandboxMode::WorkspaceWrite);
+        let ctx = SandboxContext::new(config);
+
+        assert!(ctx.check_path_access("/usr/bin/ls").is_ok());
+        assert!(ctx.check_path_access("/bin/sh").is_ok());
+        assert!(
+            ctx.check_path_access("/lib/x86_64-linux-gnu/libc.so")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn workspace_write_denies_outside_read() {
+        let config = test_config().with_mode(SandboxMode::WorkspaceWrite);
+        let ctx = SandboxContext::new(config);
+
+        assert!(ctx.check_path_access("/etc/passwd").is_err());
+        assert!(ctx.check_path_access("/root/.bashrc").is_err());
+        assert!(ctx.check_path_access("/home/other/secret").is_err());
+    }
+
+    #[test]
+    fn read_only_denies_all_writes() {
+        let config = test_config().with_mode(SandboxMode::ReadOnly);
+        let ctx = SandboxContext::new(config);
+
+        // Even workspace writes are denied.
+        assert!(ctx.check_write_access("/tmp/workspace/file.txt").is_err());
+        assert!(ctx.check_write_access("/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn read_only_allows_workspace_read() {
+        let config = test_config().with_mode(SandboxMode::ReadOnly);
+        let ctx = SandboxContext::new(config);
+
+        assert!(ctx.check_path_access("/tmp/workspace/src/main.rs").is_ok());
+    }
+
+    #[test]
+    fn read_only_allows_system_path_read() {
+        let config = test_config().with_mode(SandboxMode::ReadOnly);
+        let ctx = SandboxContext::new(config);
+
+        assert!(ctx.check_path_access("/usr/local/bin/cargo").is_ok());
+    }
+
+    #[test]
+    fn read_only_denies_outside_read() {
+        let config = test_config().with_mode(SandboxMode::ReadOnly);
+        let ctx = SandboxContext::new(config);
+
+        assert!(ctx.check_path_access("/etc/shadow").is_err());
+    }
+
+    #[test]
+    fn path_traversal_normalization() {
+        let config = test_config().with_mode(SandboxMode::WorkspaceWrite);
+        let ctx = SandboxContext::new(config);
+
+        // Attempting to escape via `..` should be caught.
+        assert!(
+            ctx.check_path_access("/tmp/workspace/../../../etc/passwd")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn normalize_path_handles_parent_dir() {
+        let result = normalize_path(Path::new("/tmp/workspace/../secret"));
+        assert_eq!(result, PathBuf::from("/tmp/secret"));
+    }
+
+    #[test]
+    fn normalize_path_handles_current_dir() {
+        let result = normalize_path(Path::new("/tmp/./workspace/./file"));
+        assert_eq!(result, PathBuf::from("/tmp/workspace/file"));
+    }
+
+    #[tokio::test]
+    async fn run_command_success() {
+        let config = test_config();
+        let ctx = SandboxContext::new(config);
+
+        let output = ctx.run_command("echo sandbox-test").await;
+        assert!(output.is_ok());
+        let output = output.unwrap_or_else(|_| CommandOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: -1,
+        });
+        assert!(output.success());
+        assert!(output.stdout.contains("sandbox-test"));
+    }
+
+    #[tokio::test]
+    async fn run_command_timeout() {
+        let config = test_config().with_timeout(1);
+        let ctx = SandboxContext::new(config);
+
+        let result = ctx.run_command("sleep 60").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn activate_is_idempotent() {
+        let config = test_config().with_mode(SandboxMode::Full);
+        let mut ctx = SandboxContext::new(config);
+
+        assert!(!ctx.is_activated());
+        ctx.activate().await.unwrap_or(());
+        assert!(ctx.is_activated());
+        // Second activation should succeed without error.
+        ctx.activate().await.unwrap_or(());
+        assert!(ctx.is_activated());
+    }
+}

--- a/crates/tmg-sandbox/src/error.rs
+++ b/crates/tmg-sandbox/src/error.rs
@@ -20,13 +20,6 @@ pub enum SandboxError {
         source: std::io::Error,
     },
 
-    /// Failed to apply iptables rules for domain allowlisting.
-    #[error("failed to apply iptables rule: {reason}")]
-    Iptables {
-        /// A human-readable description of the failure.
-        reason: String,
-    },
-
     /// A filesystem access was denied by the sandbox.
     #[error("access denied: {path} is outside the sandbox")]
     AccessDenied {
@@ -54,16 +47,6 @@ pub enum SandboxError {
     Io {
         /// Description of what the sandbox was doing when the error occurred.
         context: String,
-        /// The underlying I/O error.
-        #[source]
-        source: std::io::Error,
-    },
-
-    /// DNS resolution failed for an allowed domain.
-    #[error("DNS resolution failed for domain '{domain}': {source}")]
-    DnsResolution {
-        /// The domain that could not be resolved.
-        domain: String,
         /// The underlying I/O error.
         #[source]
         source: std::io::Error,

--- a/crates/tmg-sandbox/src/error.rs
+++ b/crates/tmg-sandbox/src/error.rs
@@ -1,0 +1,85 @@
+//! Error types for the sandbox crate.
+
+use std::path::PathBuf;
+
+/// Errors that can occur during sandbox setup or enforcement.
+#[derive(Debug, thiserror::Error)]
+pub enum SandboxError {
+    /// Failed to apply Landlock filesystem restrictions.
+    #[error("failed to apply landlock rules: {reason}")]
+    Landlock {
+        /// A human-readable description of what went wrong.
+        reason: String,
+    },
+
+    /// Failed to create a network namespace for isolation.
+    #[error("failed to create network namespace: {source}")]
+    NetworkNamespace {
+        /// The underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Failed to apply iptables rules for domain allowlisting.
+    #[error("failed to apply iptables rule: {reason}")]
+    Iptables {
+        /// A human-readable description of the failure.
+        reason: String,
+    },
+
+    /// A filesystem access was denied by the sandbox.
+    #[error("access denied: {path} is outside the sandbox")]
+    AccessDenied {
+        /// The path that was rejected.
+        path: PathBuf,
+    },
+
+    /// Failed to adjust OOM score for a child process.
+    #[error("failed to adjust OOM score: {source}")]
+    OomAdjust {
+        /// The underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A spawned process exceeded the configured timeout.
+    #[error("process timed out after {seconds}s and was killed")]
+    Timeout {
+        /// The timeout duration in seconds.
+        seconds: u64,
+    },
+
+    /// An I/O error occurred during sandbox operations.
+    #[error("{context}: {source}")]
+    Io {
+        /// Description of what the sandbox was doing when the error occurred.
+        context: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// DNS resolution failed for an allowed domain.
+    #[error("DNS resolution failed for domain '{domain}': {source}")]
+    DnsResolution {
+        /// The domain that could not be resolved.
+        domain: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The sandbox feature is not supported on this platform.
+    #[error("sandbox is not supported on this platform; running without restrictions")]
+    Unsupported,
+}
+
+impl SandboxError {
+    /// Create an I/O error with context.
+    pub fn io(context: impl Into<String>, source: std::io::Error) -> Self {
+        Self::Io {
+            context: context.into(),
+            source,
+        }
+    }
+}

--- a/crates/tmg-sandbox/src/lib.rs
+++ b/crates/tmg-sandbox/src/lib.rs
@@ -1,1 +1,61 @@
-// tmg-sandbox: Filesystem sandboxing via landlock (Linux).
+//! tmg-sandbox: Security sandbox for the tsumugi coding agent.
+//!
+//! This crate provides OS-level process isolation to restrict filesystem
+//! access, network connectivity, and resource usage of agent-spawned
+//! processes.
+//!
+//! # Platform support
+//!
+//! - **Linux**: Full support via Landlock (filesystem), network namespaces
+//!   + iptables (network), and `/proc` (OOM score adjustment).
+//! - **macOS / other**: All sandbox operations are no-ops that emit
+//!   warnings. Path validation checks still function as a software-level
+//!   safety net.
+//!
+//! # Architecture
+//!
+//! ```text
+//! SandboxConfig ──▶ SandboxContext ──▶ platform::{linux, fallback}
+//!                        │
+//!                        ├── check_path_access()   (software check)
+//!                        ├── check_write_access()  (software check)
+//!                        ├── activate()            (OS-level restrictions)
+//!                        └── run_command()          (timeout + OOM)
+//! ```
+//!
+//! # Usage
+//!
+//! ```no_run
+//! # use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
+//! # async fn example() -> Result<(), tmg_sandbox::SandboxError> {
+//! let config = SandboxConfig::new("/home/user/project")
+//!     .with_mode(SandboxMode::WorkspaceWrite)
+//!     .with_allowed_domains(vec!["api.example.com".to_owned()])
+//!     .with_timeout(60);
+//!
+//! let mut ctx = SandboxContext::new(config);
+//! ctx.activate().await?;
+//!
+//! // Validate path access before operations.
+//! ctx.check_path_access("/home/user/project/src/main.rs")?;
+//! ctx.check_write_access("/home/user/project/output.txt")?;
+//!
+//! // Run a command within sandbox constraints.
+//! let output = ctx.run_command("cargo build").await?;
+//! assert!(output.success());
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod config;
+pub mod context;
+pub mod error;
+pub mod mode;
+mod platform;
+pub mod process;
+
+pub use config::SandboxConfig;
+pub use context::SandboxContext;
+pub use error::SandboxError;
+pub use mode::SandboxMode;
+pub use process::CommandOutput;

--- a/crates/tmg-sandbox/src/lib.rs
+++ b/crates/tmg-sandbox/src/lib.rs
@@ -7,7 +7,7 @@
 //! # Platform support
 //!
 //! - **Linux**: Full support via Landlock (filesystem), network namespaces
-//!   + iptables (network), and `/proc` (OOM score adjustment).
+//!   (network isolation), and `/proc` (OOM score adjustment).
 //! - **macOS / other**: All sandbox operations are no-ops that emit
 //!   warnings. Path validation checks still function as a software-level
 //!   safety net.

--- a/crates/tmg-sandbox/src/mode.rs
+++ b/crates/tmg-sandbox/src/mode.rs
@@ -1,0 +1,112 @@
+//! Sandbox operating modes controlling filesystem access levels.
+
+use serde::{Deserialize, Serialize};
+
+/// Controls the level of filesystem access granted to sandboxed processes.
+///
+/// The mode determines which Landlock rules are applied:
+///
+/// - [`ReadOnly`](SandboxMode::ReadOnly) -- workspace directory is read-only,
+///   system paths are read-only, everything else is denied.
+/// - [`WorkspaceWrite`](SandboxMode::WorkspaceWrite) -- workspace directory is
+///   read+write (default), system paths are read-only, everything else is denied.
+/// - [`Full`](SandboxMode::Full) -- no filesystem restrictions applied (escape
+///   hatch for trusted operations).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxMode {
+    /// Workspace is read-only. No writes are permitted anywhere.
+    ReadOnly,
+
+    /// Workspace is read+write (default). System paths are read-only.
+    #[default]
+    WorkspaceWrite,
+
+    /// No filesystem restrictions. Used for trusted operations or
+    /// platforms where sandboxing is unavailable.
+    Full,
+}
+
+impl SandboxMode {
+    /// Returns `true` if writes to the workspace directory are allowed.
+    pub fn allows_workspace_write(&self) -> bool {
+        matches!(self, Self::WorkspaceWrite | Self::Full)
+    }
+
+    /// Returns `true` if arbitrary filesystem access is allowed.
+    pub fn is_unrestricted(&self) -> bool {
+        matches!(self, Self::Full)
+    }
+
+    /// Returns `true` if any filesystem restrictions are active.
+    pub fn is_restricted(&self) -> bool {
+        !self.is_unrestricted()
+    }
+}
+
+impl std::fmt::Display for SandboxMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadOnly => write!(f, "read_only"),
+            Self::WorkspaceWrite => write!(f, "workspace_write"),
+            Self::Full => write!(f, "full"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_workspace_write() {
+        assert_eq!(SandboxMode::default(), SandboxMode::WorkspaceWrite);
+    }
+
+    #[test]
+    fn read_only_denies_writes() {
+        let mode = SandboxMode::ReadOnly;
+        assert!(!mode.allows_workspace_write());
+        assert!(mode.is_restricted());
+        assert!(!mode.is_unrestricted());
+    }
+
+    #[test]
+    fn workspace_write_allows_writes() {
+        let mode = SandboxMode::WorkspaceWrite;
+        assert!(mode.allows_workspace_write());
+        assert!(mode.is_restricted());
+        assert!(!mode.is_unrestricted());
+    }
+
+    #[test]
+    fn full_mode_unrestricted() {
+        let mode = SandboxMode::Full;
+        assert!(mode.allows_workspace_write());
+        assert!(!mode.is_restricted());
+        assert!(mode.is_unrestricted());
+    }
+
+    #[test]
+    fn display_matches_serde() {
+        assert_eq!(SandboxMode::ReadOnly.to_string(), "read_only");
+        assert_eq!(SandboxMode::WorkspaceWrite.to_string(), "workspace_write");
+        assert_eq!(SandboxMode::Full.to_string(), "full");
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let modes = [
+            SandboxMode::ReadOnly,
+            SandboxMode::WorkspaceWrite,
+            SandboxMode::Full,
+        ];
+        for mode in &modes {
+            let json =
+                serde_json::to_string(mode).unwrap_or_else(|_| String::from("serialize failed"));
+            let deserialized: SandboxMode =
+                serde_json::from_str(&json).unwrap_or(SandboxMode::Full);
+            assert_eq!(*mode, deserialized);
+        }
+    }
+}

--- a/crates/tmg-sandbox/src/platform/fallback.rs
+++ b/crates/tmg-sandbox/src/platform/fallback.rs
@@ -1,0 +1,79 @@
+//! Fallback sandbox implementation for non-Linux platforms.
+//!
+//! All sandbox operations are no-ops that emit warnings. The agent
+//! functions normally but without OS-level security restrictions.
+//!
+//! Function signatures intentionally match the Linux module so the
+//! platform dispatch in `mod.rs` works uniformly.
+
+use crate::config::SandboxConfig;
+use crate::error::SandboxError;
+
+/// Emit a warning that Landlock is not available on this platform.
+///
+/// Returns `Ok(())` -- the caller should proceed without restrictions.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "signature must match linux::apply_landlock for platform dispatch"
+)]
+pub fn apply_landlock(config: &SandboxConfig) -> Result<(), SandboxError> {
+    if config.mode.is_restricted() {
+        emit_warning(
+            "Landlock filesystem sandbox is not available on this platform; running without filesystem restrictions",
+        );
+    }
+    Ok(())
+}
+
+/// Emit a warning that network namespaces are not available on this platform.
+///
+/// Returns `Ok(())` -- the caller should proceed without network restrictions.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "signature must match linux::create_network_namespace for platform dispatch"
+)]
+pub fn create_network_namespace() -> Result<(), SandboxError> {
+    emit_warning(
+        "Network namespace isolation is not available on this platform; \
+         running without network restrictions",
+    );
+    Ok(())
+}
+
+/// No-op: iptables-based network allowlisting is Linux-only.
+///
+/// Returns `Ok(())` -- the caller should proceed without network restrictions.
+pub async fn apply_network_allowlist(allowed_domains: &[String]) -> Result<(), SandboxError> {
+    if !allowed_domains.is_empty() {
+        emit_warning(
+            "Network domain allowlisting is not available on this platform; \
+             all network access is permitted",
+        );
+    }
+    Ok(())
+}
+
+/// No-op: OOM score adjustment is Linux-only.
+///
+/// Returns `Ok(())`.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "signature must match linux::adjust_oom_score for platform dispatch"
+)]
+pub fn adjust_oom_score(_pid: u32, _score: i32) -> Result<(), SandboxError> {
+    // OOM score adjustment is a Linux-specific feature. Silently skip
+    // on other platforms as it is a best-effort optimization.
+    Ok(())
+}
+
+/// Emit a warning message via `eprintln`.
+///
+/// On non-Linux platforms this is the primary way to inform the user
+/// that sandbox features are unavailable.
+#[expect(
+    clippy::print_stderr,
+    reason = "intentional warning output for unsupported platform"
+)]
+fn emit_warning(msg: &str) {
+    eprintln!("[tmg-sandbox] WARNING: {msg}");
+}

--- a/crates/tmg-sandbox/src/platform/fallback.rs
+++ b/crates/tmg-sandbox/src/platform/fallback.rs
@@ -40,19 +40,6 @@ pub fn create_network_namespace() -> Result<(), SandboxError> {
     Ok(())
 }
 
-/// No-op: iptables-based network allowlisting is Linux-only.
-///
-/// Returns `Ok(())` -- the caller should proceed without network restrictions.
-pub async fn apply_network_allowlist(allowed_domains: &[String]) -> Result<(), SandboxError> {
-    if !allowed_domains.is_empty() {
-        emit_warning(
-            "Network domain allowlisting is not available on this platform; \
-             all network access is permitted",
-        );
-    }
-    Ok(())
-}
-
 /// No-op: OOM score adjustment is Linux-only.
 ///
 /// Returns `Ok(())`.

--- a/crates/tmg-sandbox/src/platform/linux.rs
+++ b/crates/tmg-sandbox/src/platform/linux.rs
@@ -1,0 +1,246 @@
+//! Linux-specific sandbox implementation using Landlock and network namespaces.
+//!
+//! This module is only compiled on `target_os = "linux"`.
+
+use std::net::ToSocketAddrs;
+use std::path::Path;
+
+use landlock::{
+    ABI, Access, AccessFs, PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr,
+};
+
+use crate::config::SandboxConfig;
+use crate::error::SandboxError;
+use crate::mode::SandboxMode;
+
+/// The best Landlock ABI version we target.
+const LANDLOCK_ABI: ABI = ABI::V3;
+
+/// System paths that receive read-only access in the sandbox.
+const SYSTEM_READ_ONLY_PATHS: &[&str] = &["/usr", "/bin", "/lib", "/lib64"];
+
+/// Apply Landlock filesystem restrictions based on the sandbox configuration.
+///
+/// This restricts the current process (and all future children) to:
+/// - workspace directory: read-only or read+write depending on mode
+/// - system paths (`/usr`, `/bin`, `/lib`, `/lib64`): read-only
+/// - `~/.config/tsumugi/`: read-only
+/// - everything else: no access
+///
+/// # Errors
+///
+/// Returns [`SandboxError::Landlock`] if Landlock is not supported by the
+/// kernel or if rule creation/enforcement fails.
+///
+/// # Safety
+///
+/// This function uses Landlock which is a safe Linux security module API.
+/// No `unsafe` code is required.
+pub fn apply_landlock(config: &SandboxConfig) -> Result<(), SandboxError> {
+    if config.mode == SandboxMode::Full {
+        return Ok(());
+    }
+
+    let read_access = AccessFs::from_read(LANDLOCK_ABI);
+    let write_access = AccessFs::from_write(LANDLOCK_ABI);
+    let read_write_access = read_access | write_access;
+
+    let mut ruleset = Ruleset::default()
+        .handle_access(read_write_access)
+        .map_err(|e| SandboxError::Landlock {
+            reason: format!("failed to create ruleset: {e}"),
+        })?
+        .create()
+        .map_err(|e| SandboxError::Landlock {
+            reason: format!("failed to create ruleset: {e}"),
+        })?;
+
+    // Workspace directory access based on mode.
+    let workspace_access = if config.mode.allows_workspace_write() {
+        read_write_access
+    } else {
+        read_access
+    };
+
+    ruleset = add_path_rule(ruleset, &config.workspace, workspace_access)?;
+
+    // System paths: read-only.
+    for path_str in SYSTEM_READ_ONLY_PATHS {
+        let path = Path::new(path_str);
+        if path.exists() {
+            ruleset = add_path_rule(ruleset, path, read_access)?;
+        }
+    }
+
+    // ~/.config/tsumugi/: read-only.
+    if let Some(config_dir) = dirs_config_path() {
+        if config_dir.exists() {
+            ruleset = add_path_rule(ruleset, &config_dir, read_access)?;
+        }
+    }
+
+    ruleset
+        .restrict_self()
+        .map_err(|e| SandboxError::Landlock {
+            reason: format!("failed to enforce ruleset: {e}"),
+        })?;
+
+    Ok(())
+}
+
+/// Add a Landlock path rule to the ruleset.
+fn add_path_rule(
+    mut ruleset: landlock::RulesetCreated,
+    path: &Path,
+    access: AccessFs,
+) -> Result<landlock::RulesetCreated, SandboxError> {
+    let fd = PathFd::new(path).map_err(|e| SandboxError::Landlock {
+        reason: format!("failed to open path '{}': {e}", path.display()),
+    })?;
+
+    ruleset = ruleset
+        .add_rule(PathBeneath::new(fd, access))
+        .map_err(|e| SandboxError::Landlock {
+            reason: format!("failed to add rule for '{}': {e}", path.display()),
+        })?;
+
+    Ok(ruleset)
+}
+
+/// Create a new network namespace using `unshare(CLONE_NEWNET)`.
+///
+/// After this call, the current process has its own empty network
+/// namespace with only a loopback interface. All network access is
+/// blocked unless iptables rules are subsequently added.
+///
+/// # Errors
+///
+/// Returns [`SandboxError::NetworkNamespace`] if the `unshare` syscall fails
+/// (e.g., due to insufficient privileges).
+///
+/// # Safety
+///
+/// Calls `libc::unshare(CLONE_NEWNET)` which is safe to call but modifies
+/// the process's network namespace. This is an irreversible operation for
+/// the current process.
+#[expect(
+    unsafe_code,
+    reason = "FFI call to libc::unshare for network namespace isolation"
+)]
+pub fn create_network_namespace() -> Result<(), SandboxError> {
+    // SAFETY: `unshare(CLONE_NEWNET)` is a Linux syscall that creates a new
+    // network namespace for the calling process. It does not access any memory
+    // unsafely; it only modifies kernel-level namespace state. The return value
+    // is checked for errors.
+    let ret = unsafe { libc::unshare(libc::CLONE_NEWNET) };
+    if ret != 0 {
+        return Err(SandboxError::NetworkNamespace {
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    Ok(())
+}
+
+/// Apply iptables rules to allow only the specified domains.
+///
+/// Resolves each domain to IP addresses, adds ACCEPT rules for those
+/// addresses, then sets the default OUTPUT policy to DROP.
+///
+/// # Errors
+///
+/// Returns [`SandboxError::DnsResolution`] if a domain cannot be resolved,
+/// or [`SandboxError::Iptables`] if an iptables command fails.
+pub async fn apply_network_allowlist(allowed_domains: &[String]) -> Result<(), SandboxError> {
+    if allowed_domains.is_empty() {
+        // No domains allowed: set default DROP policy.
+        run_iptables(&["-P", "OUTPUT", "DROP"]).await?;
+        // Allow loopback.
+        run_iptables(&["-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"]).await?;
+        return Ok(());
+    }
+
+    // Allow loopback first.
+    run_iptables(&["-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"]).await?;
+
+    // Allow DNS resolution (port 53).
+    run_iptables(&["-A", "OUTPUT", "-p", "udp", "--dport", "53", "-j", "ACCEPT"]).await?;
+    run_iptables(&["-A", "OUTPUT", "-p", "tcp", "--dport", "53", "-j", "ACCEPT"]).await?;
+
+    // Resolve each domain and add ACCEPT rules.
+    for domain in allowed_domains {
+        let addrs = tokio::task::spawn_blocking({
+            let domain = domain.clone();
+            move || {
+                (domain.as_str(), 0u16)
+                    .to_socket_addrs()
+                    .map(|iter| iter.map(|addr| addr.ip().to_string()).collect::<Vec<_>>())
+            }
+        })
+        .await
+        .map_err(|e| SandboxError::Io {
+            context: format!("DNS resolution task for '{domain}'"),
+            source: std::io::Error::other(e.to_string()),
+        })?
+        .map_err(|e| SandboxError::DnsResolution {
+            domain: domain.clone(),
+            source: e,
+        })?;
+
+        for ip in addrs {
+            run_iptables(&["-A", "OUTPUT", "-d", &ip, "-j", "ACCEPT"]).await?;
+        }
+    }
+
+    // Default policy: DROP everything else.
+    run_iptables(&["-P", "OUTPUT", "DROP"]).await?;
+
+    Ok(())
+}
+
+/// Run an iptables command with the given arguments.
+async fn run_iptables(args: &[&str]) -> Result<(), SandboxError> {
+    let output = tokio::process::Command::new("iptables")
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| SandboxError::Iptables {
+            reason: format!("failed to execute iptables: {e}"),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(SandboxError::Iptables {
+            reason: format!("iptables {} failed: {}", args.join(" "), stderr.trim()),
+        });
+    }
+
+    Ok(())
+}
+
+/// Adjust the OOM score for a given process.
+///
+/// Writes to `/proc/{pid}/oom_score_adj` to influence the kernel's
+/// OOM killer behavior.
+///
+/// # Errors
+///
+/// Returns [`SandboxError::OomAdjust`] if the write fails.
+pub fn adjust_oom_score(pid: u32, score: i32) -> Result<(), SandboxError> {
+    let path = format!("/proc/{pid}/oom_score_adj");
+    std::fs::write(&path, score.to_string()).map_err(|e| SandboxError::OomAdjust { source: e })
+}
+
+/// Get the tsumugi configuration directory path.
+///
+/// Returns `~/.config/tsumugi/` if the home directory can be determined.
+fn dirs_config_path() -> Option<std::path::PathBuf> {
+    // Use $HOME directly as we cannot depend on the `dirs` crate here
+    // without adding it as a dependency. In production, the config path
+    // should be passed in from the caller.
+    std::env::var_os("HOME").map(|home| {
+        let mut path = std::path::PathBuf::from(home);
+        path.push(".config");
+        path.push("tsumugi");
+        path
+    })
+}

--- a/crates/tmg-sandbox/src/platform/linux.rs
+++ b/crates/tmg-sandbox/src/platform/linux.rs
@@ -2,7 +2,6 @@
 //!
 //! This module is only compiled on `target_os = "linux"`.
 
-use std::net::ToSocketAddrs;
 use std::path::Path;
 
 use landlock::{
@@ -16,7 +15,7 @@ use crate::mode::SandboxMode;
 /// The best Landlock ABI version we target.
 const LANDLOCK_ABI: ABI = ABI::V3;
 
-/// System paths that receive read-only access in the sandbox.
+/// System paths that receive read-only access in the Landlock ruleset.
 const SYSTEM_READ_ONLY_PATHS: &[&str] = &["/usr", "/bin", "/lib", "/lib64"];
 
 /// Apply Landlock filesystem restrictions based on the sandbox configuration.
@@ -138,82 +137,6 @@ pub fn create_network_namespace() -> Result<(), SandboxError> {
             source: std::io::Error::last_os_error(),
         });
     }
-    Ok(())
-}
-
-/// Apply iptables rules to allow only the specified domains.
-///
-/// Resolves each domain to IP addresses, adds ACCEPT rules for those
-/// addresses, then sets the default OUTPUT policy to DROP.
-///
-/// # Errors
-///
-/// Returns [`SandboxError::DnsResolution`] if a domain cannot be resolved,
-/// or [`SandboxError::Iptables`] if an iptables command fails.
-pub async fn apply_network_allowlist(allowed_domains: &[String]) -> Result<(), SandboxError> {
-    if allowed_domains.is_empty() {
-        // No domains allowed: set default DROP policy.
-        run_iptables(&["-P", "OUTPUT", "DROP"]).await?;
-        // Allow loopback.
-        run_iptables(&["-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"]).await?;
-        return Ok(());
-    }
-
-    // Allow loopback first.
-    run_iptables(&["-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"]).await?;
-
-    // Allow DNS resolution (port 53).
-    run_iptables(&["-A", "OUTPUT", "-p", "udp", "--dport", "53", "-j", "ACCEPT"]).await?;
-    run_iptables(&["-A", "OUTPUT", "-p", "tcp", "--dport", "53", "-j", "ACCEPT"]).await?;
-
-    // Resolve each domain and add ACCEPT rules.
-    for domain in allowed_domains {
-        let addrs = tokio::task::spawn_blocking({
-            let domain = domain.clone();
-            move || {
-                (domain.as_str(), 0u16)
-                    .to_socket_addrs()
-                    .map(|iter| iter.map(|addr| addr.ip().to_string()).collect::<Vec<_>>())
-            }
-        })
-        .await
-        .map_err(|e| SandboxError::Io {
-            context: format!("DNS resolution task for '{domain}'"),
-            source: std::io::Error::other(e.to_string()),
-        })?
-        .map_err(|e| SandboxError::DnsResolution {
-            domain: domain.clone(),
-            source: e,
-        })?;
-
-        for ip in addrs {
-            run_iptables(&["-A", "OUTPUT", "-d", &ip, "-j", "ACCEPT"]).await?;
-        }
-    }
-
-    // Default policy: DROP everything else.
-    run_iptables(&["-P", "OUTPUT", "DROP"]).await?;
-
-    Ok(())
-}
-
-/// Run an iptables command with the given arguments.
-async fn run_iptables(args: &[&str]) -> Result<(), SandboxError> {
-    let output = tokio::process::Command::new("iptables")
-        .args(args)
-        .output()
-        .await
-        .map_err(|e| SandboxError::Iptables {
-            reason: format!("failed to execute iptables: {e}"),
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(SandboxError::Iptables {
-            reason: format!("iptables {} failed: {}", args.join(" "), stderr.trim()),
-        });
-    }
-
     Ok(())
 }
 

--- a/crates/tmg-sandbox/src/platform/mod.rs
+++ b/crates/tmg-sandbox/src/platform/mod.rs
@@ -11,11 +11,7 @@ mod linux;
 mod fallback;
 
 #[cfg(target_os = "linux")]
-pub use linux::{
-    adjust_oom_score, apply_landlock, apply_network_allowlist, create_network_namespace,
-};
+pub use linux::{adjust_oom_score, apply_landlock, create_network_namespace};
 
 #[cfg(not(target_os = "linux"))]
-pub use fallback::{
-    adjust_oom_score, apply_landlock, apply_network_allowlist, create_network_namespace,
-};
+pub use fallback::{adjust_oom_score, apply_landlock, create_network_namespace};

--- a/crates/tmg-sandbox/src/platform/mod.rs
+++ b/crates/tmg-sandbox/src/platform/mod.rs
@@ -1,0 +1,21 @@
+//! Platform-specific sandbox implementations.
+//!
+//! On Linux, this module delegates to Landlock and network namespace
+//! APIs. On all other platforms, it provides no-op implementations
+//! that emit warnings.
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(not(target_os = "linux"))]
+mod fallback;
+
+#[cfg(target_os = "linux")]
+pub use linux::{
+    adjust_oom_score, apply_landlock, apply_network_allowlist, create_network_namespace,
+};
+
+#[cfg(not(target_os = "linux"))]
+pub use fallback::{
+    adjust_oom_score, apply_landlock, apply_network_allowlist, create_network_namespace,
+};

--- a/crates/tmg-sandbox/src/process.rs
+++ b/crates/tmg-sandbox/src/process.rs
@@ -25,7 +25,7 @@ pub async fn run_sandboxed_command(
     timeout_secs: u64,
     oom_score_adj: i32,
 ) -> Result<CommandOutput, SandboxError> {
-    let mut child = tokio::process::Command::new("sh")
+    let child = tokio::process::Command::new("sh")
         .arg("-c")
         .arg(command)
         .stdout(std::process::Stdio::piped())
@@ -42,60 +42,30 @@ pub async fn run_sandboxed_command(
 
     let timeout = Duration::from_secs(timeout_secs);
 
-    // Use `wait()` instead of `wait_with_output()` so we retain ownership
-    // of the child handle for explicit kill on timeout. Capture stdout/stderr
-    // pipes before awaiting.
-    let stdout_pipe = child.stdout.take();
-    let stderr_pipe = child.stderr.take();
-
-    let wait_result = tokio::time::timeout(timeout, child.wait()).await;
+    // Use `wait_with_output()` to read stdout/stderr concurrently with
+    // waiting for the process to exit. This avoids a deadlock that can
+    // occur when reading pipes sequentially after `wait()` -- the child
+    // may block on a full pipe buffer and never exit.
+    let wait_result = tokio::time::timeout(timeout, child.wait_with_output()).await;
 
     match wait_result {
-        Ok(Ok(status)) => {
-            let stdout = read_pipe(stdout_pipe).await;
-            let stderr = read_stderr_pipe(stderr_pipe).await;
-            let exit_code = status.code().unwrap_or(-1);
+        Ok(Ok(output)) => {
+            let exit_code = output.status.code().unwrap_or(-1);
 
             Ok(CommandOutput {
-                stdout,
-                stderr,
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
                 exit_code,
             })
         }
         Ok(Err(e)) => Err(SandboxError::io("waiting for sandboxed command", e)),
         Err(_) => {
-            // Timeout exceeded. Send SIGKILL for immediate cleanup.
-            // `kill_on_drop(true)` is a fallback if this fails.
-            let _ = child.kill().await;
+            // Timeout exceeded. `kill_on_drop(true)` ensures cleanup.
             Err(SandboxError::Timeout {
                 seconds: timeout_secs,
             })
         }
     }
-}
-
-/// Read all bytes from an optional pipe and return as a lossy UTF-8 string.
-async fn read_pipe(pipe: Option<tokio::process::ChildStdout>) -> String {
-    use tokio::io::AsyncReadExt;
-
-    let Some(mut pipe) = pipe else {
-        return String::new();
-    };
-    let mut buf = Vec::new();
-    let _ = pipe.read_to_end(&mut buf).await;
-    String::from_utf8_lossy(&buf).into_owned()
-}
-
-/// Read all bytes from an optional stderr pipe and return as a lossy UTF-8 string.
-async fn read_stderr_pipe(pipe: Option<tokio::process::ChildStderr>) -> String {
-    use tokio::io::AsyncReadExt;
-
-    let Some(mut pipe) = pipe else {
-        return String::new();
-    };
-    let mut buf = Vec::new();
-    let _ = pipe.read_to_end(&mut buf).await;
-    String::from_utf8_lossy(&buf).into_owned()
 }
 
 /// Output from a sandboxed command execution.

--- a/crates/tmg-sandbox/src/process.rs
+++ b/crates/tmg-sandbox/src/process.rs
@@ -1,0 +1,181 @@
+//! Process restriction utilities: timeout enforcement and OOM score adjustment.
+
+use std::time::Duration;
+
+use crate::error::SandboxError;
+use crate::platform;
+
+/// Execute a shell command within sandbox constraints.
+///
+/// This function:
+/// 1. Spawns the command via `sh -c`
+/// 2. Adjusts the child process's OOM score (Linux only)
+/// 3. Enforces a timeout, sending `SIGKILL` if exceeded
+///
+/// Returns the command's stdout, stderr, and exit code on success.
+///
+/// # Errors
+///
+/// - [`SandboxError::Timeout`] if the process exceeds `timeout_secs`
+/// - [`SandboxError::Io`] if the process cannot be spawned or waited on
+/// - [`SandboxError::OomAdjust`] if OOM score adjustment fails (non-fatal
+///   on non-Linux platforms)
+pub async fn run_sandboxed_command(
+    command: &str,
+    timeout_secs: u64,
+    oom_score_adj: i32,
+) -> Result<CommandOutput, SandboxError> {
+    let mut child = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| SandboxError::io("spawning sandboxed command", e))?;
+
+    // Adjust OOM score for the child process (best-effort).
+    if let Some(pid) = child.id() {
+        // OOM adjustment failure is logged but not fatal.
+        let _ = platform::adjust_oom_score(pid, oom_score_adj);
+    }
+
+    let timeout = Duration::from_secs(timeout_secs);
+
+    // Use `wait()` instead of `wait_with_output()` so we retain ownership
+    // of the child handle for explicit kill on timeout. Capture stdout/stderr
+    // pipes before awaiting.
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+
+    let wait_result = tokio::time::timeout(timeout, child.wait()).await;
+
+    match wait_result {
+        Ok(Ok(status)) => {
+            let stdout = read_pipe(stdout_pipe).await;
+            let stderr = read_stderr_pipe(stderr_pipe).await;
+            let exit_code = status.code().unwrap_or(-1);
+
+            Ok(CommandOutput {
+                stdout,
+                stderr,
+                exit_code,
+            })
+        }
+        Ok(Err(e)) => Err(SandboxError::io("waiting for sandboxed command", e)),
+        Err(_) => {
+            // Timeout exceeded. Send SIGKILL for immediate cleanup.
+            // `kill_on_drop(true)` is a fallback if this fails.
+            let _ = child.kill().await;
+            Err(SandboxError::Timeout {
+                seconds: timeout_secs,
+            })
+        }
+    }
+}
+
+/// Read all bytes from an optional pipe and return as a lossy UTF-8 string.
+async fn read_pipe(pipe: Option<tokio::process::ChildStdout>) -> String {
+    use tokio::io::AsyncReadExt;
+
+    let Some(mut pipe) = pipe else {
+        return String::new();
+    };
+    let mut buf = Vec::new();
+    let _ = pipe.read_to_end(&mut buf).await;
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Read all bytes from an optional stderr pipe and return as a lossy UTF-8 string.
+async fn read_stderr_pipe(pipe: Option<tokio::process::ChildStderr>) -> String {
+    use tokio::io::AsyncReadExt;
+
+    let Some(mut pipe) = pipe else {
+        return String::new();
+    };
+    let mut buf = Vec::new();
+    let _ = pipe.read_to_end(&mut buf).await;
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Output from a sandboxed command execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutput {
+    /// Standard output of the command.
+    pub stdout: String,
+    /// Standard error of the command.
+    pub stderr: String,
+    /// Exit code of the command (-1 if the process was killed by a signal).
+    pub exit_code: i32,
+}
+
+impl CommandOutput {
+    /// Returns `true` if the command exited successfully (exit code 0).
+    pub fn success(&self) -> bool {
+        self.exit_code == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn run_simple_command() {
+        let output = run_sandboxed_command("echo hello", 10, 0)
+            .await
+            .unwrap_or_else(|e| CommandOutput {
+                stdout: String::new(),
+                stderr: e.to_string(),
+                exit_code: -1,
+            });
+
+        assert!(output.success());
+        assert!(output.stdout.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn run_command_timeout_returns_error() {
+        let result = run_sandboxed_command("sleep 60", 1, 0).await;
+        let Err(SandboxError::Timeout { seconds }) = result else {
+            // If it's not a Timeout error, the test should fail.
+            assert!(result.is_err(), "expected Timeout error");
+            return;
+        };
+        assert_eq!(seconds, 1);
+    }
+
+    #[tokio::test]
+    async fn run_failing_command() {
+        let output = run_sandboxed_command("exit 42", 10, 0)
+            .await
+            .unwrap_or_else(|e| CommandOutput {
+                stdout: String::new(),
+                stderr: e.to_string(),
+                exit_code: -1,
+            });
+
+        assert!(!output.success());
+        assert_eq!(output.exit_code, 42);
+    }
+
+    #[test]
+    fn command_output_success() {
+        let output = CommandOutput {
+            stdout: "ok".to_owned(),
+            stderr: String::new(),
+            exit_code: 0,
+        };
+        assert!(output.success());
+    }
+
+    #[test]
+    fn command_output_failure() {
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: "error".to_owned(),
+            exit_code: 1,
+        };
+        assert!(!output.success());
+    }
+}


### PR DESCRIPTION
## Summary

- Implement `tmg-sandbox` crate with OS-level process isolation for filesystem, network, and process restrictions
- **Filesystem (Landlock)**: `SandboxContext` applies Landlock rules on Linux -- workspace dir gets read/write or read-only access based on `SandboxMode`, system paths (`/usr`, `/bin`, `/lib`, `/lib64`) and `~/.config/tsumugi/` are read-only, everything else is denied
- **Network**: `unshare(CLONE_NEWNET)` creates isolated network namespace; iptables rules implement domain-based allowlisting from `allowed_domains` config
- **Process**: configurable timeout (default 30s) with SIGKILL on expiry, OOM score adjustment for child processes
- **Non-Linux**: all sandbox operations are no-ops with warnings; software-level path validation still active on all platforms

## Crates modified

- `tmg-sandbox` -- full implementation (new modules: `config`, `context`, `error`, `mode`, `platform/{linux,fallback}`, `process`)
- Root `Cargo.toml` -- added `libc` to workspace dependencies

## Architecture

```
SandboxConfig --> SandboxContext --> platform::{linux, fallback}
                       |
                       +-- check_path_access()   (software check, all platforms)
                       +-- check_write_access()   (software check, all platforms)
                       +-- activate()             (OS-level restrictions, Linux only)
                       +-- run_command()           (timeout + OOM enforcement)
```

## Testing

- 30 unit tests covering:
  - `SandboxMode` access control (read-only denies writes, workspace-write allows workspace writes, full mode unrestricted)
  - Path traversal normalization (`..` component resolution)
  - Command execution with timeout enforcement
  - Configuration serialization roundtrips (TOML, JSON)
  - Activation idempotency
- All tests pass on macOS (Linux-specific code behind `cfg(target_os = "linux")`)
- `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- `cargo fmt --all -- --check` -- clean

## Unsafe code

- Single `unsafe` block in `platform/linux.rs` for `libc::unshare(CLONE_NEWNET)` with `// SAFETY:` comment
- Guarded by `#[expect(unsafe_code, reason = "...")]`
- Only compiled on Linux targets

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)