### PR TITLE
tmg-skills: Implement skill discovery, loading, and use_skill tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -344,6 +344,12 @@ dependencies = [
  "nom",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -803,6 +809,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,8 +1209,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1316,6 +1341,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1455,6 +1493,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1614,17 @@ dependencies = [
 [[package]]
 name = "tmg-skills"
 version = "0.1.0"
+dependencies = [
+ "dirs",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror",
+ "tmg-llm",
+ "tmg-tools",
+ "tokio",
+]
 
 [[package]]
 name = "tmg-tools"
@@ -1795,6 +1857,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,10 +80,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -895,6 +916,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1009,31 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -1077,6 +1132,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1276,6 +1340,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1628,6 +1704,7 @@ name = "tmg-skills"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "proptest",
  "serde",
  "serde_json",
  "serde_yml",
@@ -1836,6 +1913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,6 +1988,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,16 +1354,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -1618,7 +1630,7 @@ dependencies = [
  "dirs",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "tempfile",
  "thiserror",
  "tmg-llm",
@@ -1859,12 +1871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,6 +1899,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 serde_yaml = "0.9"
+serde_yml = "0.0.12"
 
 # TUI
 ratatui = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ eventsource-stream = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
-serde_yaml = "0.9"
 serde_yml = "0.0.12"
 
 # TUI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ eventsource-stream = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+serde_yaml = "0.9"
 
 # TUI
 ratatui = "0.29"

--- a/crates/tmg-skills/Cargo.toml
+++ b/crates/tmg-skills/Cargo.toml
@@ -6,6 +6,18 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+tmg-tools = { workspace = true }
+tmg-llm = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
+dirs = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/tmg-skills/Cargo.toml
+++ b/crates/tmg-skills/Cargo.toml
@@ -18,6 +18,7 @@ dirs = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 tempfile = "3"
+proptest = "1"
 
 [lints]
 workspace = true

--- a/crates/tmg-skills/Cargo.toml
+++ b/crates/tmg-skills/Cargo.toml
@@ -10,7 +10,7 @@ tmg-tools = { workspace = true }
 tmg-llm = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+serde_yml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 dirs = { workspace = true }

--- a/crates/tmg-skills/src/discovery.rs
+++ b/crates/tmg-skills/src/discovery.rs
@@ -1,0 +1,223 @@
+//! Skill discovery: scans configured directories for SKILL.md files.
+//!
+//! Priority order (highest first):
+//! 1. `.tsumugi/skills/`
+//! 2. `~/.config/tsumugi/skills/`
+//! 3. `.claude/skills/`
+//! 4. `.agents/skills/`
+//!
+//! Same-named skills from higher-priority sources shadow lower ones.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::error::SkillError;
+use crate::parse::parse_skill_md;
+use crate::types::{SkillMeta, SkillName, SkillPath, SkillSource};
+
+/// The expected skill definition file name.
+const SKILL_FILENAME: &str = "SKILL.md";
+
+/// Discover all skills from the configured directories.
+///
+/// Scans each source directory in priority order. When two skills
+/// share the same name, the one from the higher-priority source wins.
+///
+/// # Arguments
+///
+/// * `project_root` - The project root directory (used for
+///   `.tsumugi/skills/`, `.claude/skills/`, `.agents/skills/`).
+///
+/// # Errors
+///
+/// Returns [`SkillError`] if a SKILL.md file exists but cannot be read
+/// or contains invalid frontmatter.
+pub async fn discover_skills(project_root: impl AsRef<Path>) -> Result<Vec<SkillMeta>, SkillError> {
+    let project_root = project_root.as_ref();
+    let mut skills_by_name: HashMap<SkillName, SkillMeta> = HashMap::new();
+
+    for source in SkillSource::ALL {
+        let dir = source_directory(source, project_root);
+
+        let Some(dir) = dir else { continue };
+
+        let entries = match tokio::fs::read_dir(&dir).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => continue,
+            Err(e) => {
+                return Err(SkillError::io(
+                    format!("reading skill directory {}", dir.display()),
+                    e,
+                ));
+            }
+        };
+
+        scan_directory(entries, source, &mut skills_by_name).await?;
+    }
+
+    // Collect into a sorted Vec for deterministic output.
+    let mut skills: Vec<SkillMeta> = skills_by_name.into_values().collect();
+    skills.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
+
+    Ok(skills)
+}
+
+/// Scan a single directory for skill subdirectories containing SKILL.md.
+async fn scan_directory(
+    mut entries: tokio::fs::ReadDir,
+    source: SkillSource,
+    skills_by_name: &mut HashMap<SkillName, SkillMeta>,
+) -> Result<(), SkillError> {
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) => {
+                return Err(SkillError::io("reading directory entry", e));
+            }
+        };
+
+        // Each skill lives in a subdirectory containing a SKILL.md.
+        let entry_path = entry.path();
+
+        let is_dir = match entry.file_type().await {
+            Ok(ft) => ft.is_dir(),
+            Err(_) => continue,
+        };
+
+        if !is_dir {
+            continue;
+        }
+
+        let skill_file = entry_path.join(SKILL_FILENAME);
+        let content = match tokio::fs::read_to_string(&skill_file).await {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(SkillError::io(
+                    format!("reading {}", skill_file.display()),
+                    e,
+                ));
+            }
+        };
+
+        let file_path_str = skill_file.display().to_string();
+        let (frontmatter, _body) = parse_skill_md(&content, &file_path_str)?;
+
+        let name = SkillName::new(&frontmatter.name);
+
+        // Only insert if no higher-priority skill with the same name exists.
+        // Since we iterate in priority order, we skip if already present.
+        if !skills_by_name.contains_key(&name) {
+            skills_by_name.insert(
+                name.clone(),
+                SkillMeta {
+                    name,
+                    frontmatter,
+                    source,
+                    path: SkillPath::new(skill_file),
+                },
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve the filesystem path for a given skill source.
+fn source_directory(source: SkillSource, project_root: &Path) -> Option<PathBuf> {
+    match source {
+        SkillSource::ProjectTsumugi => Some(project_root.join(".tsumugi").join("skills")),
+        SkillSource::GlobalConfig => dirs::config_dir().map(|d| d.join("tsumugi").join("skills")),
+        SkillSource::ProjectClaude => Some(project_root.join(".claude").join("skills")),
+        SkillSource::ProjectAgents => Some(project_root.join(".agents").join("skills")),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn discover_empty_project() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let skills = discover_skills(tmp.path())
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(skills.is_empty());
+    }
+
+    #[tokio::test]
+    async fn discover_single_skill() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let skill_dir = tmp.path().join(".tsumugi").join("skills").join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: A test skill\n---\n\nBody here.\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let skills = discover_skills(tmp.path())
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name.as_str(), "my-skill");
+        assert_eq!(skills[0].source, SkillSource::ProjectTsumugi);
+    }
+
+    #[tokio::test]
+    async fn higher_priority_shadows_lower() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+
+        // Create same-named skill in two different sources.
+        let tsumugi_dir = tmp.path().join(".tsumugi").join("skills").join("dup-skill");
+        std::fs::create_dir_all(&tsumugi_dir).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(
+            tsumugi_dir.join("SKILL.md"),
+            "---\nname: dup-skill\ndescription: From tsumugi\n---\n\nTsumugi body.\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let claude_dir = tmp.path().join(".claude").join("skills").join("dup-skill");
+        std::fs::create_dir_all(&claude_dir).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(
+            claude_dir.join("SKILL.md"),
+            "---\nname: dup-skill\ndescription: From claude\n---\n\nClaude body.\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let skills = discover_skills(tmp.path())
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].frontmatter.description, "From tsumugi");
+        assert_eq!(skills[0].source, SkillSource::ProjectTsumugi);
+    }
+
+    #[tokio::test]
+    async fn discover_multiple_skills_sorted() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let base = tmp.path().join(".tsumugi").join("skills");
+
+        for name in &["zebra-skill", "alpha-skill", "middle-skill"] {
+            let dir = base.join(name);
+            std::fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("{e}"));
+            std::fs::write(
+                dir.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: Skill {name}\n---\n\nBody.\n"),
+            )
+            .unwrap_or_else(|e| panic!("{e}"));
+        }
+
+        let skills = discover_skills(tmp.path())
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(skills.len(), 3);
+        assert_eq!(skills[0].name.as_str(), "alpha-skill");
+        assert_eq!(skills[1].name.as_str(), "middle-skill");
+        assert_eq!(skills[2].name.as_str(), "zebra-skill");
+    }
+}

--- a/crates/tmg-skills/src/error.rs
+++ b/crates/tmg-skills/src/error.rs
@@ -1,0 +1,59 @@
+//! Error types for the skills crate.
+
+/// Errors that can occur during skill discovery, parsing, or loading.
+#[derive(Debug, thiserror::Error)]
+pub enum SkillError {
+    /// An I/O error occurred while reading a skill file.
+    #[error("{context}: {source}")]
+    Io {
+        /// Description of what was being done when the error occurred.
+        context: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The SKILL.md frontmatter is missing or malformed.
+    #[error("invalid frontmatter in {path}: {reason}")]
+    InvalidFrontmatter {
+        /// Path to the skill file.
+        path: String,
+        /// Description of the parsing issue.
+        reason: String,
+    },
+
+    /// YAML deserialization failed.
+    #[error("yaml parse error in {path}: {source}")]
+    YamlParse {
+        /// Path to the skill file.
+        path: String,
+        /// The underlying YAML error.
+        #[source]
+        source: serde_yaml::Error,
+    },
+
+    /// The requested skill was not found.
+    #[error("skill not found: {name}")]
+    NotFound {
+        /// The skill name that was looked up.
+        name: String,
+    },
+}
+
+impl SkillError {
+    /// Create an I/O error with context.
+    pub fn io(context: impl Into<String>, source: std::io::Error) -> Self {
+        Self::Io {
+            context: context.into(),
+            source,
+        }
+    }
+
+    /// Create an invalid frontmatter error.
+    pub fn invalid_frontmatter(path: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::InvalidFrontmatter {
+            path: path.into(),
+            reason: reason.into(),
+        }
+    }
+}

--- a/crates/tmg-skills/src/error.rs
+++ b/crates/tmg-skills/src/error.rs
@@ -29,7 +29,7 @@ pub enum SkillError {
         path: String,
         /// The underlying YAML error.
         #[source]
-        source: serde_yaml::Error,
+        source: serde_yml::Error,
     },
 
     /// The requested skill was not found.

--- a/crates/tmg-skills/src/lib.rs
+++ b/crates/tmg-skills/src/lib.rs
@@ -1,1 +1,42 @@
-// tmg-skills: Higher-level skill compositions built on top of tools.
+//! tmg-skills: Skill discovery, loading, and invocation for tsumugi.
+//!
+//! This crate implements the Agent Skills system: parsing SKILL.md files
+//! with YAML frontmatter, discovering skills from multiple directories
+//! with priority ordering, loading skill content on demand, and providing
+//! a `use_skill` tool for LLM invocation.
+//!
+//! ## Skill directory structure
+//!
+//! ```text
+//! .tsumugi/skills/
+//!   my-skill/
+//!     SKILL.md          # Frontmatter + instruction body
+//!     scripts/          # Optional helper scripts
+//!     references/       # Optional reference files
+//! ```
+//!
+//! ## Discovery priority
+//!
+//! 1. `.tsumugi/skills/` (project-local, highest priority)
+//! 2. `~/.config/tsumugi/skills/` (global config)
+//! 3. `.claude/skills/` (compatibility)
+//! 4. `.agents/skills/` (compatibility)
+
+pub mod discovery;
+pub mod error;
+pub mod loader;
+pub mod parse;
+pub mod slash;
+pub mod tool;
+pub mod types;
+
+pub use discovery::discover_skills;
+pub use error::SkillError;
+pub use loader::{format_skill_for_tool_result, format_skill_metadata, load_skill};
+pub use parse::parse_skill_md;
+pub use slash::{format_skills_list, parse_slash_command};
+pub use tool::UseSkillTool;
+pub use types::{
+    InvocationPolicy, SkillContent, SkillFrontmatter, SkillMeta, SkillName, SkillPath, SkillSource,
+    SlashCommand,
+};

--- a/crates/tmg-skills/src/loader.rs
+++ b/crates/tmg-skills/src/loader.rs
@@ -1,5 +1,8 @@
 //! Skill loading: reads the full SKILL.md body and associated resource files.
 
+// `write!`/`writeln!` to `String` is infallible (the `fmt::Write` impl for
+// `String` never returns `Err`), so `let _ = writeln!(...)` is intentional
+// throughout this module.
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -9,6 +12,11 @@ use crate::types::{InvocationPolicy, SkillContent, SkillMeta};
 
 /// Load the full content of a skill, including its instruction body
 /// and lists of associated scripts/ and references/ files.
+///
+/// # Panics
+///
+/// Panics if `meta.path` has no parent directory (should be unreachable
+/// since `SkillPath` always points to a file).
 ///
 /// # Errors
 ///
@@ -24,7 +32,13 @@ pub async fn load_skill(meta: &SkillMeta) -> Result<SkillContent, SkillError> {
     let (_frontmatter, body) = parse_skill_md(&content, &file_path_str)?;
 
     // The skill directory is the parent of SKILL.md.
-    let skill_dir = skill_file.parent().unwrap_or(Path::new("."));
+    #[expect(
+        clippy::expect_used,
+        reason = "SkillPath is always a file path with a parent directory"
+    )]
+    let skill_dir = skill_file
+        .parent()
+        .expect("SkillPath always has a parent directory");
 
     let scripts = list_files_in_subdir(skill_dir, "scripts").await?;
     let references = list_files_in_subdir(skill_dir, "references").await?;

--- a/crates/tmg-skills/src/loader.rs
+++ b/crates/tmg-skills/src/loader.rs
@@ -1,0 +1,256 @@
+//! Skill loading: reads the full SKILL.md body and associated resource files.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use crate::error::SkillError;
+use crate::parse::parse_skill_md;
+use crate::types::{InvocationPolicy, SkillContent, SkillMeta};
+
+/// Load the full content of a skill, including its instruction body
+/// and lists of associated scripts/ and references/ files.
+///
+/// # Errors
+///
+/// Returns [`SkillError::Io`] if the SKILL.md or resource directories
+/// cannot be read.
+pub async fn load_skill(meta: &SkillMeta) -> Result<SkillContent, SkillError> {
+    let skill_file = meta.path.as_path();
+    let content = tokio::fs::read_to_string(skill_file)
+        .await
+        .map_err(|e| SkillError::io(format!("reading {}", skill_file.display()), e))?;
+
+    let file_path_str = skill_file.display().to_string();
+    let (_frontmatter, body) = parse_skill_md(&content, &file_path_str)?;
+
+    // The skill directory is the parent of SKILL.md.
+    let skill_dir = skill_file.parent().unwrap_or(Path::new("."));
+
+    let scripts = list_files_in_subdir(skill_dir, "scripts").await?;
+    let references = list_files_in_subdir(skill_dir, "references").await?;
+
+    Ok(SkillContent {
+        meta: meta.clone(),
+        body,
+        scripts,
+        references,
+    })
+}
+
+/// List files in a subdirectory (non-recursive). Returns an empty Vec
+/// if the subdirectory does not exist.
+async fn list_files_in_subdir(
+    base: &Path,
+    subdir: &str,
+) -> Result<Vec<std::path::PathBuf>, SkillError> {
+    let dir = base.join(subdir);
+    let mut entries = match tokio::fs::read_dir(&dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(SkillError::io(format!("reading {}", dir.display()), e));
+        }
+    };
+
+    let mut files = Vec::new();
+    loop {
+        match entries.next_entry().await {
+            Ok(Some(entry)) => {
+                let ft = entry
+                    .file_type()
+                    .await
+                    .map_err(|e| SkillError::io("reading file type", e))?;
+                if ft.is_file() {
+                    files.push(entry.path());
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                return Err(SkillError::io("reading directory entry", e));
+            }
+        }
+    }
+
+    files.sort();
+    Ok(files)
+}
+
+/// Format skill metadata for injection into the system prompt.
+///
+/// Each skill is represented as two lines:
+/// ```text
+/// - <name>: <description>
+///   invocation: <auto|explicit_only>
+/// ```
+///
+/// Only skills with `invocation: auto` are included, since
+/// `explicit_only` skills should not appear in auto-discovery metadata.
+pub fn format_skill_metadata(skills: &[SkillMeta]) -> String {
+    let mut output = String::new();
+
+    let auto_skills: Vec<&SkillMeta> = skills
+        .iter()
+        .filter(|s| s.frontmatter.invocation == InvocationPolicy::Auto)
+        .collect();
+
+    if auto_skills.is_empty() {
+        return output;
+    }
+
+    output.push_str("Available skills (use `use_skill` tool to invoke):\n");
+    for skill in auto_skills {
+        let _ = writeln!(
+            output,
+            "- {}: {}",
+            skill.name, skill.frontmatter.description
+        );
+    }
+
+    output
+}
+
+/// Format a loaded skill for inclusion in a tool result.
+///
+/// Includes the instruction body and lists of scripts/ and references/ files.
+pub fn format_skill_for_tool_result(content: &SkillContent) -> String {
+    let mut result = String::new();
+
+    let _ = writeln!(result, "# Skill: {}\n", content.meta.name);
+    result.push_str(&content.body);
+
+    if !content.scripts.is_empty() {
+        result.push_str("\n\n## Scripts\n");
+        for script in &content.scripts {
+            let _ = writeln!(result, "- {}", script.display());
+        }
+    }
+
+    if !content.references.is_empty() {
+        result.push_str("\n\n## References\n");
+        for reference in &content.references {
+            let _ = writeln!(result, "- {}", reference.display());
+        }
+    }
+
+    if let Some(tools) = &content.meta.frontmatter.allowed_tools {
+        result.push_str("\n\n## Allowed Tools\n");
+        for tool in tools {
+            let _ = writeln!(result, "- {tool}");
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::types::{InvocationPolicy, SkillFrontmatter, SkillName, SkillPath, SkillSource};
+
+    fn sample_meta(name: &str, invocation: InvocationPolicy) -> SkillMeta {
+        SkillMeta {
+            name: SkillName::new(name),
+            frontmatter: SkillFrontmatter {
+                name: name.to_owned(),
+                description: format!("Description of {name}"),
+                invocation,
+                allowed_tools: None,
+            },
+            source: SkillSource::ProjectTsumugi,
+            path: SkillPath::new(format!("/fake/{name}/SKILL.md")),
+        }
+    }
+
+    #[test]
+    fn format_metadata_auto_only() {
+        let skills = vec![
+            sample_meta("auto-skill", InvocationPolicy::Auto),
+            sample_meta("explicit-skill", InvocationPolicy::ExplicitOnly),
+            sample_meta("another-auto", InvocationPolicy::Auto),
+        ];
+
+        let output = format_skill_metadata(&skills);
+        assert!(output.contains("auto-skill"));
+        assert!(output.contains("another-auto"));
+        assert!(!output.contains("explicit-skill"));
+    }
+
+    #[test]
+    fn format_metadata_empty() {
+        let output = format_skill_metadata(&[]);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn format_metadata_all_explicit() {
+        let skills = vec![sample_meta("explicit", InvocationPolicy::ExplicitOnly)];
+        let output = format_skill_metadata(&skills);
+        assert!(output.is_empty());
+    }
+
+    #[tokio::test]
+    async fn load_skill_with_resources() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(skill_dir.join("scripts")).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::create_dir_all(skill_dir.join("references")).unwrap_or_else(|e| panic!("{e}"));
+
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: Test\n---\n\nDo things.\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(skill_dir.join("scripts").join("run.sh"), "#!/bin/bash\n")
+            .unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(skill_dir.join("references").join("guide.md"), "# Guide\n")
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let meta = SkillMeta {
+            name: SkillName::new("my-skill"),
+            frontmatter: SkillFrontmatter {
+                name: "my-skill".to_owned(),
+                description: "Test".to_owned(),
+                invocation: InvocationPolicy::Auto,
+                allowed_tools: None,
+            },
+            source: SkillSource::ProjectTsumugi,
+            path: SkillPath::new(skill_dir.join("SKILL.md")),
+        };
+
+        let content = load_skill(&meta).await.unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(content.body, "Do things.\n");
+        assert_eq!(content.scripts.len(), 1);
+        assert_eq!(content.references.len(), 1);
+    }
+
+    #[test]
+    fn format_tool_result_with_resources() {
+        let content = SkillContent {
+            meta: SkillMeta {
+                name: SkillName::new("test-skill"),
+                frontmatter: SkillFrontmatter {
+                    name: "test-skill".to_owned(),
+                    description: "A test".to_owned(),
+                    invocation: InvocationPolicy::Auto,
+                    allowed_tools: Some(vec!["file_read".to_owned()]),
+                },
+                source: SkillSource::ProjectTsumugi,
+                path: SkillPath::new("/fake/SKILL.md"),
+            },
+            body: "Instructions here.\n".to_owned(),
+            scripts: vec!["/fake/scripts/run.sh".into()],
+            references: vec!["/fake/references/guide.md".into()],
+        };
+
+        let result = format_skill_for_tool_result(&content);
+        assert!(result.contains("# Skill: test-skill"));
+        assert!(result.contains("Instructions here."));
+        assert!(result.contains("## Scripts"));
+        assert!(result.contains("run.sh"));
+        assert!(result.contains("## References"));
+        assert!(result.contains("guide.md"));
+        assert!(result.contains("## Allowed Tools"));
+        assert!(result.contains("file_read"));
+    }
+}

--- a/crates/tmg-skills/src/parse.rs
+++ b/crates/tmg-skills/src/parse.rs
@@ -57,12 +57,10 @@ pub fn parse_skill_md(
 
     let yaml_content = &rest[..end_idx];
     let body_start = end_idx + FRONTMATTER_DELIMITER.len();
-    let body = rest[body_start..]
-        .trim_start_matches('\n')
-        .trim_start_matches('\r');
+    let body = rest[body_start..].trim_start_matches(['\n', '\r']);
 
     let frontmatter: SkillFrontmatter =
-        serde_yaml::from_str(yaml_content).map_err(|e| SkillError::YamlParse {
+        serde_yml::from_str(yaml_content).map_err(|e| SkillError::YamlParse {
             path: file_path.to_owned(),
             source: e,
         })?;
@@ -73,47 +71,34 @@ pub fn parse_skill_md(
 /// Find the byte offset of the closing `---` delimiter within the text
 /// after the opening delimiter has been stripped.
 ///
-/// The closing delimiter must appear at the start of a line.
+/// The closing delimiter must appear at the start of a line. Uses
+/// cumulative byte offsets to avoid mismatch when YAML content contains
+/// `---` substrings.
 fn find_closing_delimiter(text: &str) -> Option<usize> {
-    for (idx, line) in text.lines().enumerate() {
-        // Skip the first "line" which is the remainder of the opening
-        // delimiter line (usually empty or just a newline).
+    let mut offset = 0;
+    for (idx, line) in text.split('\n').enumerate() {
         if idx == 0 {
+            offset += line.len() + 1;
             continue;
         }
         if line.trim() == FRONTMATTER_DELIMITER {
-            // Calculate byte offset: we need to find where this line
-            // starts in the original text.
-            let line_start = text
-                .match_indices(line)
-                .find(|(pos, _)| {
-                    // Make sure this is at a line boundary.
-                    *pos == 0 || text.as_bytes().get(pos - 1) == Some(&b'\n')
-                })
-                .map(|(pos, _)| pos);
-
-            // Only match `---` lines that are exactly the delimiter
-            // (not a longer line starting with `---`).
-            if let Some(start) = line_start {
-                if text[start..].starts_with(FRONTMATTER_DELIMITER) {
-                    return Some(start);
-                }
-            }
+            return Some(offset);
         }
+        offset += line.len() + 1;
     }
     None
 }
 
 /// Serialize a `SkillFrontmatter` back to YAML string (for roundtrip testing).
-pub fn serialize_frontmatter(frontmatter: &SkillFrontmatter) -> Result<String, serde_yaml::Error> {
-    serde_yaml::to_string(frontmatter)
+pub fn serialize_frontmatter(frontmatter: &SkillFrontmatter) -> Result<String, serde_yml::Error> {
+    serde_yml::to_string(frontmatter)
 }
 
 /// Format a full SKILL.md file from frontmatter and body.
 pub fn format_skill_md(
     frontmatter: &SkillFrontmatter,
     body: &str,
-) -> Result<String, serde_yaml::Error> {
+) -> Result<String, serde_yml::Error> {
     let yaml = serialize_frontmatter(frontmatter)?;
     Ok(format!("---\n{yaml}---\n\n{body}"))
 }
@@ -204,8 +189,7 @@ Review the code carefully.
         };
 
         let yaml = serialize_frontmatter(&original).unwrap_or_else(|e| panic!("{e}"));
-        let parsed: SkillFrontmatter =
-            serde_yaml::from_str(&yaml).unwrap_or_else(|e| panic!("{e}"));
+        let parsed: SkillFrontmatter = serde_yml::from_str(&yaml).unwrap_or_else(|e| panic!("{e}"));
 
         assert_eq!(original, parsed);
     }

--- a/crates/tmg-skills/src/parse.rs
+++ b/crates/tmg-skills/src/parse.rs
@@ -57,7 +57,10 @@ pub fn parse_skill_md(
 
     let yaml_content = &rest[..end_idx];
     let body_start = end_idx + FRONTMATTER_DELIMITER.len();
-    let body = rest[body_start..].trim_start_matches(['\n', '\r']);
+    let body = rest
+        .get(body_start..)
+        .unwrap_or("")
+        .trim_start_matches(['\n', '\r']);
 
     let frontmatter: SkillFrontmatter =
         serde_yml::from_str(yaml_content).map_err(|e| SkillError::YamlParse {
@@ -89,26 +92,26 @@ fn find_closing_delimiter(text: &str) -> Option<usize> {
     None
 }
 
-/// Serialize a `SkillFrontmatter` back to YAML string (for roundtrip testing).
-pub fn serialize_frontmatter(frontmatter: &SkillFrontmatter) -> Result<String, serde_yml::Error> {
-    serde_yml::to_string(frontmatter)
-}
-
-/// Format a full SKILL.md file from frontmatter and body.
-pub fn format_skill_md(
-    frontmatter: &SkillFrontmatter,
-    body: &str,
-) -> Result<String, serde_yml::Error> {
-    let yaml = serialize_frontmatter(frontmatter)?;
-    Ok(format!("---\n{yaml}---\n\n{body}"))
-}
-
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions")]
 #[expect(clippy::panic, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::types::InvocationPolicy;
+
+    /// Serialize a `SkillFrontmatter` back to YAML string (for roundtrip testing).
+    fn serialize_frontmatter(frontmatter: &SkillFrontmatter) -> Result<String, serde_yml::Error> {
+        serde_yml::to_string(frontmatter)
+    }
+
+    /// Format a full SKILL.md file from frontmatter and body.
+    fn format_skill_md(
+        frontmatter: &SkillFrontmatter,
+        body: &str,
+    ) -> Result<String, serde_yml::Error> {
+        let yaml = serialize_frontmatter(frontmatter)?;
+        Ok(format!("---\n{yaml}---\n\n{body}"))
+    }
 
     #[test]
     fn parse_basic_frontmatter() {
@@ -195,6 +198,15 @@ Review the code carefully.
     }
 
     #[test]
+    fn parse_closing_delimiter_on_last_line_without_trailing_newline() {
+        let content = "---\nname: x\ndescription: y\n---";
+        let (fm, body) = parse_skill_md(content, "f.md").unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(fm.name, "x");
+        assert_eq!(fm.description, "y");
+        assert_eq!(body, "");
+    }
+
+    #[test]
     fn format_and_reparse() {
         let original = SkillFrontmatter {
             name: "format-test".to_owned(),
@@ -210,5 +222,70 @@ Review the code carefully.
 
         assert_eq!(original, parsed_fm);
         assert_eq!(parsed_body, body);
+    }
+
+    #[expect(clippy::expect_used, reason = "proptest assertions")]
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_invocation_policy() -> impl Strategy<Value = InvocationPolicy> {
+            prop_oneof![
+                Just(InvocationPolicy::Auto),
+                Just(InvocationPolicy::ExplicitOnly),
+            ]
+        }
+
+        /// Generate a non-empty string that does not contain `---` on its own
+        /// line and has no leading/trailing whitespace that would be lost in
+        /// YAML roundtrip.
+        fn arb_yaml_safe_string() -> impl Strategy<Value = String> {
+            "[a-zA-Z0-9][a-zA-Z0-9 _-]{0,30}[a-zA-Z0-9]"
+        }
+
+        fn arb_allowed_tools() -> impl Strategy<Value = Option<Vec<String>>> {
+            prop_oneof![
+                Just(None),
+                proptest::collection::vec("[a-z_]{1,20}", 1..5).prop_map(Some),
+            ]
+        }
+
+        fn arb_frontmatter() -> impl Strategy<Value = SkillFrontmatter> {
+            (
+                arb_yaml_safe_string(),
+                arb_yaml_safe_string(),
+                arb_invocation_policy(),
+                arb_allowed_tools(),
+            )
+                .prop_map(|(name, description, invocation, allowed_tools)| {
+                    SkillFrontmatter {
+                        name,
+                        description,
+                        invocation,
+                        allowed_tools,
+                    }
+                })
+        }
+
+        proptest! {
+            #[test]
+            fn frontmatter_roundtrip(fm in arb_frontmatter()) {
+                let yaml = serialize_frontmatter(&fm).expect("serialize");
+                let parsed: SkillFrontmatter =
+                    serde_yml::from_str(&yaml).expect("deserialize");
+                prop_assert_eq!(&fm, &parsed);
+            }
+
+            #[test]
+            fn format_parse_roundtrip(fm in arb_frontmatter(), body in "[a-zA-Z0-9 .!?\n]{0,100}") {
+                let md = format_skill_md(&fm, &body).expect("format");
+                let (parsed_fm, parsed_body) =
+                    parse_skill_md(&md, "prop.md").expect("parse");
+                prop_assert_eq!(&fm, &parsed_fm);
+                // Body is trimmed of leading newlines by the parser.
+                let expected_body = body.trim_start_matches(['\n', '\r']);
+                prop_assert_eq!(parsed_body, expected_body);
+            }
+        }
     }
 }

--- a/crates/tmg-skills/src/parse.rs
+++ b/crates/tmg-skills/src/parse.rs
@@ -1,0 +1,230 @@
+//! SKILL.md frontmatter parsing.
+//!
+//! A SKILL.md file has the format:
+//!
+//! ```text
+//! ---
+//! name: my-skill
+//! description: A short description
+//! invocation: auto
+//! allowed_tools:
+//!   - file_read
+//!   - grep_search
+//! ---
+//!
+//! Instruction body goes here...
+//! ```
+//!
+//! The frontmatter is delimited by `---` lines at the start of the file.
+
+use crate::error::SkillError;
+use crate::types::SkillFrontmatter;
+
+/// The frontmatter delimiter.
+const FRONTMATTER_DELIMITER: &str = "---";
+
+/// Parse a SKILL.md file into its frontmatter and body.
+///
+/// Returns `(frontmatter, body)` where `body` is everything after the
+/// closing `---` delimiter.
+///
+/// # Errors
+///
+/// Returns [`SkillError::InvalidFrontmatter`] if the file does not contain
+/// valid frontmatter delimiters, or [`SkillError::YamlParse`] if the YAML
+/// content cannot be deserialized.
+pub fn parse_skill_md(
+    content: &str,
+    file_path: &str,
+) -> Result<(SkillFrontmatter, String), SkillError> {
+    let trimmed = content.trim_start();
+
+    // The file must start with `---`.
+    let Some(rest) = trimmed.strip_prefix(FRONTMATTER_DELIMITER) else {
+        return Err(SkillError::invalid_frontmatter(
+            file_path,
+            "file does not start with '---'",
+        ));
+    };
+
+    // Find the closing `---`.
+    let Some(end_idx) = find_closing_delimiter(rest) else {
+        return Err(SkillError::invalid_frontmatter(
+            file_path,
+            "closing '---' delimiter not found",
+        ));
+    };
+
+    let yaml_content = &rest[..end_idx];
+    let body_start = end_idx + FRONTMATTER_DELIMITER.len();
+    let body = rest[body_start..]
+        .trim_start_matches('\n')
+        .trim_start_matches('\r');
+
+    let frontmatter: SkillFrontmatter =
+        serde_yaml::from_str(yaml_content).map_err(|e| SkillError::YamlParse {
+            path: file_path.to_owned(),
+            source: e,
+        })?;
+
+    Ok((frontmatter, body.to_owned()))
+}
+
+/// Find the byte offset of the closing `---` delimiter within the text
+/// after the opening delimiter has been stripped.
+///
+/// The closing delimiter must appear at the start of a line.
+fn find_closing_delimiter(text: &str) -> Option<usize> {
+    for (idx, line) in text.lines().enumerate() {
+        // Skip the first "line" which is the remainder of the opening
+        // delimiter line (usually empty or just a newline).
+        if idx == 0 {
+            continue;
+        }
+        if line.trim() == FRONTMATTER_DELIMITER {
+            // Calculate byte offset: we need to find where this line
+            // starts in the original text.
+            let line_start = text
+                .match_indices(line)
+                .find(|(pos, _)| {
+                    // Make sure this is at a line boundary.
+                    *pos == 0 || text.as_bytes().get(pos - 1) == Some(&b'\n')
+                })
+                .map(|(pos, _)| pos);
+
+            // Only match `---` lines that are exactly the delimiter
+            // (not a longer line starting with `---`).
+            if let Some(start) = line_start {
+                if text[start..].starts_with(FRONTMATTER_DELIMITER) {
+                    return Some(start);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Serialize a `SkillFrontmatter` back to YAML string (for roundtrip testing).
+pub fn serialize_frontmatter(frontmatter: &SkillFrontmatter) -> Result<String, serde_yaml::Error> {
+    serde_yaml::to_string(frontmatter)
+}
+
+/// Format a full SKILL.md file from frontmatter and body.
+pub fn format_skill_md(
+    frontmatter: &SkillFrontmatter,
+    body: &str,
+) -> Result<String, serde_yaml::Error> {
+    let yaml = serialize_frontmatter(frontmatter)?;
+    Ok(format!("---\n{yaml}---\n\n{body}"))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(clippy::panic, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::types::InvocationPolicy;
+
+    #[test]
+    fn parse_basic_frontmatter() {
+        let content = "\
+---
+name: test-skill
+description: A test skill
+---
+
+This is the body.
+";
+        let (fm, body) = parse_skill_md(content, "test.md").unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(fm.name, "test-skill");
+        assert_eq!(fm.description, "A test skill");
+        assert_eq!(fm.invocation, InvocationPolicy::Auto);
+        assert!(fm.allowed_tools.is_none());
+        assert_eq!(body, "This is the body.\n");
+    }
+
+    #[test]
+    fn parse_full_frontmatter() {
+        let content = "\
+---
+name: code-review
+description: Reviews code for best practices
+invocation: explicit_only
+allowed_tools:
+  - file_read
+  - grep_search
+---
+
+Review the code carefully.
+";
+        let (fm, body) = parse_skill_md(content, "test.md").unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(fm.name, "code-review");
+        assert_eq!(fm.description, "Reviews code for best practices");
+        assert_eq!(fm.invocation, InvocationPolicy::ExplicitOnly);
+        assert_eq!(
+            fm.allowed_tools,
+            Some(vec!["file_read".to_owned(), "grep_search".to_owned()])
+        );
+        assert_eq!(body, "Review the code carefully.\n");
+    }
+
+    #[test]
+    fn parse_missing_opening_delimiter() {
+        let content = "name: test\n---\nbody";
+        let err = parse_skill_md(content, "bad.md").unwrap_err();
+        assert!(err.to_string().contains("does not start with '---'"));
+    }
+
+    #[test]
+    fn parse_missing_closing_delimiter() {
+        let content = "---\nname: test\n";
+        let err = parse_skill_md(content, "bad.md").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("closing '---' delimiter not found")
+        );
+    }
+
+    #[test]
+    fn parse_invalid_yaml() {
+        let content = "---\n[invalid yaml\n---\nbody";
+        let err = parse_skill_md(content, "bad.md").unwrap_err();
+        assert!(err.to_string().contains("yaml parse error"));
+    }
+
+    #[test]
+    fn roundtrip_frontmatter() {
+        let original = SkillFrontmatter {
+            name: "roundtrip-test".to_owned(),
+            description: "Tests roundtrip".to_owned(),
+            invocation: InvocationPolicy::ExplicitOnly,
+            allowed_tools: Some(vec!["file_read".to_owned()]),
+        };
+
+        let yaml = serialize_frontmatter(&original).unwrap_or_else(|e| panic!("{e}"));
+        let parsed: SkillFrontmatter =
+            serde_yaml::from_str(&yaml).unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn format_and_reparse() {
+        let original = SkillFrontmatter {
+            name: "format-test".to_owned(),
+            description: "Tests formatting".to_owned(),
+            invocation: InvocationPolicy::Auto,
+            allowed_tools: None,
+        };
+        let body = "Do the thing.\n";
+
+        let md = format_skill_md(&original, body).unwrap_or_else(|e| panic!("{e}"));
+        let (parsed_fm, parsed_body) =
+            parse_skill_md(&md, "formatted.md").unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(original, parsed_fm);
+        assert_eq!(parsed_body, body);
+    }
+}

--- a/crates/tmg-skills/src/slash.rs
+++ b/crates/tmg-skills/src/slash.rs
@@ -1,0 +1,155 @@
+//! Slash command parsing for skill invocation.
+//!
+//! Supports:
+//! - `/skills` — list all installed skills
+//! - `/<skill-name>` — invoke a skill explicitly (with optional arguments)
+
+use std::fmt::Write as _;
+
+use crate::types::{SkillName, SlashCommand};
+
+/// Try to parse user input as a slash command.
+///
+/// Returns `None` if the input does not start with `/` or is not a
+/// recognized command pattern.
+pub fn parse_slash_command(input: &str) -> Option<SlashCommand> {
+    let trimmed = input.trim();
+
+    let rest = trimmed.strip_prefix('/')?;
+
+    if rest.is_empty() {
+        return None;
+    }
+
+    // Split into command name and optional arguments.
+    let (command, args) = match rest.split_once(char::is_whitespace) {
+        Some((cmd, remainder)) => {
+            let remainder = remainder.trim();
+            let args = if remainder.is_empty() {
+                None
+            } else {
+                Some(remainder.to_owned())
+            };
+            (cmd, args)
+        }
+        None => (rest, None),
+    };
+
+    if command == "skills" {
+        return Some(SlashCommand::ListSkills);
+    }
+
+    // Any other `/foo` is treated as a skill invocation.
+    Some(SlashCommand::InvokeSkill {
+        name: SkillName::new(command),
+        args,
+    })
+}
+
+/// Format a list of skills for display (e.g. in TUI).
+pub fn format_skills_list(skills: &[crate::types::SkillMeta]) -> String {
+    if skills.is_empty() {
+        return "No skills installed.".to_owned();
+    }
+
+    let mut output = String::from("Installed skills:\n\n");
+    for skill in skills {
+        let _ = writeln!(
+            output,
+            "  /{} — {} [{}] (from {})",
+            skill.name, skill.frontmatter.description, skill.frontmatter.invocation, skill.source,
+        );
+    }
+    output
+}
+
+impl std::fmt::Display for crate::types::InvocationPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auto => write!(f, "auto"),
+            Self::ExplicitOnly => write!(f, "explicit_only"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_skills_command() {
+        let cmd = parse_slash_command("/skills");
+        assert_eq!(cmd, Some(SlashCommand::ListSkills));
+    }
+
+    #[test]
+    fn parse_skills_command_with_whitespace() {
+        let cmd = parse_slash_command("  /skills  ");
+        assert_eq!(cmd, Some(SlashCommand::ListSkills));
+    }
+
+    #[test]
+    fn parse_skill_invocation_no_args() {
+        let cmd = parse_slash_command("/code-review");
+        assert_eq!(
+            cmd,
+            Some(SlashCommand::InvokeSkill {
+                name: SkillName::new("code-review"),
+                args: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_skill_invocation_with_args() {
+        let cmd = parse_slash_command("/test-runner src/main.rs");
+        assert_eq!(
+            cmd,
+            Some(SlashCommand::InvokeSkill {
+                name: SkillName::new("test-runner"),
+                args: Some("src/main.rs".to_owned()),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_empty_slash() {
+        let cmd = parse_slash_command("/");
+        assert_eq!(cmd, None);
+    }
+
+    #[test]
+    fn parse_no_slash() {
+        let cmd = parse_slash_command("hello world");
+        assert_eq!(cmd, None);
+    }
+
+    #[test]
+    fn format_empty_list() {
+        let output = format_skills_list(&[]);
+        assert_eq!(output, "No skills installed.");
+    }
+
+    #[test]
+    fn format_nonempty_list() {
+        use crate::types::*;
+
+        let skills = vec![SkillMeta {
+            name: SkillName::new("test-skill"),
+            frontmatter: SkillFrontmatter {
+                name: "test-skill".to_owned(),
+                description: "A test skill".to_owned(),
+                invocation: InvocationPolicy::Auto,
+                allowed_tools: None,
+            },
+            source: SkillSource::ProjectTsumugi,
+            path: SkillPath::new("/fake/SKILL.md"),
+        }];
+
+        let output = format_skills_list(&skills);
+        assert!(output.contains("/test-skill"));
+        assert!(output.contains("A test skill"));
+        assert!(output.contains("auto"));
+        assert!(output.contains(".tsumugi/skills"));
+    }
+}

--- a/crates/tmg-skills/src/tool.rs
+++ b/crates/tmg-skills/src/tool.rs
@@ -1,0 +1,161 @@
+//! `use_skill` tool implementation.
+//!
+//! This tool loads a skill's SKILL.md body and returns it as a tool result,
+//! enabling the LLM to incorporate skill instructions into its context.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tmg_tools::error::ToolError;
+use tmg_tools::types::{Tool, ToolResult};
+
+use crate::loader::{format_skill_for_tool_result, load_skill};
+use crate::types::{SkillMeta, SkillName};
+
+/// The `use_skill` tool: loads a skill's instruction body and returns it.
+pub struct UseSkillTool {
+    /// Index of available skills by name for lookup.
+    skills: Arc<HashMap<SkillName, SkillMeta>>,
+}
+
+impl UseSkillTool {
+    /// Create a new `UseSkillTool` from discovered skill metadata.
+    pub fn new(skills: Vec<SkillMeta>) -> Self {
+        let map: HashMap<SkillName, SkillMeta> =
+            skills.into_iter().map(|s| (s.name.clone(), s)).collect();
+        Self {
+            skills: Arc::new(map),
+        }
+    }
+}
+
+impl Tool for UseSkillTool {
+    fn name(&self) -> &'static str {
+        "use_skill"
+    }
+
+    fn description(&self) -> &'static str {
+        "Load a skill's instructions into context. Returns the SKILL.md body, \
+         associated scripts/references file list, and allowed_tools constraints."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "skill_name": {
+                    "type": "string",
+                    "description": "The name of the skill to load."
+                }
+            },
+            "required": ["skill_name"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute(
+        &self,
+        params: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult, ToolError>> + Send + '_>> {
+        Box::pin(self.execute_inner(params))
+    }
+}
+
+impl UseSkillTool {
+    async fn execute_inner(&self, params: serde_json::Value) -> Result<ToolResult, ToolError> {
+        let Some(skill_name) = params.get("skill_name").and_then(serde_json::Value::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: skill_name",
+            ));
+        };
+
+        let name = SkillName::new(skill_name);
+        let Some(meta) = self.skills.get(&name) else {
+            return Ok(ToolResult::error(format!(
+                "Skill not found: {skill_name}. Available skills: {}",
+                self.skills
+                    .keys()
+                    .map(SkillName::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )));
+        };
+
+        match load_skill(meta).await {
+            Ok(content) => {
+                let result = format_skill_for_tool_result(&content);
+                Ok(ToolResult::success(result))
+            }
+            Err(e) => Ok(ToolResult::error(format!(
+                "Failed to load skill '{skill_name}': {e}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::types::{InvocationPolicy, SkillFrontmatter, SkillPath, SkillSource};
+
+    fn make_tool_with_skill(tmp_dir: &std::path::Path) -> UseSkillTool {
+        let skill_dir = tmp_dir.join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: A test\n---\n\nDo the thing.\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let meta = SkillMeta {
+            name: SkillName::new("my-skill"),
+            frontmatter: SkillFrontmatter {
+                name: "my-skill".to_owned(),
+                description: "A test".to_owned(),
+                invocation: InvocationPolicy::Auto,
+                allowed_tools: None,
+            },
+            source: SkillSource::ProjectTsumugi,
+            path: SkillPath::new(skill_dir.join("SKILL.md")),
+        };
+
+        UseSkillTool::new(vec![meta])
+    }
+
+    #[tokio::test]
+    async fn use_skill_success() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let tool = make_tool_with_skill(tmp.path());
+
+        let result = tool
+            .execute_inner(serde_json::json!({ "skill_name": "my-skill" }))
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("Do the thing."));
+        assert!(result.output.contains("# Skill: my-skill"));
+    }
+
+    #[tokio::test]
+    async fn use_skill_not_found() {
+        let tool = UseSkillTool::new(vec![]);
+        let result = tool
+            .execute_inner(serde_json::json!({ "skill_name": "nonexistent" }))
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        assert!(result.is_error);
+        assert!(result.output.contains("Skill not found"));
+    }
+
+    #[tokio::test]
+    async fn use_skill_missing_param() {
+        let tool = UseSkillTool::new(vec![]);
+        let result = tool.execute_inner(serde_json::json!({})).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/tmg-skills/src/tool.rs
+++ b/crates/tmg-skills/src/tool.rs
@@ -73,13 +73,11 @@ impl UseSkillTool {
 
         let name = SkillName::new(skill_name);
         let Some(meta) = self.skills.get(&name) else {
+            let mut available: Vec<&str> = self.skills.keys().map(SkillName::as_str).collect();
+            available.sort_unstable();
             return Ok(ToolResult::error(format!(
                 "Skill not found: {skill_name}. Available skills: {}",
-                self.skills
-                    .keys()
-                    .map(SkillName::as_str)
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                available.join(", ")
             )));
         };
 

--- a/crates/tmg-skills/src/types.rs
+++ b/crates/tmg-skills/src/types.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 /// A unique skill name (e.g. `"code-review"`, `"test-runner"`).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct SkillName(pub String);
+pub struct SkillName(String);
 
 impl SkillName {
     /// Create a new `SkillName`.
@@ -26,6 +26,11 @@ impl SkillName {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// Consume self and return the inner `String`.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
 }
 
 impl fmt::Display for SkillName {
@@ -36,7 +41,7 @@ impl fmt::Display for SkillName {
 
 /// An absolute path to a SKILL.md file.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct SkillPath(pub PathBuf);
+pub struct SkillPath(PathBuf);
 
 impl SkillPath {
     /// Create a new `SkillPath`.
@@ -47,6 +52,11 @@ impl SkillPath {
     /// Return the inner path reference.
     pub fn as_path(&self) -> &std::path::Path {
         &self.0
+    }
+
+    /// Consume self and return the inner `PathBuf`.
+    pub fn into_inner(self) -> PathBuf {
+        self.0
     }
 }
 

--- a/crates/tmg-skills/src/types.rs
+++ b/crates/tmg-skills/src/types.rs
@@ -1,0 +1,204 @@
+//! Domain types for the skills system.
+//!
+//! Uses newtypes for domain concepts to avoid primitive obsession.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Newtypes
+// ---------------------------------------------------------------------------
+
+/// A unique skill name (e.g. `"code-review"`, `"test-runner"`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SkillName(pub String);
+
+impl SkillName {
+    /// Create a new `SkillName`.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// Return the name as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SkillName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// An absolute path to a SKILL.md file.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SkillPath(pub PathBuf);
+
+impl SkillPath {
+    /// Create a new `SkillPath`.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self(path.into())
+    }
+
+    /// Return the inner path reference.
+    pub fn as_path(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+
+impl fmt::Display for SkillPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.display())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Invocation policy
+// ---------------------------------------------------------------------------
+
+/// Controls when a skill can be invoked by the LLM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum InvocationPolicy {
+    /// The LLM may invoke the skill automatically when it determines
+    /// the skill is relevant.
+    #[default]
+    Auto,
+
+    /// The skill can only be invoked explicitly via a `/skill-name`
+    /// slash command. It will not appear in auto-discovery metadata
+    /// sent to the LLM.
+    ExplicitOnly,
+}
+
+// ---------------------------------------------------------------------------
+// Skill source (priority ordering)
+// ---------------------------------------------------------------------------
+
+/// Where a skill was discovered from, in descending priority order.
+///
+/// Skills from higher-priority sources shadow skills with the same name
+/// from lower-priority sources.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SkillSource {
+    /// `.tsumugi/skills/` in the project root (highest priority).
+    ProjectTsumugi = 0,
+    /// `~/.config/tsumugi/skills/` in the global config directory.
+    GlobalConfig = 1,
+    /// `.claude/skills/` in the project root.
+    ProjectClaude = 2,
+    /// `.agents/skills/` in the project root.
+    ProjectAgents = 3,
+}
+
+impl SkillSource {
+    /// All sources in priority order (highest first).
+    pub const ALL: [Self; 4] = [
+        Self::ProjectTsumugi,
+        Self::GlobalConfig,
+        Self::ProjectClaude,
+        Self::ProjectAgents,
+    ];
+}
+
+impl fmt::Display for SkillSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProjectTsumugi => write!(f, ".tsumugi/skills"),
+            Self::GlobalConfig => write!(f, "~/.config/tsumugi/skills"),
+            Self::ProjectClaude => write!(f, ".claude/skills"),
+            Self::ProjectAgents => write!(f, ".agents/skills"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// YAML frontmatter
+// ---------------------------------------------------------------------------
+
+/// The parsed YAML frontmatter from a SKILL.md file.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkillFrontmatter {
+    /// The skill's human-readable name.
+    pub name: String,
+
+    /// A short description of what the skill does.
+    pub description: String,
+
+    /// How and when the skill can be invoked.
+    #[serde(default)]
+    pub invocation: InvocationPolicy,
+
+    /// Optional list of tool names this skill is allowed to use.
+    /// When `None`, all tools are available.
+    #[serde(default)]
+    pub allowed_tools: Option<Vec<String>>,
+}
+
+// ---------------------------------------------------------------------------
+// Skill metadata (frontmatter + source info)
+// ---------------------------------------------------------------------------
+
+/// Metadata about a discovered skill (frontmatter + source info).
+///
+/// This is the lightweight representation used during discovery and
+/// for system prompt injection. The full skill body is not loaded
+/// until `load_skill()` is called.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkillMeta {
+    /// The skill's unique name (derived from frontmatter or directory name).
+    pub name: SkillName,
+
+    /// The parsed frontmatter.
+    pub frontmatter: SkillFrontmatter,
+
+    /// Where this skill was discovered from.
+    pub source: SkillSource,
+
+    /// The absolute path to the SKILL.md file.
+    pub path: SkillPath,
+}
+
+// ---------------------------------------------------------------------------
+// Full skill content
+// ---------------------------------------------------------------------------
+
+/// The full content of a loaded skill, including the instruction body
+/// and any associated resource files.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkillContent {
+    /// The skill metadata.
+    pub meta: SkillMeta,
+
+    /// The instruction body (everything after the frontmatter).
+    pub body: String,
+
+    /// Paths to files in the `scripts/` subdirectory (if any).
+    pub scripts: Vec<PathBuf>,
+
+    /// Paths to files in the `references/` subdirectory (if any).
+    pub references: Vec<PathBuf>,
+}
+
+// ---------------------------------------------------------------------------
+// Slash command
+// ---------------------------------------------------------------------------
+
+/// A parsed slash command from user input.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SlashCommand {
+    /// `/skills` — list all installed skills.
+    ListSkills,
+
+    /// `/<skill-name>` with optional arguments — invoke a skill explicitly.
+    InvokeSkill {
+        /// The skill name (without the leading `/`).
+        name: SkillName,
+        /// Optional arguments passed after the skill name.
+        args: Option<String>,
+    },
+}


### PR DESCRIPTION
## Summary

Implements the Agent Skills system in the `tmg-skills` crate as specified in #8:

- **Type definitions** (`SkillMeta`, `SkillContent`, `SkillFrontmatter`, `InvocationPolicy`, `SkillSource`, `SlashCommand`) with newtypes (`SkillName`, `SkillPath`) for domain concepts
- **SKILL.md frontmatter parsing** (YAML) with structured `SkillError` using `thiserror` 2.x, including `parse_skill_md`, `serialize_frontmatter`, and `format_skill_md` for roundtrip support
- **`discover_skills()`**: async skill discovery scanning `.tsumugi/skills/` > `~/.config/tsumugi/skills/` > `.claude/skills/` > `.agents/skills/` with priority-based shadowing for same-named skills
- **`load_skill()`**: full SKILL.md body loading with `scripts/` and `references/` file listing
- **`format_skill_metadata()`**: system prompt injection metadata (auto-invocation skills only, 2 lines per skill)
- **`use_skill` tool**: implements the `Tool` trait from `tmg-tools`, returns SKILL.md body + resource file lists + `allowed_tools` constraints as `ToolResult`
- **Slash commands**: `/skills` for listing all installed skills, `/<skill-name>` for explicit skill invocation with optional arguments
- Path parameters accept `impl AsRef<Path>` per project convention

## Crates modified

- `tmg-skills` — all new implementation
- Root `Cargo.toml` — added `serde_yaml` to workspace dependencies

## Testing

- **27 unit tests** covering:
  - Frontmatter parsing (basic, full, error cases)
  - Frontmatter roundtrip (serialize -> parse)
  - Format and reparse roundtrip
  - Discovery: empty project, single skill, priority shadowing, multiple skills sorted
  - Skill loading with scripts/ and references/ subdirectories
  - Metadata formatting (auto-only filtering, empty, all-explicit)
  - Tool result formatting with resources and allowed_tools
  - `use_skill` tool: success, not found, missing parameter
  - Slash command parsing: `/skills`, `/<name>`, `/<name> args`, edge cases
  - Skills list formatting
- All workspace tests pass (126 total)
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all -- --check` clean

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)