### PR TITLE
tmg-agents: Implement Subagent system with spawn_agent tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tmg-agents"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tmg-llm",
+ "tmg-tools",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+]
 
 [[package]]
 name = "tmg-cli"
@@ -1648,6 +1658,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "tmg-agents",
  "tmg-core",
  "tmg-llm",
  "tmg-tools",
@@ -1734,6 +1745,7 @@ dependencies = [
  "crossterm",
  "ratatui",
  "thiserror",
+ "tmg-agents",
  "tmg-core",
  "tmg-llm",
  "tokio",

--- a/crates/tmg-agents/Cargo.toml
+++ b/crates/tmg-agents/Cargo.toml
@@ -6,6 +6,17 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+tmg-llm = { workspace = true }
+tmg-tools = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tokio-util = { workspace = true }
+tokio-stream = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync"] }
 
 [lints]
 workspace = true

--- a/crates/tmg-agents/src/builtins.rs
+++ b/crates/tmg-agents/src/builtins.rs
@@ -35,7 +35,9 @@ fn register_tool_by_name(registry: &mut ToolRegistry, name: &str) {
         "grep_search" => registry.register(tmg_tools::tools::GrepSearchTool),
         "list_dir" => registry.register(tmg_tools::tools::ListDirTool),
         "shell_exec" => registry.register(tmg_tools::tools::ShellExecTool),
-        _ => {} // Unknown tool names are silently skipped.
+        _ => {
+            debug_assert!(false, "register_tool_by_name: unknown tool name: {name}");
+        }
     }
 }
 

--- a/crates/tmg-agents/src/builtins.rs
+++ b/crates/tmg-agents/src/builtins.rs
@@ -1,0 +1,85 @@
+//! Built-in subagent definitions.
+//!
+//! Provides a helper to create a [`ToolRegistry`] filtered to only the
+//! tools allowed for a given [`AgentType`].
+
+use tmg_tools::ToolRegistry;
+
+use crate::config::AgentType;
+
+/// Create a [`ToolRegistry`] containing only the tools allowed for the
+/// given agent type.
+///
+/// This filters the default registry, keeping only tools whose names
+/// appear in [`AgentType::allowed_tools`].
+pub fn registry_for_agent_type(agent_type: AgentType) -> ToolRegistry {
+    let full_registry = tmg_tools::default_registry();
+    let allowed = agent_type.allowed_tools();
+
+    let mut filtered = ToolRegistry::new();
+    for name in allowed {
+        if full_registry.get(name).is_some() {
+            register_tool_by_name(&mut filtered, name);
+        }
+    }
+
+    filtered
+}
+
+/// Register a built-in tool by name into the given registry.
+fn register_tool_by_name(registry: &mut ToolRegistry, name: &str) {
+    match name {
+        "file_read" => registry.register(tmg_tools::tools::FileReadTool),
+        "file_write" => registry.register(tmg_tools::tools::FileWriteTool),
+        "file_patch" => registry.register(tmg_tools::tools::FilePatchTool),
+        "grep_search" => registry.register(tmg_tools::tools::GrepSearchTool),
+        "list_dir" => registry.register(tmg_tools::tools::ListDirTool),
+        "shell_exec" => registry.register(tmg_tools::tools::ShellExecTool),
+        _ => {} // Unknown tool names are silently skipped.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explore_registry_has_read_only_tools() {
+        let registry = registry_for_agent_type(AgentType::Explore);
+        assert!(registry.get("file_read").is_some());
+        assert!(registry.get("list_dir").is_some());
+        assert!(registry.get("grep_search").is_some());
+        assert!(registry.get("file_write").is_none());
+        assert!(registry.get("shell_exec").is_none());
+        assert!(registry.get("spawn_agent").is_none());
+    }
+
+    #[test]
+    fn worker_registry_has_all_standard_tools() {
+        let registry = registry_for_agent_type(AgentType::Worker);
+        assert!(registry.get("file_read").is_some());
+        assert!(registry.get("file_write").is_some());
+        assert!(registry.get("file_patch").is_some());
+        assert!(registry.get("grep_search").is_some());
+        assert!(registry.get("list_dir").is_some());
+        assert!(registry.get("shell_exec").is_some());
+        assert!(registry.get("spawn_agent").is_none());
+    }
+
+    #[test]
+    fn plan_registry_matches_explore() {
+        let plan_registry = registry_for_agent_type(AgentType::Plan);
+        let explore_registry = registry_for_agent_type(AgentType::Explore);
+
+        // Both should have the same tools.
+        assert!(plan_registry.get("file_read").is_some());
+        assert!(plan_registry.get("list_dir").is_some());
+        assert!(plan_registry.get("grep_search").is_some());
+        assert!(plan_registry.get("file_write").is_none());
+
+        assert!(explore_registry.get("file_read").is_some());
+        assert!(explore_registry.get("list_dir").is_some());
+        assert!(explore_registry.get("grep_search").is_some());
+        assert!(explore_registry.get("file_write").is_none());
+    }
+}

--- a/crates/tmg-agents/src/config.rs
+++ b/crates/tmg-agents/src/config.rs
@@ -91,13 +91,12 @@ impl AgentType {
     }
 
     /// Parse an agent type from a string name.
+    ///
+    /// Delegates to serde deserialization so the canonical name mapping
+    /// is defined in a single place (`#[serde(rename_all = "snake_case")]`).
     pub fn from_name(name: &str) -> Option<Self> {
-        match name {
-            "explore" => Some(Self::Explore),
-            "worker" => Some(Self::Worker),
-            "plan" => Some(Self::Plan),
-            _ => None,
-        }
+        let quoted = format!("\"{name}\"");
+        serde_json::from_str(&quoted).ok()
     }
 }
 

--- a/crates/tmg-agents/src/config.rs
+++ b/crates/tmg-agents/src/config.rs
@@ -1,0 +1,184 @@
+//! Subagent configuration types.
+//!
+//! Defines [`AgentType`] (the built-in subagent kinds) and
+//! [`SubagentConfig`] (the parameters for spawning a subagent).
+
+use serde::{Deserialize, Serialize};
+
+/// The built-in subagent types.
+///
+/// Each type defines a different set of allowed tools and a tailored
+/// system prompt for its purpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentType {
+    /// Read-only codebase exploration agent.
+    ///
+    /// Allowed tools: `file_read`, `list_dir`, `grep_search`.
+    Explore,
+
+    /// General-purpose worker agent with full tool access.
+    ///
+    /// Allowed tools: all tools except `spawn_agent` (no nesting).
+    Worker,
+
+    /// Read-only planning agent that produces structured plans.
+    ///
+    /// Allowed tools: `file_read`, `list_dir`, `grep_search`.
+    Plan,
+}
+
+impl AgentType {
+    /// All built-in agent types.
+    pub const ALL: &'static [Self] = &[Self::Explore, Self::Worker, Self::Plan];
+
+    /// Return the tool names allowed for this agent type.
+    ///
+    /// `spawn_agent` is never included (nesting is forbidden).
+    pub fn allowed_tools(&self) -> &'static [&'static str] {
+        match self {
+            Self::Explore | Self::Plan => &["file_read", "list_dir", "grep_search"],
+            Self::Worker => &[
+                "file_read",
+                "file_write",
+                "file_patch",
+                "grep_search",
+                "list_dir",
+                "shell_exec",
+            ],
+        }
+    }
+
+    /// Return the system prompt for this agent type.
+    pub fn system_prompt(&self) -> &'static str {
+        match self {
+            Self::Explore => {
+                "You are an explore subagent. Your job is to investigate the codebase \
+                 and report findings. You have read-only access to files: you can read \
+                 files, list directories, and search with grep. Provide a thorough and \
+                 well-structured summary of what you find."
+            }
+            Self::Worker => {
+                "You are a worker subagent. You have full tool access to read, write, \
+                 patch files, and run shell commands. Execute the assigned task \
+                 efficiently and report the result. You cannot spawn other subagents."
+            }
+            Self::Plan => {
+                "You are a planning subagent. Your job is to analyze the codebase \
+                 (read-only) and produce a structured plan. You can read files, list \
+                 directories, and search with grep. Output a clear, actionable plan \
+                 with numbered steps."
+            }
+        }
+    }
+
+    /// A human-readable description of this agent type.
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Explore => "Read-only codebase exploration (file_read, list_dir, grep_search)",
+            Self::Worker => "Full tool access worker (all tools except spawn_agent)",
+            Self::Plan => "Read-only planning agent (file_read, list_dir, grep_search)",
+        }
+    }
+
+    /// The display name of this agent type.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Explore => "explore",
+            Self::Worker => "worker",
+            Self::Plan => "plan",
+        }
+    }
+
+    /// Parse an agent type from a string name.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "explore" => Some(Self::Explore),
+            "worker" => Some(Self::Worker),
+            "plan" => Some(Self::Plan),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for AgentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// Configuration for spawning a subagent.
+#[derive(Debug, Clone)]
+pub struct SubagentConfig {
+    /// The type of subagent to spawn.
+    pub agent_type: AgentType,
+
+    /// The task description for the subagent.
+    pub task: String,
+
+    /// Whether to run in the background (`true`) or await completion
+    /// (`false`).
+    pub background: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_type_from_name() {
+        assert_eq!(AgentType::from_name("explore"), Some(AgentType::Explore));
+        assert_eq!(AgentType::from_name("worker"), Some(AgentType::Worker));
+        assert_eq!(AgentType::from_name("plan"), Some(AgentType::Plan));
+        assert_eq!(AgentType::from_name("unknown"), None);
+    }
+
+    #[test]
+    fn agent_type_display() {
+        assert_eq!(AgentType::Explore.to_string(), "explore");
+        assert_eq!(AgentType::Worker.to_string(), "worker");
+        assert_eq!(AgentType::Plan.to_string(), "plan");
+    }
+
+    #[test]
+    fn explore_tools_are_read_only() {
+        let tools = AgentType::Explore.allowed_tools();
+        assert!(tools.contains(&"file_read"));
+        assert!(tools.contains(&"list_dir"));
+        assert!(tools.contains(&"grep_search"));
+        assert!(!tools.contains(&"file_write"));
+        assert!(!tools.contains(&"shell_exec"));
+        assert!(!tools.contains(&"spawn_agent"));
+    }
+
+    #[test]
+    fn worker_tools_exclude_spawn_agent() {
+        let tools = AgentType::Worker.allowed_tools();
+        assert!(!tools.contains(&"spawn_agent"));
+        assert!(tools.contains(&"file_read"));
+        assert!(tools.contains(&"file_write"));
+        assert!(tools.contains(&"shell_exec"));
+    }
+
+    #[test]
+    fn plan_tools_are_read_only() {
+        let tools = AgentType::Plan.allowed_tools();
+        assert_eq!(tools, AgentType::Explore.allowed_tools());
+    }
+
+    #[test]
+    fn all_types_covered() {
+        assert_eq!(AgentType::ALL.len(), 3);
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let json = serde_json::to_string(&AgentType::Explore).ok();
+        assert_eq!(json.as_deref(), Some("\"explore\""));
+
+        let parsed: AgentType = serde_json::from_str("\"worker\"")
+            .ok()
+            .unwrap_or(AgentType::Explore);
+        assert_eq!(parsed, AgentType::Worker);
+    }
+}

--- a/crates/tmg-agents/src/error.rs
+++ b/crates/tmg-agents/src/error.rs
@@ -1,0 +1,39 @@
+//! Error types for the agents crate.
+
+/// Errors produced by the subagent system.
+#[derive(Debug, thiserror::Error)]
+pub enum AgentError {
+    /// An error originating from the LLM communication layer.
+    #[error("llm error: {0}")]
+    Llm(#[from] tmg_llm::LlmError),
+
+    /// An error originating from tool execution.
+    #[error("tool error: {0}")]
+    Tool(#[from] tmg_tools::ToolError),
+
+    /// An unknown agent type was requested.
+    #[error("unknown agent type: {name}")]
+    UnknownAgentType {
+        /// The agent type name that was not recognized.
+        name: String,
+    },
+
+    /// A subagent attempted to spawn another subagent (nesting is forbidden).
+    #[error("subagent nesting is not allowed: spawn_agent cannot be called from a subagent")]
+    NestingForbidden,
+
+    /// The subagent was cancelled via `CancellationToken`.
+    #[error("subagent cancelled")]
+    Cancelled,
+
+    /// A task join error from `JoinSet`.
+    #[error("subagent task join error: {message}")]
+    JoinError {
+        /// Description of the join error.
+        message: String,
+    },
+
+    /// JSON serialization/deserialization error.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/crates/tmg-agents/src/lib.rs
+++ b/crates/tmg-agents/src/lib.rs
@@ -14,7 +14,7 @@ pub mod tools;
 
 pub use config::{AgentType, SubagentConfig};
 pub use error::AgentError;
-pub use manager::{SubagentManager, SubagentSummary};
+pub use manager::{SubagentId, SubagentManager, SubagentSummary};
 pub use runner::SubagentRunner;
-pub use status::SubagentStatus;
+pub use status::{SubagentStatus, truncate_str};
 pub use tools::SpawnAgentTool;

--- a/crates/tmg-agents/src/lib.rs
+++ b/crates/tmg-agents/src/lib.rs
@@ -1,1 +1,20 @@
-// tmg-agents: Agent loop and orchestration logic.
+//! tmg-agents: Subagent system for independent, parallel agent execution.
+//!
+//! Provides built-in subagent types (`explore`, `worker`, `plan`) that run
+//! with independent conversation contexts, restricted tool sets, and
+//! structured lifecycle management via [`tokio::task::JoinSet`].
+
+pub mod builtins;
+pub mod config;
+pub mod error;
+pub mod manager;
+pub mod runner;
+pub mod status;
+pub mod tools;
+
+pub use config::{AgentType, SubagentConfig};
+pub use error::AgentError;
+pub use manager::{SubagentManager, SubagentSummary};
+pub use runner::SubagentRunner;
+pub use status::SubagentStatus;
+pub use tools::SpawnAgentTool;

--- a/crates/tmg-agents/src/manager.rs
+++ b/crates/tmg-agents/src/manager.rs
@@ -4,10 +4,11 @@
 //! as tokio tasks in a [`JoinSet`], and provides methods to query
 //! status and collect results.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
+use std::fmt;
 use std::sync::Arc;
 
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
@@ -20,7 +21,21 @@ use crate::runner::SubagentRunner;
 use crate::status::SubagentStatus;
 
 /// A unique identifier for a subagent instance.
-pub type SubagentId = u64;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SubagentId(u64);
+
+impl SubagentId {
+    /// Return the inner `u64` value.
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for SubagentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// Summary information about a subagent for display purposes.
 #[derive(Debug, Clone)]
@@ -58,10 +73,13 @@ pub struct SubagentManager {
     join_set: JoinSet<(SubagentId, Result<String, AgentError>)>,
 
     /// Shared state for all tracked subagent instances.
-    instances: Arc<Mutex<HashMap<SubagentId, SubagentInstance>>>,
+    ///
+    /// Uses `BTreeMap` for sorted iteration (by ID) and better cache
+    /// locality on the small collections expected here.
+    instances: Arc<Mutex<BTreeMap<SubagentId, SubagentInstance>>>,
 
     /// Counter for generating unique subagent IDs.
-    next_id: SubagentId,
+    next_id: u64,
 }
 
 impl SubagentManager {
@@ -71,7 +89,7 @@ impl SubagentManager {
             client,
             parent_cancel,
             join_set: JoinSet::new(),
-            instances: Arc::new(Mutex::new(HashMap::new())),
+            instances: Arc::new(Mutex::new(BTreeMap::new())),
             next_id: 1,
         }
     }
@@ -82,28 +100,44 @@ impl SubagentManager {
     /// [`collect_completed`] to drain finished results, or
     /// [`wait_for`] to await a specific subagent.
     pub async fn spawn(&mut self, config: SubagentConfig) -> SubagentId {
-        let id = self.next_id;
+        self.spawn_inner(config, None).await
+    }
+
+    /// Spawn a subagent and return both its ID and a oneshot receiver
+    /// that will deliver the result when the subagent completes.
+    ///
+    /// This is designed for foreground spawns where the caller needs to
+    /// drop the manager lock before awaiting the result (e.g., so the
+    /// TUI can still call `summaries()` while the subagent runs).
+    pub async fn spawn_with_notify(
+        &mut self,
+        config: SubagentConfig,
+    ) -> (SubagentId, oneshot::Receiver<Result<String, AgentError>>) {
+        let (tx, rx) = oneshot::channel();
+        let id = self.spawn_inner(config, Some(tx)).await;
+        (id, rx)
+    }
+
+    /// Internal spawn implementation shared by `spawn` and `spawn_with_notify`.
+    async fn spawn_inner(
+        &mut self,
+        config: SubagentConfig,
+        notify: Option<oneshot::Sender<Result<String, AgentError>>>,
+    ) -> SubagentId {
+        let id = SubagentId(self.next_id);
         self.next_id += 1;
 
+        // Insert directly as Running -- no need for the Pending ->
+        // Running transition since we spawn the task immediately.
         let instance = SubagentInstance {
             agent_type: config.agent_type,
             task: config.task.clone(),
-            status: SubagentStatus::Pending,
+            status: SubagentStatus::Running,
         };
 
         {
             let mut instances = self.instances.lock().await;
             instances.insert(id, instance);
-        }
-
-        // Transition to Running.
-        {
-            let mut instances = self.instances.lock().await;
-            if let Some(inst) = instances.get_mut(&id) {
-                if let Some(new_status) = inst.status.clone().transition_to_running() {
-                    inst.status = new_status;
-                }
-            }
         }
 
         let client = self.client.clone();
@@ -122,43 +156,37 @@ impl SubagentManager {
             {
                 let mut insts = instances.lock().await;
                 if let Some(inst) = insts.get_mut(&id) {
-                    let current = inst.status.clone();
                     match &result {
                         Ok(output) => {
-                            if let Some(new_status) = current.complete(output.clone()) {
-                                inst.status = new_status;
-                            }
+                            inst.status.complete(output.clone());
                         }
                         Err(AgentError::Cancelled) => {
-                            if let Some(new_status) = current.cancel() {
-                                inst.status = new_status;
-                            }
+                            inst.status.cancel();
                         }
                         Err(e) => {
-                            if let Some(new_status) = current.fail(e.to_string()) {
-                                inst.status = new_status;
-                            }
+                            inst.status.fail(e.to_string());
                         }
                     }
                 }
+            }
+
+            // If a foreground caller is waiting via oneshot, deliver the
+            // result. Ignore send errors (the receiver may have been
+            // dropped if the caller was cancelled).
+            if let Some(tx) = notify {
+                let to_send = match &result {
+                    Ok(output) => Ok(output.clone()),
+                    Err(e) => Err(AgentError::JoinError {
+                        message: e.to_string(),
+                    }),
+                };
+                let _ = tx.send(to_send);
             }
 
             (id, result)
         });
 
         id
-    }
-
-    /// Spawn a subagent and wait for it to complete, returning its result.
-    ///
-    /// This is the synchronous (foreground) spawn mode.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AgentError`] if the subagent fails or is cancelled.
-    pub async fn spawn_and_wait(&mut self, config: SubagentConfig) -> Result<String, AgentError> {
-        let id = self.spawn(config).await;
-        self.wait_for(id).await
     }
 
     /// Wait for a specific subagent to complete and return its result.
@@ -205,9 +233,11 @@ impl SubagentManager {
     }
 
     /// Return summaries of all tracked subagent instances.
+    ///
+    /// Results are sorted by ID (guaranteed by `BTreeMap` iteration order).
     pub async fn summaries(&self) -> Vec<SubagentSummary> {
         let instances = self.instances.lock().await;
-        let mut summaries: Vec<SubagentSummary> = instances
+        instances
             .iter()
             .map(|(&id, inst)| SubagentSummary {
                 id,
@@ -215,11 +245,7 @@ impl SubagentManager {
                 task: inst.task.clone(),
                 status: inst.status.clone(),
             })
-            .collect();
-
-        // Sort by ID for deterministic output.
-        summaries.sort_by_key(|s| s.id);
-        summaries
+            .collect()
     }
 
     /// Return the number of currently running (non-terminal) subagents.
@@ -246,13 +272,13 @@ mod tests {
     #[test]
     fn subagent_summary_fields() {
         let summary = SubagentSummary {
-            id: 1,
+            id: SubagentId(1),
             agent_type: AgentType::Explore,
             task: "test task".to_owned(),
             status: SubagentStatus::Running,
         };
 
-        assert_eq!(summary.id, 1);
+        assert_eq!(summary.id, SubagentId(1));
         assert_eq!(summary.agent_type, AgentType::Explore);
         assert_eq!(summary.task, "test task");
         assert_eq!(summary.status, SubagentStatus::Running);
@@ -285,8 +311,8 @@ mod tests {
         let id1 = manager.spawn(config1).await;
         let id2 = manager.spawn(config2).await;
 
-        assert_eq!(id1, 1);
-        assert_eq!(id2, 2);
+        assert_eq!(id1, SubagentId(1));
+        assert_eq!(id2, SubagentId(2));
 
         // Clean up: cancel and shutdown to avoid dangling tasks.
         cancel.cancel();

--- a/crates/tmg-agents/src/manager.rs
+++ b/crates/tmg-agents/src/manager.rs
@@ -1,0 +1,320 @@
+//! Subagent manager: lifecycle tracking and parallel execution via `JoinSet`.
+//!
+//! The [`SubagentManager`] tracks all subagent instances, spawns them
+//! as tokio tasks in a [`JoinSet`], and provides methods to query
+//! status and collect results.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+use tmg_llm::LlmClient;
+
+use crate::builtins::registry_for_agent_type;
+use crate::config::{AgentType, SubagentConfig};
+use crate::error::AgentError;
+use crate::runner::SubagentRunner;
+use crate::status::SubagentStatus;
+
+/// A unique identifier for a subagent instance.
+pub type SubagentId = u64;
+
+/// Summary information about a subagent for display purposes.
+#[derive(Debug, Clone)]
+pub struct SubagentSummary {
+    /// The subagent's unique identifier.
+    pub id: SubagentId,
+    /// The type of subagent.
+    pub agent_type: AgentType,
+    /// The task description.
+    pub task: String,
+    /// The current status.
+    pub status: SubagentStatus,
+}
+
+/// Internal state for a tracked subagent instance.
+struct SubagentInstance {
+    agent_type: AgentType,
+    task: String,
+    status: SubagentStatus,
+}
+
+/// Manages the lifecycle of subagent instances.
+///
+/// Uses a [`JoinSet`] for structured concurrency: all spawned subagent
+/// tasks are tracked and can be shut down together via
+/// [`SubagentManager::shutdown`].
+pub struct SubagentManager {
+    /// The LLM client shared with all subagents.
+    client: LlmClient,
+
+    /// The parent cancellation token.
+    parent_cancel: CancellationToken,
+
+    /// The `JoinSet` tracking all running subagent tasks.
+    join_set: JoinSet<(SubagentId, Result<String, AgentError>)>,
+
+    /// Shared state for all tracked subagent instances.
+    instances: Arc<Mutex<HashMap<SubagentId, SubagentInstance>>>,
+
+    /// Counter for generating unique subagent IDs.
+    next_id: SubagentId,
+}
+
+impl SubagentManager {
+    /// Create a new subagent manager.
+    pub fn new(client: LlmClient, parent_cancel: CancellationToken) -> Self {
+        Self {
+            client,
+            parent_cancel,
+            join_set: JoinSet::new(),
+            instances: Arc::new(Mutex::new(HashMap::new())),
+            next_id: 1,
+        }
+    }
+
+    /// Spawn a subagent and return its ID immediately.
+    ///
+    /// The subagent runs as a task in the internal `JoinSet`. Use
+    /// [`collect_completed`] to drain finished results, or
+    /// [`wait_for`] to await a specific subagent.
+    pub async fn spawn(&mut self, config: SubagentConfig) -> SubagentId {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        let instance = SubagentInstance {
+            agent_type: config.agent_type,
+            task: config.task.clone(),
+            status: SubagentStatus::Pending,
+        };
+
+        {
+            let mut instances = self.instances.lock().await;
+            instances.insert(id, instance);
+        }
+
+        // Transition to Running.
+        {
+            let mut instances = self.instances.lock().await;
+            if let Some(inst) = instances.get_mut(&id) {
+                if let Some(new_status) = inst.status.clone().transition_to_running() {
+                    inst.status = new_status;
+                }
+            }
+        }
+
+        let client = self.client.clone();
+        let agent_type = config.agent_type;
+        let task = config.task.clone();
+        let cancel = self.parent_cancel.child_token();
+        let instances = Arc::clone(&self.instances);
+
+        self.join_set.spawn(async move {
+            let registry = registry_for_agent_type(agent_type);
+            let mut runner = SubagentRunner::new(client, registry, agent_type, cancel);
+
+            let result = runner.run(&task).await;
+
+            // Update the instance status.
+            {
+                let mut insts = instances.lock().await;
+                if let Some(inst) = insts.get_mut(&id) {
+                    let current = inst.status.clone();
+                    match &result {
+                        Ok(output) => {
+                            if let Some(new_status) = current.complete(output.clone()) {
+                                inst.status = new_status;
+                            }
+                        }
+                        Err(AgentError::Cancelled) => {
+                            if let Some(new_status) = current.cancel() {
+                                inst.status = new_status;
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(new_status) = current.fail(e.to_string()) {
+                                inst.status = new_status;
+                            }
+                        }
+                    }
+                }
+            }
+
+            (id, result)
+        });
+
+        id
+    }
+
+    /// Spawn a subagent and wait for it to complete, returning its result.
+    ///
+    /// This is the synchronous (foreground) spawn mode.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgentError`] if the subagent fails or is cancelled.
+    pub async fn spawn_and_wait(&mut self, config: SubagentConfig) -> Result<String, AgentError> {
+        let id = self.spawn(config).await;
+        self.wait_for(id).await
+    }
+
+    /// Wait for a specific subagent to complete and return its result.
+    ///
+    /// Drains the `JoinSet` until the target subagent's result is found.
+    /// Other completed results are recorded in their instance state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgentError`] if the subagent fails, is cancelled, or
+    /// the task panics.
+    pub async fn wait_for(&mut self, target_id: SubagentId) -> Result<String, AgentError> {
+        loop {
+            let Some(join_result) = self.join_set.join_next().await else {
+                return Err(AgentError::JoinError {
+                    message: format!("subagent {target_id} not found in JoinSet"),
+                });
+            };
+
+            let (id, result) = join_result.map_err(|e| AgentError::JoinError {
+                message: e.to_string(),
+            })?;
+
+            if id == target_id {
+                return result;
+            }
+            // Otherwise, the result was for a different subagent -- its
+            // status was already updated in the spawn closure.
+        }
+    }
+
+    /// Collect all completed subagent results without blocking.
+    ///
+    /// Returns a list of `(SubagentId, Result)` for subagents that have
+    /// finished since the last call. Does not wait for running subagents.
+    pub fn collect_completed(&mut self) -> Vec<(SubagentId, Result<String, AgentError>)> {
+        let mut results = Vec::new();
+
+        while let Some(Ok((id, result))) = self.join_set.try_join_next() {
+            results.push((id, result));
+        }
+
+        results
+    }
+
+    /// Return summaries of all tracked subagent instances.
+    pub async fn summaries(&self) -> Vec<SubagentSummary> {
+        let instances = self.instances.lock().await;
+        let mut summaries: Vec<SubagentSummary> = instances
+            .iter()
+            .map(|(&id, inst)| SubagentSummary {
+                id,
+                agent_type: inst.agent_type,
+                task: inst.task.clone(),
+                status: inst.status.clone(),
+            })
+            .collect();
+
+        // Sort by ID for deterministic output.
+        summaries.sort_by_key(|s| s.id);
+        summaries
+    }
+
+    /// Return the number of currently running (non-terminal) subagents.
+    pub async fn running_count(&self) -> usize {
+        let instances = self.instances.lock().await;
+        instances
+            .values()
+            .filter(|inst| !inst.status.is_terminal())
+            .count()
+    }
+
+    /// Gracefully shut down all running subagents.
+    ///
+    /// Aborts all tasks in the `JoinSet` and waits for them to complete.
+    pub async fn shutdown(&mut self) {
+        self.join_set.shutdown().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subagent_summary_fields() {
+        let summary = SubagentSummary {
+            id: 1,
+            agent_type: AgentType::Explore,
+            task: "test task".to_owned(),
+            status: SubagentStatus::Running,
+        };
+
+        assert_eq!(summary.id, 1);
+        assert_eq!(summary.agent_type, AgentType::Explore);
+        assert_eq!(summary.task, "test task");
+        assert_eq!(summary.status, SubagentStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn manager_spawn_increments_id() {
+        let config = tmg_llm::LlmClientConfig::new("http://localhost:9999", "test");
+        // This will fail to connect, but we only test ID assignment.
+        let client = tmg_llm::LlmClient::new(config);
+        // If LlmClient::new can fail, we skip. Otherwise proceed.
+        let Ok(client) = client else {
+            return;
+        };
+
+        let cancel = CancellationToken::new();
+        let mut manager = SubagentManager::new(client, cancel.clone());
+
+        let config1 = SubagentConfig {
+            agent_type: AgentType::Explore,
+            task: "task 1".to_owned(),
+            background: true,
+        };
+        let config2 = SubagentConfig {
+            agent_type: AgentType::Plan,
+            task: "task 2".to_owned(),
+            background: true,
+        };
+
+        let id1 = manager.spawn(config1).await;
+        let id2 = manager.spawn(config2).await;
+
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+
+        // Clean up: cancel and shutdown to avoid dangling tasks.
+        cancel.cancel();
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn manager_summaries_include_all() {
+        let config = tmg_llm::LlmClientConfig::new("http://localhost:9999", "test");
+        let Ok(client) = tmg_llm::LlmClient::new(config) else {
+            return;
+        };
+
+        let cancel = CancellationToken::new();
+        let mut manager = SubagentManager::new(client, cancel.clone());
+
+        let config1 = SubagentConfig {
+            agent_type: AgentType::Explore,
+            task: "task 1".to_owned(),
+            background: true,
+        };
+        manager.spawn(config1).await;
+
+        let summaries = manager.summaries().await;
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].agent_type, AgentType::Explore);
+
+        cancel.cancel();
+        manager.shutdown().await;
+    }
+}

--- a/crates/tmg-agents/src/runner.rs
+++ b/crates/tmg-agents/src/runner.rs
@@ -184,6 +184,13 @@ impl SubagentRunner {
     }
 
     /// Stream one round of LLM output.
+    ///
+    /// # Cancel safety
+    ///
+    /// Uses `tokio::select!` to respond to cancellation promptly even
+    /// during slow LLM responses. The `stream.next()` future is
+    /// cancel-safe (dropping it just means we stop reading from the
+    /// stream).
     async fn stream_one_round(&self) -> Result<(String, Vec<ToolCall>), AgentError> {
         let chat_messages: Vec<_> = self
             .history
@@ -200,26 +207,36 @@ impl SubagentRunner {
         let mut response_text = String::new();
         let mut tool_calls = Vec::new();
 
-        while let Some(event) = stream.next().await {
-            match event {
-                Ok(StreamEvent::ContentDelta(token)) => {
-                    response_text.push_str(&token);
-                }
-                Ok(StreamEvent::ToolCallComplete(tc)) => {
-                    // Check: subagents must not call spawn_agent.
-                    if tc.function.name == "spawn_agent" {
-                        return Err(AgentError::NestingForbidden);
-                    }
-                    tool_calls.push(tc);
-                }
-                Ok(StreamEvent::Done(_)) => {
-                    break;
-                }
-                Err(tmg_llm::LlmError::Cancelled) => {
+        loop {
+            tokio::select! {
+                () = self.cancel.cancelled() => {
                     return Err(AgentError::Cancelled);
                 }
-                Err(e) => {
-                    return Err(AgentError::Llm(e));
+                maybe_event = stream.next() => {
+                    let Some(event) = maybe_event else {
+                        break;
+                    };
+                    match event {
+                        Ok(StreamEvent::ContentDelta(token)) => {
+                            response_text.push_str(&token);
+                        }
+                        Ok(StreamEvent::ToolCallComplete(tc)) => {
+                            // Check: subagents must not call spawn_agent.
+                            if tc.function.name == "spawn_agent" {
+                                return Err(AgentError::NestingForbidden);
+                            }
+                            tool_calls.push(tc);
+                        }
+                        Ok(StreamEvent::Done(_)) => {
+                            break;
+                        }
+                        Err(tmg_llm::LlmError::Cancelled) => {
+                            return Err(AgentError::Cancelled);
+                        }
+                        Err(e) => {
+                            return Err(AgentError::Llm(e));
+                        }
+                    }
                 }
             }
         }
@@ -228,6 +245,15 @@ impl SubagentRunner {
     }
 
     /// Execute tool calls in parallel via `JoinSet`.
+    ///
+    /// # Cancellation behaviour
+    ///
+    /// If any tool task returns `AgentError::Cancelled`, the `?`
+    /// propagation causes this method to return early and discard
+    /// results from other (potentially completed) tool calls. This is
+    /// intentional: once cancellation is signaled the entire subagent
+    /// loop is shutting down, so preserving partial results is not
+    /// useful. The `JoinSet` is dropped, which aborts remaining tasks.
     async fn dispatch_tool_calls(&mut self, tool_calls: &[ToolCall]) -> Result<(), AgentError> {
         let mut join_set = JoinSet::new();
 

--- a/crates/tmg-agents/src/runner.rs
+++ b/crates/tmg-agents/src/runner.rs
@@ -1,0 +1,293 @@
+//! Subagent runner: independent agent loop for a single subagent.
+//!
+//! Each subagent gets its own conversation history, filtered tool
+//! registry, and system prompt. The runner streams LLM responses,
+//! dispatches tool calls (only allowed tools), and loops until the
+//! model produces a final text response.
+
+use std::sync::Arc;
+
+use tokio::task::JoinSet;
+use tokio_stream::StreamExt as _;
+use tokio_util::sync::CancellationToken;
+
+use tmg_llm::{LlmClient, StreamEvent, ToolCall, ToolDefinition};
+use tmg_tools::ToolRegistry;
+
+use crate::config::AgentType;
+use crate::error::AgentError;
+
+/// Maximum number of consecutive tool-call rounds for a subagent.
+const MAX_SUBAGENT_TOOL_ROUNDS: usize = 15;
+
+/// A single message in the subagent's conversation history.
+#[derive(Debug, Clone)]
+struct SubagentMessage {
+    role: tmg_llm::Role,
+    content: String,
+    tool_calls: Option<Vec<ToolCall>>,
+    tool_call_id: Option<String>,
+}
+
+impl SubagentMessage {
+    fn system(content: &str) -> Self {
+        Self {
+            role: tmg_llm::Role::System,
+            content: content.to_owned(),
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+
+    fn user(content: &str) -> Self {
+        Self {
+            role: tmg_llm::Role::User,
+            content: content.to_owned(),
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+
+    fn assistant(content: String) -> Self {
+        Self {
+            role: tmg_llm::Role::Assistant,
+            content,
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+
+    fn assistant_with_tool_calls(content: String, tool_calls: Vec<ToolCall>) -> Self {
+        Self {
+            role: tmg_llm::Role::Assistant,
+            content,
+            tool_calls: Some(tool_calls),
+            tool_call_id: None,
+        }
+    }
+
+    fn tool_result(call_id: String, output: String) -> Self {
+        Self {
+            role: tmg_llm::Role::Tool,
+            content: output,
+            tool_calls: None,
+            tool_call_id: Some(call_id),
+        }
+    }
+
+    fn to_chat_message(&self) -> tmg_llm::ChatMessage {
+        let content = if self.content.is_empty() {
+            None
+        } else {
+            Some(self.content.clone())
+        };
+        tmg_llm::ChatMessage {
+            role: self.role,
+            content,
+            tool_calls: self.tool_calls.clone(),
+            tool_call_id: self.tool_call_id.clone(),
+        }
+    }
+}
+
+/// Runs an independent agent loop for a subagent.
+///
+/// The runner owns its own conversation history and tool registry,
+/// completely independent of the main agent loop.
+pub struct SubagentRunner {
+    /// The LLM client (shared with the main agent).
+    client: LlmClient,
+
+    /// The filtered tool registry for this subagent.
+    registry: Arc<ToolRegistry>,
+
+    /// Pre-computed tool definitions for the LLM API.
+    tool_defs: Vec<ToolDefinition>,
+
+    /// The subagent's conversation history.
+    history: Vec<SubagentMessage>,
+
+    /// Cancellation token for graceful shutdown.
+    cancel: CancellationToken,
+}
+
+impl SubagentRunner {
+    /// Create a new subagent runner.
+    ///
+    /// The runner initializes with a system prompt appropriate for
+    /// the agent type and a filtered tool registry.
+    pub fn new(
+        client: LlmClient,
+        registry: ToolRegistry,
+        agent_type: AgentType,
+        cancel: CancellationToken,
+    ) -> Self {
+        let tool_defs = registry.tool_definitions();
+        let registry = Arc::new(registry);
+
+        let history = vec![SubagentMessage::system(agent_type.system_prompt())];
+
+        Self {
+            client,
+            registry,
+            tool_defs,
+            history,
+            cancel,
+        }
+    }
+
+    /// Execute the subagent's task and return the final text response.
+    ///
+    /// The subagent runs its own agent loop: streaming LLM responses,
+    /// dispatching tool calls, and looping until a final text response
+    /// is produced.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgentError`] on LLM failure, tool errors, or
+    /// cancellation.
+    ///
+    /// # Cancel safety
+    ///
+    /// If the `CancellationToken` fires during execution, in-flight
+    /// tool tasks are dropped via `JoinSet` drop and
+    /// [`AgentError::Cancelled`] is returned.
+    pub async fn run(&mut self, task: &str) -> Result<String, AgentError> {
+        self.history.push(SubagentMessage::user(task));
+
+        for _round in 0..MAX_SUBAGENT_TOOL_ROUNDS {
+            if self.cancel.is_cancelled() {
+                return Err(AgentError::Cancelled);
+            }
+
+            let (response_text, tool_calls) = self.stream_one_round().await?;
+
+            if tool_calls.is_empty() {
+                if !response_text.is_empty() {
+                    self.history
+                        .push(SubagentMessage::assistant(response_text.clone()));
+                }
+                return Ok(response_text);
+            }
+
+            // Record the assistant message with tool calls.
+            self.history
+                .push(SubagentMessage::assistant_with_tool_calls(
+                    response_text,
+                    tool_calls.clone(),
+                ));
+
+            self.dispatch_tool_calls(&tool_calls).await?;
+        }
+
+        Ok("[Subagent terminated: maximum tool-call rounds reached]".to_owned())
+    }
+
+    /// Stream one round of LLM output.
+    async fn stream_one_round(&self) -> Result<(String, Vec<ToolCall>), AgentError> {
+        let chat_messages: Vec<_> = self
+            .history
+            .iter()
+            .map(SubagentMessage::to_chat_message)
+            .collect();
+
+        let mut stream = self
+            .client
+            .chat_streaming(chat_messages, self.tool_defs.clone(), self.cancel.clone())
+            .await
+            .map_err(AgentError::Llm)?;
+
+        let mut response_text = String::new();
+        let mut tool_calls = Vec::new();
+
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(StreamEvent::ContentDelta(token)) => {
+                    response_text.push_str(&token);
+                }
+                Ok(StreamEvent::ToolCallComplete(tc)) => {
+                    // Check: subagents must not call spawn_agent.
+                    if tc.function.name == "spawn_agent" {
+                        return Err(AgentError::NestingForbidden);
+                    }
+                    tool_calls.push(tc);
+                }
+                Ok(StreamEvent::Done(_)) => {
+                    break;
+                }
+                Err(tmg_llm::LlmError::Cancelled) => {
+                    return Err(AgentError::Cancelled);
+                }
+                Err(e) => {
+                    return Err(AgentError::Llm(e));
+                }
+            }
+        }
+
+        Ok((response_text, tool_calls))
+    }
+
+    /// Execute tool calls in parallel via `JoinSet`.
+    async fn dispatch_tool_calls(&mut self, tool_calls: &[ToolCall]) -> Result<(), AgentError> {
+        let mut join_set = JoinSet::new();
+
+        for tc in tool_calls {
+            let registry = Arc::clone(&self.registry);
+            let name = tc.function.name.clone();
+            let arguments_str = tc.function.arguments.clone();
+            let call_id = tc.id.clone();
+            let cancel = self.cancel.clone();
+
+            join_set.spawn(async move {
+                if cancel.is_cancelled() {
+                    return (call_id, Err(AgentError::Cancelled));
+                }
+
+                let params: serde_json::Value = match serde_json::from_str(&arguments_str) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let result =
+                            tmg_tools::ToolResult::error(format!("invalid JSON arguments: {e}"));
+                        return (call_id, Ok(result));
+                    }
+                };
+
+                match registry.execute(&name, params).await {
+                    Ok(tool_result) => (call_id, Ok(tool_result)),
+                    Err(e) => {
+                        let error_result = tmg_tools::ToolResult::error(e.to_string());
+                        (call_id, Ok(error_result))
+                    }
+                }
+            });
+        }
+
+        let mut results: Vec<(String, tmg_tools::ToolResult)> =
+            Vec::with_capacity(tool_calls.len());
+
+        while let Some(join_result) = join_set.join_next().await {
+            let (call_id, tool_result) = join_result.map_err(|e| AgentError::JoinError {
+                message: e.to_string(),
+            })?;
+
+            let tool_result = tool_result?;
+            results.push((call_id, tool_result));
+        }
+
+        // Sort results to match original order for deterministic history.
+        let call_order: Vec<&str> = tool_calls.iter().map(|tc| tc.id.as_str()).collect();
+        results.sort_by_key(|(id, _)| {
+            call_order
+                .iter()
+                .position(|&cid| cid == id)
+                .unwrap_or(usize::MAX)
+        });
+
+        for (call_id, tool_result) in results {
+            self.history
+                .push(SubagentMessage::tool_result(call_id, tool_result.output));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/tmg-agents/src/status.rs
+++ b/crates/tmg-agents/src/status.rs
@@ -1,9 +1,8 @@
-//! Subagent status with type-level state transitions.
+//! Subagent status with enum-based state transitions.
 //!
-//! Uses an enum with explicit transition methods to prevent invalid
-//! state changes at the type level. The `transition_to_running`,
-//! `complete`, and `fail` methods consume the status value and return
-//! the new status, enforcing valid transitions.
+//! Uses `&mut self` methods that return `bool` to indicate success,
+//! preventing invalid state changes while allowing ergonomic in-place
+//! mutation without requiring `clone()`.
 
 /// The lifecycle status of a subagent instance.
 ///
@@ -38,41 +37,53 @@ pub enum SubagentStatus {
 impl SubagentStatus {
     /// Transition from `Pending` to `Running`.
     ///
-    /// Returns `None` if the current status is not `Pending`.
-    pub fn transition_to_running(self) -> Option<Self> {
-        match self {
-            Self::Pending => Some(Self::Running),
-            _ => None,
+    /// Returns `true` if the transition was applied, `false` if the
+    /// current status is not `Pending`.
+    pub fn transition_to_running(&mut self) -> bool {
+        if matches!(self, Self::Pending) {
+            *self = Self::Running;
+            true
+        } else {
+            false
         }
     }
 
     /// Transition from `Running` to `Completed` with a result.
     ///
-    /// Returns `None` if the current status is not `Running`.
-    pub fn complete(self, result: String) -> Option<Self> {
-        match self {
-            Self::Running => Some(Self::Completed { result }),
-            _ => None,
+    /// Returns `true` if the transition was applied, `false` if the
+    /// current status is not `Running`.
+    pub fn complete(&mut self, result: String) -> bool {
+        if matches!(self, Self::Running) {
+            *self = Self::Completed { result };
+            true
+        } else {
+            false
         }
     }
 
     /// Transition from `Running` to `Failed` with an error message.
     ///
-    /// Returns `None` if the current status is not `Running`.
-    pub fn fail(self, error: String) -> Option<Self> {
-        match self {
-            Self::Running => Some(Self::Failed { error }),
-            _ => None,
+    /// Returns `true` if the transition was applied, `false` if the
+    /// current status is not `Running`.
+    pub fn fail(&mut self, error: String) -> bool {
+        if matches!(self, Self::Running) {
+            *self = Self::Failed { error };
+            true
+        } else {
+            false
         }
     }
 
     /// Transition from `Running` to `Cancelled`.
     ///
-    /// Returns `None` if the current status is not `Running`.
-    pub fn cancel(self) -> Option<Self> {
-        match self {
-            Self::Running => Some(Self::Cancelled),
-            _ => None,
+    /// Returns `true` if the transition was applied, `false` if the
+    /// current status is not `Running`.
+    pub fn cancel(&mut self) -> bool {
+        if matches!(self, Self::Running) {
+            *self = Self::Cancelled;
+            true
+        } else {
+            false
         }
     }
 
@@ -97,14 +108,24 @@ impl SubagentStatus {
     }
 }
 
+/// Truncate a string to at most `max_chars` characters, returning a
+/// `&str` slice. This is safe for multi-byte UTF-8 (CJK, emoji, etc.)
+/// because it uses `char_indices` to find the correct byte boundary.
+pub fn truncate_str(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((byte_idx, _)) => &s[..byte_idx],
+        None => s,
+    }
+}
+
 impl std::fmt::Display for SubagentStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Pending => write!(f, "pending"),
             Self::Running => write!(f, "running"),
             Self::Completed { result } => {
-                let preview = if result.len() > 80 {
-                    format!("{}...", &result[..77])
+                let preview = if result.chars().count() > 80 {
+                    format!("{}...", truncate_str(result, 77))
                 } else {
                     result.clone()
                 };
@@ -122,65 +143,63 @@ mod tests {
 
     #[test]
     fn pending_to_running() {
-        let status = SubagentStatus::Pending;
-        let status = status.transition_to_running();
-        assert_eq!(status, Some(SubagentStatus::Running));
+        let mut status = SubagentStatus::Pending;
+        assert!(status.transition_to_running());
+        assert_eq!(status, SubagentStatus::Running);
     }
 
     #[test]
     fn running_to_completed() {
-        let status = SubagentStatus::Running;
-        let status = status.complete("done".to_owned());
+        let mut status = SubagentStatus::Running;
+        assert!(status.complete("done".to_owned()));
         assert_eq!(
             status,
-            Some(SubagentStatus::Completed {
+            SubagentStatus::Completed {
                 result: "done".to_owned()
-            })
+            }
         );
     }
 
     #[test]
     fn running_to_failed() {
-        let status = SubagentStatus::Running;
-        let status = status.fail("oops".to_owned());
+        let mut status = SubagentStatus::Running;
+        assert!(status.fail("oops".to_owned()));
         assert_eq!(
             status,
-            Some(SubagentStatus::Failed {
+            SubagentStatus::Failed {
                 error: "oops".to_owned()
-            })
+            }
         );
     }
 
     #[test]
     fn running_to_cancelled() {
-        let status = SubagentStatus::Running;
-        let status = status.cancel();
-        assert_eq!(status, Some(SubagentStatus::Cancelled));
+        let mut status = SubagentStatus::Running;
+        assert!(status.cancel());
+        assert_eq!(status, SubagentStatus::Cancelled);
     }
 
     #[test]
     fn invalid_pending_to_completed() {
-        let status = SubagentStatus::Pending;
-        let result = status.complete("done".to_owned());
-        assert!(result.is_none());
+        let mut status = SubagentStatus::Pending;
+        assert!(!status.complete("done".to_owned()));
+        assert_eq!(status, SubagentStatus::Pending);
     }
 
     #[test]
     fn invalid_completed_to_running() {
-        let status = SubagentStatus::Completed {
+        let mut status = SubagentStatus::Completed {
             result: "done".to_owned(),
         };
-        let result = status.transition_to_running();
-        assert!(result.is_none());
+        assert!(!status.transition_to_running());
     }
 
     #[test]
     fn invalid_failed_to_completed() {
-        let status = SubagentStatus::Failed {
+        let mut status = SubagentStatus::Failed {
             error: "err".to_owned(),
         };
-        let result = status.complete("done".to_owned());
-        assert!(result.is_none());
+        assert!(!status.complete("done".to_owned()));
     }
 
     #[test]
@@ -221,5 +240,34 @@ mod tests {
             "failed"
         );
         assert_eq!(SubagentStatus::Cancelled.label(), "cancelled");
+    }
+
+    #[test]
+    fn truncate_str_ascii() {
+        assert_eq!(truncate_str("hello world", 5), "hello");
+        assert_eq!(truncate_str("hi", 10), "hi");
+    }
+
+    #[test]
+    fn truncate_str_multibyte() {
+        // CJK characters are 3 bytes each in UTF-8.
+        let cjk = "あいうえお";
+        assert_eq!(truncate_str(cjk, 3), "あいう");
+        assert_eq!(truncate_str(cjk, 10), cjk);
+    }
+
+    #[test]
+    fn truncate_str_emoji() {
+        let emoji = "😀😁😂🤣😃";
+        assert_eq!(truncate_str(emoji, 2), "😀😁");
+    }
+
+    #[test]
+    fn display_completed_truncates_long_result() {
+        let long = "あ".repeat(100);
+        let display = SubagentStatus::Completed { result: long }.to_string();
+        assert!(display.starts_with("completed: "));
+        assert!(display.ends_with("..."));
+        // Should not panic on multi-byte truncation.
     }
 }

--- a/crates/tmg-agents/src/status.rs
+++ b/crates/tmg-agents/src/status.rs
@@ -1,0 +1,225 @@
+//! Subagent status with type-level state transitions.
+//!
+//! Uses an enum with explicit transition methods to prevent invalid
+//! state changes at the type level. The `transition_to_running`,
+//! `complete`, and `fail` methods consume the status value and return
+//! the new status, enforcing valid transitions.
+
+/// The lifecycle status of a subagent instance.
+///
+/// Valid transitions:
+/// - `Pending` -> `Running`
+/// - `Running` -> `Completed`
+/// - `Running` -> `Failed`
+/// - `Running` -> `Cancelled`
+///
+/// Invalid transitions (e.g. `Pending` -> `Completed`) are prevented
+/// by the typed transition methods which check the current variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubagentStatus {
+    /// The subagent has been created but not yet started.
+    Pending,
+    /// The subagent is currently executing.
+    Running,
+    /// The subagent completed successfully with a result.
+    Completed {
+        /// The subagent's final output text.
+        result: String,
+    },
+    /// The subagent failed with an error.
+    Failed {
+        /// The error message.
+        error: String,
+    },
+    /// The subagent was cancelled before completion.
+    Cancelled,
+}
+
+impl SubagentStatus {
+    /// Transition from `Pending` to `Running`.
+    ///
+    /// Returns `None` if the current status is not `Pending`.
+    pub fn transition_to_running(self) -> Option<Self> {
+        match self {
+            Self::Pending => Some(Self::Running),
+            _ => None,
+        }
+    }
+
+    /// Transition from `Running` to `Completed` with a result.
+    ///
+    /// Returns `None` if the current status is not `Running`.
+    pub fn complete(self, result: String) -> Option<Self> {
+        match self {
+            Self::Running => Some(Self::Completed { result }),
+            _ => None,
+        }
+    }
+
+    /// Transition from `Running` to `Failed` with an error message.
+    ///
+    /// Returns `None` if the current status is not `Running`.
+    pub fn fail(self, error: String) -> Option<Self> {
+        match self {
+            Self::Running => Some(Self::Failed { error }),
+            _ => None,
+        }
+    }
+
+    /// Transition from `Running` to `Cancelled`.
+    ///
+    /// Returns `None` if the current status is not `Running`.
+    pub fn cancel(self) -> Option<Self> {
+        match self {
+            Self::Running => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+
+    /// Whether this status represents a terminal state (completed,
+    /// failed, or cancelled).
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Completed { .. } | Self::Failed { .. } | Self::Cancelled
+        )
+    }
+
+    /// A short human-readable label for the status.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Completed { .. } => "completed",
+            Self::Failed { .. } => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl std::fmt::Display for SubagentStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::Running => write!(f, "running"),
+            Self::Completed { result } => {
+                let preview = if result.len() > 80 {
+                    format!("{}...", &result[..77])
+                } else {
+                    result.clone()
+                };
+                write!(f, "completed: {preview}")
+            }
+            Self::Failed { error } => write!(f, "failed: {error}"),
+            Self::Cancelled => write!(f, "cancelled"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_to_running() {
+        let status = SubagentStatus::Pending;
+        let status = status.transition_to_running();
+        assert_eq!(status, Some(SubagentStatus::Running));
+    }
+
+    #[test]
+    fn running_to_completed() {
+        let status = SubagentStatus::Running;
+        let status = status.complete("done".to_owned());
+        assert_eq!(
+            status,
+            Some(SubagentStatus::Completed {
+                result: "done".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn running_to_failed() {
+        let status = SubagentStatus::Running;
+        let status = status.fail("oops".to_owned());
+        assert_eq!(
+            status,
+            Some(SubagentStatus::Failed {
+                error: "oops".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn running_to_cancelled() {
+        let status = SubagentStatus::Running;
+        let status = status.cancel();
+        assert_eq!(status, Some(SubagentStatus::Cancelled));
+    }
+
+    #[test]
+    fn invalid_pending_to_completed() {
+        let status = SubagentStatus::Pending;
+        let result = status.complete("done".to_owned());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn invalid_completed_to_running() {
+        let status = SubagentStatus::Completed {
+            result: "done".to_owned(),
+        };
+        let result = status.transition_to_running();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn invalid_failed_to_completed() {
+        let status = SubagentStatus::Failed {
+            error: "err".to_owned(),
+        };
+        let result = status.complete("done".to_owned());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn is_terminal() {
+        assert!(!SubagentStatus::Pending.is_terminal());
+        assert!(!SubagentStatus::Running.is_terminal());
+        assert!(
+            SubagentStatus::Completed {
+                result: String::new()
+            }
+            .is_terminal()
+        );
+        assert!(
+            SubagentStatus::Failed {
+                error: String::new()
+            }
+            .is_terminal()
+        );
+        assert!(SubagentStatus::Cancelled.is_terminal());
+    }
+
+    #[test]
+    fn label_values() {
+        assert_eq!(SubagentStatus::Pending.label(), "pending");
+        assert_eq!(SubagentStatus::Running.label(), "running");
+        assert_eq!(
+            SubagentStatus::Completed {
+                result: String::new()
+            }
+            .label(),
+            "completed"
+        );
+        assert_eq!(
+            SubagentStatus::Failed {
+                error: String::new()
+            }
+            .label(),
+            "failed"
+        );
+        assert_eq!(SubagentStatus::Cancelled.label(), "cancelled");
+    }
+}

--- a/crates/tmg-agents/src/tools/mod.rs
+++ b/crates/tmg-agents/src/tools/mod.rs
@@ -1,0 +1,5 @@
+//! Tools provided by the agents crate.
+
+mod spawn_agent;
+
+pub use spawn_agent::SpawnAgentTool;

--- a/crates/tmg-agents/src/tools/spawn_agent.rs
+++ b/crates/tmg-agents/src/tools/spawn_agent.rs
@@ -20,8 +20,11 @@ use crate::manager::SubagentManager;
 
 /// A tool that spawns subagents from the main agent loop.
 ///
-/// When `background` is `false` (default), the tool awaits the
-/// subagent's completion and returns its result as the tool output.
+/// When `background` is `false` (default), the tool acquires the
+/// manager lock to spawn (obtaining the ID and a oneshot receiver),
+/// then **drops the lock** and awaits the oneshot. This avoids holding
+/// the lock for the entire subagent lifetime, which would freeze the
+/// TUI's periodic `refresh_subagent_summaries` calls.
 ///
 /// When `background` is `true`, the tool spawns the subagent, returns
 /// its ID immediately, and the subagent runs concurrently.
@@ -112,19 +115,34 @@ impl Tool for SpawnAgentTool {
                 background,
             };
 
-            let mut manager = self.manager.lock().await;
-
             if background {
-                let id = manager.spawn(config).await;
+                // Background: acquire lock, spawn, release lock, return ID.
+                let id = {
+                    let mut manager = self.manager.lock().await;
+                    manager.spawn(config).await
+                };
                 Ok(ToolResult::success(format!(
                     "Subagent spawned in background with ID {id}. \
                      It will run concurrently and results will be \
                      available when it completes."
                 )))
             } else {
-                match manager.spawn_and_wait(config).await {
-                    Ok(result) => Ok(ToolResult::success(result)),
-                    Err(e) => Ok(ToolResult::error(format!("Subagent failed: {e}"))),
+                // Foreground: acquire lock, spawn with oneshot notification,
+                // release lock, then await the oneshot receiver. This
+                // ensures the TUI can still acquire the lock for
+                // `refresh_subagent_summaries` while the subagent runs.
+                let (_id, rx) = {
+                    let mut manager = self.manager.lock().await;
+                    manager.spawn_with_notify(config).await
+                };
+                // Lock is now dropped -- the TUI can freely poll summaries.
+
+                match rx.await {
+                    Ok(Ok(output)) => Ok(ToolResult::success(output)),
+                    Ok(Err(e)) => Ok(ToolResult::error(format!("Subagent failed: {e}"))),
+                    Err(_) => Ok(ToolResult::error(
+                        "Subagent task dropped without producing a result".to_owned(),
+                    )),
                 }
             }
         })

--- a/crates/tmg-agents/src/tools/spawn_agent.rs
+++ b/crates/tmg-agents/src/tools/spawn_agent.rs
@@ -1,0 +1,132 @@
+//! The `spawn_agent` tool: spawns a subagent from the main agent loop.
+//!
+//! Parameters:
+//! - `agent_type` (string, required): one of `"explore"`, `"worker"`, `"plan"`
+//! - `task` (string, required): the task description for the subagent
+//! - `background` (boolean, optional, default: `false`): whether to run
+//!   in the background
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use tmg_tools::ToolError;
+use tmg_tools::types::{Tool, ToolResult};
+
+use crate::config::{AgentType, SubagentConfig};
+use crate::manager::SubagentManager;
+
+/// A tool that spawns subagents from the main agent loop.
+///
+/// When `background` is `false` (default), the tool awaits the
+/// subagent's completion and returns its result as the tool output.
+///
+/// When `background` is `true`, the tool spawns the subagent, returns
+/// its ID immediately, and the subagent runs concurrently.
+pub struct SpawnAgentTool {
+    /// Shared reference to the subagent manager.
+    manager: Arc<Mutex<SubagentManager>>,
+}
+
+impl SpawnAgentTool {
+    /// Create a new `spawn_agent` tool backed by the given manager.
+    pub fn new(manager: Arc<Mutex<SubagentManager>>) -> Self {
+        Self { manager }
+    }
+}
+
+impl Tool for SpawnAgentTool {
+    fn name(&self) -> &'static str {
+        "spawn_agent"
+    }
+
+    fn description(&self) -> &'static str {
+        "Spawn a subagent to perform a task. Available types: \
+         'explore' (read-only codebase exploration), \
+         'worker' (full tool access), \
+         'plan' (read-only planning). \
+         Set background=true to run asynchronously."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "agent_type": {
+                    "type": "string",
+                    "enum": ["explore", "worker", "plan"],
+                    "description": "The type of subagent to spawn."
+                },
+                "task": {
+                    "type": "string",
+                    "description": "The task description for the subagent."
+                },
+                "background": {
+                    "type": "boolean",
+                    "description": "If true, the subagent runs in the background and the tool returns immediately with an ID. Default: false.",
+                    "default": false
+                }
+            },
+            "required": ["agent_type", "task"]
+        })
+    }
+
+    fn execute(
+        &self,
+        params: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult, ToolError>> + Send + '_>> {
+        Box::pin(async move {
+            let agent_type_str = params
+                .get("agent_type")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| ToolError::InvalidParams {
+                    message: "missing required parameter: agent_type".to_owned(),
+                })?;
+
+            let agent_type =
+                AgentType::from_name(agent_type_str).ok_or_else(|| ToolError::InvalidParams {
+                    message: format!(
+                        "unknown agent_type: {agent_type_str}. \
+                         Valid types: explore, worker, plan"
+                    ),
+                })?;
+
+            let task = params
+                .get("task")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| ToolError::InvalidParams {
+                    message: "missing required parameter: task".to_owned(),
+                })?
+                .to_owned();
+
+            let background = params
+                .get("background")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+
+            let config = SubagentConfig {
+                agent_type,
+                task,
+                background,
+            };
+
+            let mut manager = self.manager.lock().await;
+
+            if background {
+                let id = manager.spawn(config).await;
+                Ok(ToolResult::success(format!(
+                    "Subagent spawned in background with ID {id}. \
+                     It will run concurrently and results will be \
+                     available when it completes."
+                )))
+            } else {
+                match manager.spawn_and_wait(config).await {
+                    Ok(result) => Ok(ToolResult::success(result)),
+                    Err(e) => Ok(ToolResult::error(format!("Subagent failed: {e}"))),
+                }
+            }
+        })
+    }
+}

--- a/crates/tmg-tui/Cargo.toml
+++ b/crates/tmg-tui/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 tmg-core = { workspace = true }
 tmg-llm = { workspace = true }
+tmg-agents = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 tokio = { workspace = true, features = ["signal", "sync"] }

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -4,7 +4,7 @@ use std::fmt::Write as _;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use tmg_agents::{AgentType, SubagentManager, SubagentSummary};
+use tmg_agents::{AgentType, SubagentManager, SubagentSummary, truncate_str};
 use tmg_core::{AgentLoop, CoreError, StreamSink};
 use tmg_llm::Role;
 use tokio::sync::Mutex;
@@ -392,8 +392,8 @@ impl App {
         if !self.subagent_summaries.is_empty() {
             text.push_str("\nActive subagents:\n");
             for summary in &self.subagent_summaries {
-                let task_preview = if summary.task.len() > 60 {
-                    format!("{}...", &summary.task[..57])
+                let task_preview = if summary.task.chars().count() > 60 {
+                    format!("{}...", truncate_str(&summary.task, 57))
                 } else {
                     summary.task.clone()
                 };

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -1,9 +1,13 @@
 //! Application state and business logic for the TUI.
 
+use std::fmt::Write as _;
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use tmg_agents::{AgentType, SubagentManager, SubagentSummary};
 use tmg_core::{AgentLoop, CoreError, StreamSink};
 use tmg_llm::Role;
+use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -123,6 +127,12 @@ pub struct App {
 
     /// Handle for the currently running turn, if any.
     turn_handle: Option<TurnHandle>,
+
+    /// Shared reference to the subagent manager for status display.
+    subagent_manager: Option<Arc<Mutex<SubagentManager>>>,
+
+    /// Cached subagent summaries for display (updated periodically).
+    subagent_summaries: Vec<SubagentSummary>,
 }
 
 impl App {
@@ -143,7 +153,14 @@ impl App {
             cwd,
             error_message: None,
             turn_handle: None,
+            subagent_manager: None,
+            subagent_summaries: Vec::new(),
         }
+    }
+
+    /// Set the subagent manager for status display.
+    pub fn set_subagent_manager(&mut self, manager: Arc<Mutex<SubagentManager>>) {
+        self.subagent_manager = Some(manager);
     }
 
     /// Whether the application should exit.
@@ -209,6 +226,30 @@ impl App {
     /// Clear the error message.
     pub fn clear_error(&mut self) {
         self.error_message = None;
+    }
+
+    /// Return the cached subagent summaries for display.
+    pub fn subagent_summaries(&self) -> &[SubagentSummary] {
+        &self.subagent_summaries
+    }
+
+    /// Return the count of running subagents from cached summaries.
+    pub fn running_subagent_count(&self) -> usize {
+        self.subagent_summaries
+            .iter()
+            .filter(|s| !s.status.is_terminal())
+            .count()
+    }
+
+    /// Refresh the cached subagent summaries from the manager.
+    ///
+    /// This is called periodically from the event loop to update
+    /// the TUI display.
+    pub async fn refresh_subagent_summaries(&mut self) {
+        if let Some(manager) = &self.subagent_manager {
+            let manager = manager.lock().await;
+            self.subagent_summaries = manager.summaries().await;
+        }
     }
 
     /// Insert a character at the cursor position.
@@ -326,11 +367,51 @@ impl App {
                     agent.clear_history(&self.project_root, &self.cwd)?;
                 }
             }
+            "agents" => {
+                self.show_agents_list();
+            }
             other => {
                 self.error_message = Some(format!("Unknown command: /{other}"));
             }
         }
         Ok(())
+    }
+
+    /// Display the list of available subagent types and running subagents.
+    fn show_agents_list(&mut self) {
+        let mut text = String::from("Available subagent types:\n");
+        for agent_type in AgentType::ALL {
+            let _ = writeln!(
+                text,
+                "  - {}: {}",
+                agent_type.name(),
+                agent_type.description()
+            );
+        }
+
+        if !self.subagent_summaries.is_empty() {
+            text.push_str("\nActive subagents:\n");
+            for summary in &self.subagent_summaries {
+                let task_preview = if summary.task.len() > 60 {
+                    format!("{}...", &summary.task[..57])
+                } else {
+                    summary.task.clone()
+                };
+                let _ = writeln!(
+                    text,
+                    "  [{}] {} ({}): {}",
+                    summary.id,
+                    summary.agent_type,
+                    summary.status.label(),
+                    task_preview,
+                );
+            }
+        }
+
+        self.chat_entries.push(ChatEntry {
+            role: Role::System,
+            text,
+        });
     }
 
     /// Start a conversation turn in a background task.

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -1,6 +1,6 @@
 //! Event loop: polls terminal events and drives the application.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::DefaultTerminal;
@@ -15,6 +15,13 @@ use crate::ui;
 /// This controls how often the TUI checks for new terminal events
 /// and redraws the screen during streaming.
 const TICK_RATE: Duration = Duration::from_millis(33); // ~30 fps
+
+/// Minimum interval between subagent summary refreshes.
+///
+/// Refreshing every tick (~33ms) is excessive since it acquires a
+/// `tokio::sync::Mutex` lock. Once per second is sufficient for
+/// human-readable status updates.
+const SUBAGENT_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Run the TUI event loop.
 ///
@@ -38,12 +45,20 @@ pub async fn run_event_loop(
     app: &mut App,
     cancel: CancellationToken,
 ) -> Result<(), TuiError> {
+    let mut last_subagent_refresh = Instant::now()
+        .checked_sub(SUBAGENT_REFRESH_INTERVAL)
+        .unwrap_or_else(Instant::now);
+
     loop {
         // Drain any pending turn messages before drawing.
         app.drain_turn_messages();
 
-        // Refresh subagent summaries for display.
-        app.refresh_subagent_summaries().await;
+        // Refresh subagent summaries at a throttled rate (once per second)
+        // to avoid excessive lock contention with the manager mutex.
+        if last_subagent_refresh.elapsed() >= SUBAGENT_REFRESH_INTERVAL {
+            app.refresh_subagent_summaries().await;
+            last_subagent_refresh = Instant::now();
+        }
 
         // Draw the current state.
         terminal.draw(|frame| ui::draw(frame, app))?;

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -42,6 +42,9 @@ pub async fn run_event_loop(
         // Drain any pending turn messages before drawing.
         app.drain_turn_messages();
 
+        // Refresh subagent summaries for display.
+        app.refresh_subagent_summaries().await;
+
         // Draw the current state.
         terminal.draw(|frame| ui::draw(frame, app))?;
 

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -12,8 +12,11 @@ pub use app::App;
 pub use error::TuiError;
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use tmg_agents::SubagentManager;
 use tmg_core::AgentLoop;
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 /// Run the TUI application.
@@ -29,6 +32,7 @@ use tokio_util::sync::CancellationToken;
 /// * `cancel` - Cancellation token for graceful shutdown.
 /// * `project_root` - Project root directory for prompt file loading.
 /// * `cwd` - Current working directory for prompt file loading.
+/// * `subagent_manager` - Optional shared subagent manager for status display.
 ///
 /// # Errors
 ///
@@ -39,6 +43,7 @@ pub async fn run(
     cancel: CancellationToken,
     project_root: PathBuf,
     cwd: PathBuf,
+    subagent_manager: Option<Arc<Mutex<SubagentManager>>>,
 ) -> Result<(), TuiError> {
     // Install a panic hook that restores the terminal before printing
     // the panic message.  Without this, a panic during TUI operation
@@ -51,6 +56,10 @@ pub async fn run(
 
     let mut terminal = ratatui::init();
     let mut app = App::new(agent, model_name, project_root, cwd);
+
+    if let Some(manager) = subagent_manager {
+        app.set_subagent_manager(manager);
+    }
 
     let result = event::run_event_loop(&mut terminal, &mut app, cancel).await;
 

--- a/crates/tmg-tui/src/ui.rs
+++ b/crates/tmg-tui/src/ui.rs
@@ -34,11 +34,23 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
 }
 
-/// Draw the header bar: model name and context usage.
+/// Draw the header bar: model name, context usage, and subagent count.
 fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
+    let running_count = app.running_subagent_count();
+
+    let constraints = if running_count > 0 {
+        vec![
+            Constraint::Percentage(35),
+            Constraint::Percentage(35),
+            Constraint::Percentage(30),
+        ]
+    } else {
+        vec![Constraint::Percentage(50), Constraint::Percentage(50)]
+    };
+
     let header_layout = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .constraints(constraints)
         .split(area);
 
     let model_block = Block::default().borders(Borders::ALL).title(" Model ");
@@ -58,6 +70,18 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
     )]))
     .block(context_block);
     frame.render_widget(context_text, header_layout[1]);
+
+    if running_count > 0 {
+        let agents_block = Block::default().borders(Borders::ALL).title(" Agents ");
+        let agents_text = Paragraph::new(Line::from(vec![Span::styled(
+            format!("{running_count} running"),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        )]))
+        .block(agents_block);
+        frame.render_widget(agents_text, header_layout[2]);
+    }
 }
 
 /// Draw the main area: chat pane (left) and tool activity pane (right).
@@ -153,8 +177,28 @@ fn draw_chat_pane(frame: &mut Frame, app: &App, area: Rect) {
     }
 }
 
-/// Draw the tool activity pane showing tool call logs.
+/// Draw the tool activity pane showing tool call logs and subagent status.
 fn draw_tool_pane(frame: &mut Frame, app: &App, area: Rect) {
+    let subagent_summaries = app.subagent_summaries();
+    let has_subagents = !subagent_summaries.is_empty();
+
+    if has_subagents {
+        // Split the tool pane vertically: tool activity on top, subagent
+        // status on bottom.
+        let vertical = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .split(area);
+
+        draw_tool_activity(frame, app, vertical[0]);
+        draw_subagent_pane(frame, subagent_summaries, vertical[1]);
+    } else {
+        draw_tool_activity(frame, app, area);
+    }
+}
+
+/// Draw the tool activity log.
+fn draw_tool_activity(frame: &mut Frame, app: &App, area: Rect) {
     let block = Block::default().borders(Borders::ALL).title(" Tools ");
 
     let activity = app.tool_activity();
@@ -218,6 +262,54 @@ fn draw_tool_pane(frame: &mut Frame, app: &App, area: Rect) {
         .scroll((scroll, 0));
 
     frame.render_widget(tool_log, area);
+}
+
+/// Draw the subagent status pane.
+fn draw_subagent_pane(frame: &mut Frame, summaries: &[tmg_agents::SubagentSummary], area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title(" Subagents ");
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    for summary in summaries {
+        let status_style = match summary.status.label() {
+            "running" => Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+            "completed" => Style::default().fg(Color::Cyan),
+            "failed" => Style::default().fg(Color::Red),
+            "cancelled" => Style::default().fg(Color::Yellow),
+            _ => Style::default().fg(Color::DarkGray),
+        };
+
+        let task_preview = if summary.task.len() > 40 {
+            format!("{}...", &summary.task[..37])
+        } else {
+            summary.task.clone()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("[{}:{}] ", summary.id, summary.agent_type),
+                Style::default()
+                    .fg(Color::Magenta)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(summary.status.label(), status_style),
+        ]));
+
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(task_preview, Style::default().fg(Color::DarkGray)),
+        ]));
+
+        lines.push(Line::from(""));
+    }
+
+    let subagent_log = Paragraph::new(Text::from(lines))
+        .block(block)
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(subagent_log, area);
 }
 
 /// Draw the input area at the bottom.

--- a/crates/tmg-tui/src/ui.rs
+++ b/crates/tmg-tui/src/ui.rs
@@ -8,6 +8,8 @@ use ratatui::widgets::{
     Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap,
 };
 
+use tmg_agents::truncate_str;
+
 use crate::app::App;
 
 /// Render the full application UI into the given frame.
@@ -281,8 +283,8 @@ fn draw_subagent_pane(frame: &mut Frame, summaries: &[tmg_agents::SubagentSummar
             _ => Style::default().fg(Color::DarkGray),
         };
 
-        let task_preview = if summary.task.len() > 40 {
-            format!("{}...", &summary.task[..37])
+        let task_preview = if summary.task.chars().count() > 40 {
+            format!("{}...", truncate_str(&summary.task, 37))
         } else {
             summary.task.clone()
         };

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -8,9 +8,10 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-tokio = { workspace = true, features = ["signal"] }
+tokio = { workspace = true, features = ["signal", "sync"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
+tmg-agents = { workspace = true }
 tmg-core = { workspace = true }
 tmg-llm = { workspace = true }
 tmg-tools = { workspace = true }

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use clap::Parser;
+use tokio::sync::Mutex;
 
 /// tsumugi - a local-LLM-powered coding agent
 #[derive(Parser, Debug)]
@@ -85,7 +88,8 @@ fn run_prompt(endpoint: &str, model: &str, prompt: &str) -> anyhow::Result<()> {
 ///
 /// Launches a ratatui terminal interface with a chat pane, header,
 /// and input area. The TUI handles multi-turn conversations with
-/// streaming LLM responses.
+/// streaming LLM responses. Includes subagent support via
+/// `spawn_agent` tool.
 fn run_tui(endpoint: &str, model: &str) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
@@ -106,11 +110,30 @@ fn run_tui(endpoint: &str, model: &str) -> anyhow::Result<()> {
         // Use cwd as project root for now (could be improved with git root detection).
         let project_root = cwd.clone();
 
-        let registry = tmg_tools::default_registry();
+        // Create the subagent manager.
+        let subagent_manager = Arc::new(Mutex::new(tmg_agents::SubagentManager::new(
+            client.clone(),
+            cancel.clone(),
+        )));
+
+        // Create the tool registry with spawn_agent tool.
+        let mut registry = tmg_tools::default_registry();
+        registry.register(tmg_agents::SpawnAgentTool::new(Arc::clone(
+            &subagent_manager,
+        )));
+
         let agent =
             tmg_core::AgentLoop::new(client, registry, cancel.clone(), &project_root, &cwd)?;
 
-        tmg_tui::run(agent, model, cancel, project_root, cwd).await?;
+        tmg_tui::run(
+            agent,
+            model,
+            cancel,
+            project_root,
+            cwd,
+            Some(subagent_manager),
+        )
+        .await?;
 
         Ok::<(), anyhow::Error>(())
     })


### PR DESCRIPTION
## Summary

Implements the subagent system for issue #9, enabling independent parallel agent execution with structured lifecycle management.

### Changes

**tmg-agents crate** (new implementation):
- `SubagentStatus` enum with type-level state transitions (`Pending` -> `Running` -> `Completed`/`Failed`/`Cancelled`), enforced via consuming transition methods
- `AgentType` enum with 3 built-in types: `explore` (read-only: file_read, list_dir, grep_search), `worker` (full tool access minus spawn_agent), `plan` (read-only planning)
- `SubagentConfig` for spawn parameters (agent_type, task, background)
- `SubagentRunner`: independent agent loop with own conversation history, filtered tool registry, and CancellationToken support
- `SubagentManager`: lifecycle tracking with `tokio::task::JoinSet` for structured concurrency, graceful shutdown via `JoinSet::shutdown()`
- `SpawnAgentTool`: implements `Tool` trait, supports foreground (await result) and background (return ID immediately) modes
- Built-in registry filtering (`builtins::registry_for_agent_type`) to restrict tool access per agent type
- Nesting prevention: subagents cannot call `spawn_agent`

**tmg-tui crate** (modified):
- Subagent status pane in the tool activity area (shows running/completed/failed status per subagent)
- Running subagent count in the header bar
- `/agents` slash command displaying available subagent types and active subagent instances

**tmg-cli crate** (modified):
- Wires `SubagentManager` and `SpawnAgentTool` into the tool registry and TUI

### Crates modified
- `tmg-agents` (new modules: builtins, config, error, manager, runner, status, tools)
- `tmg-tui` (app, event, lib, ui)
- `tmg-cli` (main)

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes (151 tests, including 22 new tests for tmg-agents)
- [ ] Manual: TUI displays `/agents` output with all 3 built-in types
- [ ] Manual: `spawn_agent { agent_type: "explore", task: "..." }` returns exploration results
- [ ] Manual: `background: true` shows subagent status in TUI pane

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)