### PR TITLE
Context compression and token count integration

### DIFF
--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -12,6 +12,7 @@ use tokio_util::sync::CancellationToken;
 use tmg_llm::{LlmClient, StreamEvent, ToolCall, ToolDefinition};
 use tmg_tools::ToolRegistry;
 
+use crate::context::{ContextCompressor, ContextConfig, TokenCounter, truncate_tool_result};
 use crate::error::CoreError;
 use crate::message::Message;
 use crate::prompt;
@@ -75,6 +76,12 @@ pub trait StreamSink {
 /// using a [`JoinSet`]. The loop continues sending tool results back
 /// to the LLM until it produces a final text-only response (or the
 /// maximum round count is reached).
+/// Number of recent messages to preserve during compression.
+///
+/// These messages are never summarized to ensure the model has
+/// immediate context for the current task.
+const PRESERVE_RECENT_MESSAGES: usize = 6;
+
 pub struct AgentLoop {
     /// The LLM client used to send requests.
     client: LlmClient,
@@ -90,6 +97,15 @@ pub struct AgentLoop {
 
     /// Cancellation token for graceful shutdown.
     cancel: CancellationToken,
+
+    /// Context window configuration.
+    context_config: ContextConfig,
+
+    /// Async token counter for tracking context usage.
+    token_counter: TokenCounter,
+
+    /// Context compressor for automatic and manual compression.
+    compressor: ContextCompressor,
 }
 
 impl AgentLoop {
@@ -109,6 +125,29 @@ impl AgentLoop {
         project_root: &Path,
         cwd: &Path,
     ) -> Result<Self, CoreError> {
+        Self::with_context_config(
+            client,
+            registry,
+            cancel,
+            project_root,
+            cwd,
+            ContextConfig::default(),
+        )
+    }
+
+    /// Create a new agent loop with tool support and custom context config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError::Io`] if a prompt file exists but cannot be read.
+    pub fn with_context_config(
+        client: LlmClient,
+        registry: ToolRegistry,
+        cancel: CancellationToken,
+        project_root: &Path,
+        cwd: &Path,
+        context_config: ContextConfig,
+    ) -> Result<Self, CoreError> {
         let mut history = vec![Message::system(DEFAULT_SYSTEM_PROMPT)];
 
         // Load prompt files and inject as initial messages.
@@ -117,6 +156,8 @@ impl AgentLoop {
 
         let tool_defs = registry.tool_definitions();
         let registry = Arc::new(registry);
+        let token_counter = TokenCounter::new(client.clone());
+        let compressor = ContextCompressor::new(client.clone());
 
         Ok(Self {
             client,
@@ -124,6 +165,9 @@ impl AgentLoop {
             tool_defs,
             history,
             cancel,
+            context_config,
+            token_counter,
+            compressor,
         })
     }
 
@@ -154,6 +198,55 @@ impl AgentLoop {
         let prompt_messages = prompt::load_prompt_files(project_root, cwd)?;
         history.extend(prompt_messages);
         self.history = history;
+        Ok(())
+    }
+
+    /// Return the context configuration.
+    pub fn context_config(&self) -> &ContextConfig {
+        &self.context_config
+    }
+
+    /// Return the current cached token count.
+    pub fn token_count(&self) -> usize {
+        self.token_counter.cached_count()
+    }
+
+    /// Request an asynchronous token count update for the current history.
+    pub async fn update_token_count(&self) {
+        self.token_counter.request_update(&self.history).await;
+    }
+
+    /// Manually compress the context (used by `/compact` command).
+    ///
+    /// # Cancel safety
+    ///
+    /// If the [`CancellationToken`] is cancelled during compression,
+    /// the history remains unchanged and [`CoreError::Cancelled`] is
+    /// returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] on LLM communication failure or cancellation.
+    pub async fn compact(&mut self) -> Result<(), CoreError> {
+        let new_history = self
+            .compressor
+            .compress(&self.history, self.cancel.clone(), PRESERVE_RECENT_MESSAGES)
+            .await?;
+        self.history = new_history;
+        // Update token count after compression.
+        self.token_counter.request_update(&self.history).await;
+        Ok(())
+    }
+
+    /// Check if context compression should be auto-triggered and
+    /// compress if needed. Called after each turn completes.
+    async fn maybe_auto_compress(&mut self) -> Result<(), CoreError> {
+        let current_tokens = self.token_counter.cached_count();
+        let trigger = self.context_config.compression_trigger();
+
+        if current_tokens > trigger && trigger > 0 {
+            self.compact().await?;
+        }
         Ok(())
     }
 
@@ -195,6 +288,13 @@ impl AgentLoop {
                 if !response_text.is_empty() {
                     self.history.push(Message::assistant(response_text));
                 }
+
+                // Update token count and check for auto-compression.
+                self.token_counter.request_update(&self.history).await;
+                // Ignore compression errors -- a failed compression should
+                // not prevent the turn from completing successfully.
+                let _ = self.maybe_auto_compress().await;
+
                 return Ok(());
             }
 
@@ -215,6 +315,9 @@ impl AgentLoop {
             "[Agent loop terminated: maximum tool-call rounds reached]".to_owned(),
         ));
         sink.on_done()?;
+
+        // Update token count even on max-rounds termination.
+        self.token_counter.request_update(&self.history).await;
 
         Ok(())
     }
@@ -343,10 +446,11 @@ impl AgentLoop {
                 .unwrap_or(usize::MAX)
         });
 
-        // Append tool-result messages to history.
+        // Append tool-result messages to history, truncating if needed.
+        let max_tool_tokens = self.context_config.max_tool_result_tokens;
         for (call_id, _name, tool_result) in results {
-            self.history
-                .push(Message::tool_result(call_id, tool_result.output));
+            let output = truncate_tool_result(&tool_result.output, max_tool_tokens);
+            self.history.push(Message::tool_result(call_id, output));
         }
 
         Ok(())

--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -63,11 +63,22 @@ pub trait StreamSink {
     ) -> Result<(), CoreError> {
         Ok(())
     }
+
+    /// Called when a non-fatal warning occurs (e.g., auto-compression failure).
+    fn on_warning(&mut self, _message: &str) -> Result<(), CoreError> {
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
 // AgentLoop
 // ---------------------------------------------------------------------------
+
+/// Number of recent messages to preserve during compression.
+///
+/// These messages are never summarized to ensure the model has
+/// immediate context for the current task.
+const PRESERVE_RECENT_MESSAGES: usize = 6;
 
 /// An agent loop that manages conversation history, streams LLM
 /// responses, dispatches tool calls, and loops until the model is done.
@@ -76,12 +87,6 @@ pub trait StreamSink {
 /// using a [`JoinSet`]. The loop continues sending tool results back
 /// to the LLM until it produces a final text-only response (or the
 /// maximum round count is reached).
-/// Number of recent messages to preserve during compression.
-///
-/// These messages are never summarized to ensure the model has
-/// immediate context for the current task.
-const PRESERVE_RECENT_MESSAGES: usize = 6;
-
 pub struct AgentLoop {
     /// The LLM client used to send requests.
     client: LlmClient,
@@ -291,9 +296,11 @@ impl AgentLoop {
 
                 // Update token count and check for auto-compression.
                 self.token_counter.request_update(&self.history).await;
-                // Ignore compression errors -- a failed compression should
-                // not prevent the turn from completing successfully.
-                let _ = self.maybe_auto_compress().await;
+                // Surface compression errors as a warning so users know
+                // compression failed, but do not abort the turn.
+                if let Err(e) = self.maybe_auto_compress().await {
+                    sink.on_warning(&format!("auto-compression failed: {e}"))?;
+                }
 
                 return Ok(());
             }

--- a/crates/tmg-core/src/context.rs
+++ b/crates/tmg-core/src/context.rs
@@ -53,6 +53,7 @@ impl Default for ContextConfig {
 
 impl ContextConfig {
     /// The token count at which compression should trigger.
+    #[must_use]
     #[expect(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
@@ -104,6 +105,7 @@ impl TokenCounter {
     ///
     /// This value is updated asynchronously and may lag behind the
     /// actual message count by one turn.
+    #[must_use]
     #[expect(
         clippy::cast_possible_truncation,
         reason = "token counts are always well within usize range"
@@ -142,6 +144,7 @@ impl TokenCounter {
     /// Estimate token count using a simple heuristic (characters / 4).
     ///
     /// Useful when the tokenize API is unavailable.
+    #[must_use]
     pub fn estimate_tokens(text: &str) -> usize {
         // Integer division: 4 chars per token heuristic.
         (text.len() / 4).max(1)
@@ -388,6 +391,7 @@ fn find_ceil_char_boundary(s: &str, index: usize) -> usize {
 /// Format token count for display in the TUI header.
 ///
 /// Produces strings like `ctx: 2.1k/8k` or `ctx: 512/8192`.
+#[must_use]
 pub fn format_context_usage(current: usize, max: usize) -> String {
     format!(
         "ctx: {}/{}",

--- a/crates/tmg-core/src/context.rs
+++ b/crates/tmg-core/src/context.rs
@@ -60,7 +60,8 @@ impl ContextConfig {
         reason = "threshold is clamped to 0..1 and max_context_tokens fits in usize; precision loss is acceptable"
     )]
     pub fn compression_trigger(&self) -> usize {
-        (self.max_context_tokens as f64 * self.compression_threshold) as usize
+        let threshold = self.compression_threshold.clamp(0.0, 1.0);
+        (self.max_context_tokens as f64 * threshold) as usize
     }
 }
 
@@ -72,7 +73,6 @@ impl ContextConfig {
 ///
 /// Maintains a cached count that is updated asynchronously so TUI rendering
 /// is never blocked.
-#[derive(Debug)]
 pub struct TokenCounter {
     /// The LLM client used for tokenization requests.
     client: LlmClient,
@@ -80,6 +80,14 @@ pub struct TokenCounter {
     cached_count: Arc<AtomicU64>,
     /// Background task set for managing tokenization requests.
     tasks: Arc<Mutex<JoinSet<()>>>,
+}
+
+impl std::fmt::Debug for TokenCounter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenCounter")
+            .field("cached_count", &self.cached_count.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
 }
 
 impl TokenCounter {
@@ -115,6 +123,9 @@ impl TokenCounter {
         let cached = Arc::clone(&self.cached_count);
 
         let mut tasks = self.tasks.lock().await;
+        // Only the latest count matters; abort all prior tasks and drain them.
+        tasks.abort_all();
+        while tasks.join_next().await.is_some() {}
         tasks.spawn(async move {
             let count = match client.tokenize(&content).await {
                 Ok(count) => count,
@@ -251,9 +262,12 @@ impl ContextCompressor {
             // Truncate very long messages for the summary request.
             let content = msg.content();
             if content.len() > 2000 {
-                context_text.push_str(&content[..1000]);
+                let head_end = find_floor_char_boundary(content, 1000);
+                let tail_start =
+                    find_ceil_char_boundary(content, content.len().saturating_sub(500));
+                context_text.push_str(&content[..head_end]);
                 context_text.push_str("\n...(truncated)...\n");
-                context_text.push_str(&content[content.len() - 500..]);
+                context_text.push_str(&content[tail_start..]);
             } else {
                 context_text.push_str(content);
             }

--- a/crates/tmg-core/src/context.rs
+++ b/crates/tmg-core/src/context.rs
@@ -1,0 +1,528 @@
+//! Context compression and token counting for managing the LLM context window.
+//!
+//! This module provides:
+//! - [`ContextConfig`]: configuration for context window management
+//! - [`TokenCounter`]: async token counting via llama-server's `/tokenize` endpoint
+//! - [`ContextCompressor`]: automatic and manual context compression
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::Mutex;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+use tmg_llm::LlmClient;
+
+use crate::error::CoreError;
+use crate::message::Message;
+
+/// Default maximum context tokens (matches common llama.cpp defaults).
+const DEFAULT_MAX_CONTEXT_TOKENS: usize = 8192;
+
+/// Default compression threshold as a fraction of max context.
+const DEFAULT_COMPRESSION_THRESHOLD: f64 = 0.8;
+
+/// Default maximum tokens for a single tool result.
+const DEFAULT_MAX_TOOL_RESULT_TOKENS: usize = 4096;
+
+// ---------------------------------------------------------------------------
+// ContextConfig
+// ---------------------------------------------------------------------------
+
+/// Configuration for context window management.
+#[derive(Debug, Clone)]
+pub struct ContextConfig {
+    /// Maximum number of tokens in the context window.
+    pub max_context_tokens: usize,
+    /// Fraction of max context at which compression auto-triggers (0.0..=1.0).
+    pub compression_threshold: f64,
+    /// Maximum tokens allowed in a single tool result before truncation.
+    pub max_tool_result_tokens: usize,
+}
+
+impl Default for ContextConfig {
+    fn default() -> Self {
+        Self {
+            max_context_tokens: DEFAULT_MAX_CONTEXT_TOKENS,
+            compression_threshold: DEFAULT_COMPRESSION_THRESHOLD,
+            max_tool_result_tokens: DEFAULT_MAX_TOOL_RESULT_TOKENS,
+        }
+    }
+}
+
+impl ContextConfig {
+    /// The token count at which compression should trigger.
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss,
+        reason = "threshold is clamped to 0..1 and max_context_tokens fits in usize; precision loss is acceptable"
+    )]
+    pub fn compression_trigger(&self) -> usize {
+        (self.max_context_tokens as f64 * self.compression_threshold) as usize
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TokenCounter
+// ---------------------------------------------------------------------------
+
+/// Async token counter backed by llama-server's `/tokenize` endpoint.
+///
+/// Maintains a cached count that is updated asynchronously so TUI rendering
+/// is never blocked.
+#[derive(Debug)]
+pub struct TokenCounter {
+    /// The LLM client used for tokenization requests.
+    client: LlmClient,
+    /// Cached token count, updated asynchronously.
+    cached_count: Arc<AtomicU64>,
+    /// Background task set for managing tokenization requests.
+    tasks: Arc<Mutex<JoinSet<()>>>,
+}
+
+impl TokenCounter {
+    /// Create a new token counter using the given LLM client.
+    pub fn new(client: LlmClient) -> Self {
+        Self {
+            client,
+            cached_count: Arc::new(AtomicU64::new(0)),
+            tasks: Arc::new(Mutex::new(JoinSet::new())),
+        }
+    }
+
+    /// Return the last known token count.
+    ///
+    /// This value is updated asynchronously and may lag behind the
+    /// actual message count by one turn.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "token counts are always well within usize range"
+    )]
+    pub fn cached_count(&self) -> usize {
+        self.cached_count.load(Ordering::Relaxed) as usize
+    }
+
+    /// Request an async token count update for the given messages.
+    ///
+    /// Spawns a background task to count tokens via the LLM server.
+    /// The result updates `cached_count` when complete. Does not block.
+    pub async fn request_update(&self, messages: &[Message]) {
+        // Serialize all messages into a single string for counting.
+        let content = serialize_messages_for_counting(messages);
+        let client = self.client.clone();
+        let cached = Arc::clone(&self.cached_count);
+
+        let mut tasks = self.tasks.lock().await;
+        tasks.spawn(async move {
+            let count = match client.tokenize(&content).await {
+                Ok(count) => count,
+                Err(_) => {
+                    // Fall back to heuristic estimation on API failure.
+                    content.len() / 4
+                }
+            };
+            // Token counts always fit in u64.
+            cached.store(count as u64, Ordering::Relaxed);
+        });
+    }
+
+    /// Estimate token count using a simple heuristic (characters / 4).
+    ///
+    /// Useful when the tokenize API is unavailable.
+    pub fn estimate_tokens(text: &str) -> usize {
+        // Integer division: 4 chars per token heuristic.
+        (text.len() / 4).max(1)
+    }
+}
+
+/// Serialize conversation messages into a string for token counting.
+///
+/// Approximates the chat template format used by llama-server.
+fn serialize_messages_for_counting(messages: &[Message]) -> String {
+    let mut buf = String::new();
+    for msg in messages {
+        let role_tag = match msg.role() {
+            tmg_llm::Role::System => "system",
+            tmg_llm::Role::User => "user",
+            tmg_llm::Role::Assistant => "assistant",
+            tmg_llm::Role::Tool => "tool",
+        };
+        buf.push_str("<|");
+        buf.push_str(role_tag);
+        buf.push_str("|>\n");
+        buf.push_str(msg.content());
+        buf.push('\n');
+
+        // Include tool call arguments in the count.
+        if let Some(tool_calls) = msg.tool_calls() {
+            for tc in tool_calls {
+                buf.push_str(&tc.function.name);
+                buf.push('(');
+                buf.push_str(&tc.function.arguments);
+                buf.push_str(")\n");
+            }
+        }
+    }
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// ContextCompressor
+// ---------------------------------------------------------------------------
+
+/// Context compressor that summarizes old conversation turns to free
+/// context window space.
+///
+/// Compression works by:
+/// 1. Identifying old tool-result messages with large outputs
+/// 2. Asking the LLM to summarize them (compaction turn)
+/// 3. Replacing the originals with shorter summaries
+///
+/// Compression is cancellable via [`CancellationToken`].
+pub struct ContextCompressor {
+    /// The LLM client for generating summaries.
+    client: LlmClient,
+}
+
+/// The prompt used to ask the LLM to summarize old context.
+const COMPACTION_PROMPT: &str = "\
+Summarize the following conversation context concisely, preserving \
+all key technical details, file paths, code changes, and decisions. \
+Remove verbose tool outputs but keep their essential findings. \
+Output only the summary, no preamble.";
+
+impl ContextCompressor {
+    /// Create a new compressor using the given LLM client.
+    pub fn new(client: LlmClient) -> Self {
+        Self { client }
+    }
+
+    /// Compress the conversation history by summarizing old turns.
+    ///
+    /// Keeps the system prompt (first message) and the most recent
+    /// `preserve_recent` messages intact. Everything in between is
+    /// summarized into a single user-role message.
+    ///
+    /// # Cancel safety
+    ///
+    /// If the [`CancellationToken`] is cancelled during the LLM
+    /// summarization call, the original history is returned unchanged
+    /// and [`CoreError::Cancelled`] is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] on LLM communication failure or cancellation.
+    pub async fn compress(
+        &self,
+        history: &[Message],
+        cancel: CancellationToken,
+        preserve_recent: usize,
+    ) -> Result<Vec<Message>, CoreError> {
+        // We need at least a system prompt + some messages to compress.
+        let min_messages = 1 + preserve_recent + 1; // system + recent + at least 1 to compress
+        if history.len() <= min_messages {
+            // Nothing to compress.
+            return Ok(history.to_vec());
+        }
+
+        // Split: [system_prompt] [compressible...] [recent...]
+        let system_msg = &history[0];
+        let split_point = history.len().saturating_sub(preserve_recent);
+        let compressible = &history[1..split_point];
+        let recent = &history[split_point..];
+
+        if compressible.is_empty() {
+            return Ok(history.to_vec());
+        }
+
+        // Build a text representation of the compressible section.
+        let mut context_text = String::new();
+        for msg in compressible {
+            let role_label = match msg.role() {
+                tmg_llm::Role::System => "System",
+                tmg_llm::Role::User => "User",
+                tmg_llm::Role::Assistant => "Assistant",
+                tmg_llm::Role::Tool => "Tool result",
+            };
+            context_text.push_str(role_label);
+            context_text.push_str(": ");
+            // Truncate very long messages for the summary request.
+            let content = msg.content();
+            if content.len() > 2000 {
+                context_text.push_str(&content[..1000]);
+                context_text.push_str("\n...(truncated)...\n");
+                context_text.push_str(&content[content.len() - 500..]);
+            } else {
+                context_text.push_str(content);
+            }
+            context_text.push_str("\n\n");
+        }
+
+        // Ask the LLM to summarize.
+        let summary_messages = vec![
+            tmg_llm::ChatMessage {
+                role: tmg_llm::Role::System,
+                content: Some(COMPACTION_PROMPT.to_owned()),
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            tmg_llm::ChatMessage {
+                role: tmg_llm::Role::User,
+                content: Some(context_text),
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        ];
+
+        if cancel.is_cancelled() {
+            return Err(CoreError::Cancelled);
+        }
+
+        let response = tokio::select! {
+            () = cancel.cancelled() => {
+                return Err(CoreError::Cancelled);
+            }
+            result = self.client.chat(summary_messages, vec![]) => {
+                result.map_err(CoreError::Llm)?
+            }
+        };
+
+        let summary_text = response
+            .choices
+            .first()
+            .and_then(|c| c.message.content.as_deref())
+            .unwrap_or("[compression failed: no response]")
+            .to_owned();
+
+        // Build the new history: system + summary + recent
+        let mut new_history = Vec::with_capacity(2 + recent.len());
+        new_history.push(system_msg.clone());
+        new_history.push(Message::user(format!(
+            "[Context summary from previous conversation]\n\n{summary_text}"
+        )));
+        new_history.extend_from_slice(recent);
+
+        Ok(new_history)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tool result truncation
+// ---------------------------------------------------------------------------
+
+/// Truncate a tool result string if it exceeds the token limit.
+///
+/// Uses heuristic token estimation (chars / 4) for fast, non-blocking
+/// truncation. The truncated text preserves the beginning and end with
+/// an indicator of how much was removed.
+pub fn truncate_tool_result(output: &str, max_tokens: usize) -> String {
+    let estimated_tokens = TokenCounter::estimate_tokens(output);
+    if estimated_tokens <= max_tokens {
+        return output.to_owned();
+    }
+
+    // Approximate character budget from token limit (4 chars per token).
+    let char_budget = max_tokens * 4;
+    let half = char_budget / 2;
+
+    if output.len() <= char_budget {
+        return output.to_owned();
+    }
+
+    // Find safe char boundaries.
+    let start_end = find_floor_char_boundary(output, half);
+    let tail_start = find_ceil_char_boundary(output, output.len().saturating_sub(half));
+    let truncated = output.len() - start_end - (output.len() - tail_start);
+
+    format!(
+        "{}\n\n... ({truncated} bytes truncated, tool result exceeded {max_tokens} token limit) ...\n\n{}",
+        &output[..start_end],
+        &output[tail_start..],
+    )
+}
+
+/// Find the largest byte index <= `index` that is a char boundary.
+fn find_floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut i = index;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+/// Find the smallest byte index >= `index` that is a char boundary.
+fn find_ceil_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut i = index;
+    while i < s.len() && !s.is_char_boundary(i) {
+        i += 1;
+    }
+    i
+}
+
+// ---------------------------------------------------------------------------
+// Context usage formatting
+// ---------------------------------------------------------------------------
+
+/// Format token count for display in the TUI header.
+///
+/// Produces strings like `ctx: 2.1k/8k` or `ctx: 512/8192`.
+pub fn format_context_usage(current: usize, max: usize) -> String {
+    format!(
+        "ctx: {}/{}",
+        format_token_count(current),
+        format_token_count(max)
+    )
+}
+
+/// Format a token count with k-suffix for values >= 1000.
+fn format_token_count(count: usize) -> String {
+    if count >= 1000 {
+        let whole = count / 1000;
+        let frac = (count % 1000) / 100; // single decimal digit
+        if frac == 0 {
+            format!("{whole}k")
+        } else {
+            format!("{whole}.{frac}k")
+        }
+    } else {
+        count.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_config_defaults() {
+        let config = ContextConfig::default();
+        assert_eq!(config.max_context_tokens, DEFAULT_MAX_CONTEXT_TOKENS);
+        assert!(
+            (config.compression_threshold - DEFAULT_COMPRESSION_THRESHOLD).abs() < f64::EPSILON
+        );
+        assert_eq!(
+            config.max_tool_result_tokens,
+            DEFAULT_MAX_TOOL_RESULT_TOKENS
+        );
+    }
+
+    #[test]
+    fn compression_trigger_calculation() {
+        let config = ContextConfig {
+            max_context_tokens: 10_000,
+            compression_threshold: 0.8,
+            max_tool_result_tokens: 4096,
+        };
+        assert_eq!(config.compression_trigger(), 8000);
+    }
+
+    #[test]
+    fn compression_trigger_zero_threshold() {
+        let config = ContextConfig {
+            max_context_tokens: 10_000,
+            compression_threshold: 0.0,
+            max_tool_result_tokens: 4096,
+        };
+        assert_eq!(config.compression_trigger(), 0);
+    }
+
+    #[test]
+    fn format_context_usage_small() {
+        let result = format_context_usage(512, 8192);
+        assert_eq!(result, "ctx: 512/8.1k");
+    }
+
+    #[test]
+    fn format_context_usage_large() {
+        let result = format_context_usage(2100, 8000);
+        assert_eq!(result, "ctx: 2.1k/8k");
+    }
+
+    #[test]
+    fn format_context_usage_exact_k() {
+        let result = format_context_usage(2000, 8000);
+        assert_eq!(result, "ctx: 2k/8k");
+    }
+
+    #[test]
+    fn format_token_count_below_1k() {
+        assert_eq!(format_token_count(0), "0");
+        assert_eq!(format_token_count(999), "999");
+    }
+
+    #[test]
+    fn format_token_count_at_and_above_1k() {
+        assert_eq!(format_token_count(1000), "1k");
+        assert_eq!(format_token_count(1500), "1.5k");
+        assert_eq!(format_token_count(2100), "2.1k");
+        assert_eq!(format_token_count(10000), "10k");
+    }
+
+    #[test]
+    fn estimate_tokens_basic() {
+        assert_eq!(TokenCounter::estimate_tokens("abcd"), 1);
+        assert_eq!(TokenCounter::estimate_tokens("a".repeat(400).as_str()), 100);
+    }
+
+    #[test]
+    fn estimate_tokens_empty() {
+        // Empty string should return at least 1.
+        assert_eq!(TokenCounter::estimate_tokens(""), 1);
+    }
+
+    #[test]
+    fn truncate_tool_result_short() {
+        let short = "hello world";
+        let result = truncate_tool_result(short, 4096);
+        assert_eq!(result, short);
+    }
+
+    #[test]
+    fn truncate_tool_result_long() {
+        let long = "x".repeat(100_000);
+        let result = truncate_tool_result(&long, 100);
+        assert!(result.len() < long.len());
+        assert!(result.contains("truncated"));
+        assert!(result.contains("100 token limit"));
+    }
+
+    #[test]
+    fn serialize_messages_includes_tool_calls() {
+        let tc = tmg_llm::ToolCall {
+            id: "call_1".to_owned(),
+            kind: tmg_llm::ToolKind::Function,
+            function: tmg_llm::FunctionCall {
+                name: "file_read".to_owned(),
+                arguments: r#"{"path":"/tmp"}"#.to_owned(),
+            },
+        };
+        let msg = Message::assistant_with_tool_calls("thinking", vec![tc]);
+        let serialized = serialize_messages_for_counting(&[msg]);
+        assert!(serialized.contains("file_read"));
+        assert!(serialized.contains("/tmp"));
+    }
+
+    #[test]
+    fn serialize_messages_basic() {
+        let msgs = vec![
+            Message::system("You are helpful"),
+            Message::user("Hello"),
+            Message::assistant("Hi there"),
+        ];
+        let serialized = serialize_messages_for_counting(&msgs);
+        assert!(serialized.contains("<|system|>"));
+        assert!(serialized.contains("<|user|>"));
+        assert!(serialized.contains("<|assistant|>"));
+        assert!(serialized.contains("You are helpful"));
+        assert!(serialized.contains("Hello"));
+        assert!(serialized.contains("Hi there"));
+    }
+}

--- a/crates/tmg-core/src/lib.rs
+++ b/crates/tmg-core/src/lib.rs
@@ -1,10 +1,14 @@
 //! tmg-core: Core domain types, traits, and orchestration logic for tsumugi.
 
 pub mod agent_loop;
+pub mod context;
 pub mod error;
 pub mod message;
 pub mod prompt;
 
 pub use agent_loop::{AgentLoop, StreamSink};
+pub use context::{
+    ContextCompressor, ContextConfig, TokenCounter, format_context_usage, truncate_tool_result,
+};
 pub use error::CoreError;
 pub use message::Message;

--- a/crates/tmg-llm/src/client.rs
+++ b/crates/tmg-llm/src/client.rs
@@ -85,10 +85,60 @@ impl LlmClient {
         Ok(Self { http, config })
     }
 
+    /// Return the base URL of the endpoint (used for constructing API URLs).
+    pub fn endpoint(&self) -> &str {
+        &self.config.endpoint
+    }
+
     /// The chat completions endpoint URL.
     fn completions_url(&self) -> String {
         let base = self.config.endpoint.trim_end_matches('/');
         format!("{base}/v1/chat/completions")
+    }
+
+    /// The tokenize endpoint URL (llama-server specific).
+    fn tokenize_url(&self) -> String {
+        let base = self.config.endpoint.trim_end_matches('/');
+        format!("{base}/tokenize")
+    }
+
+    /// Tokenize a string and return the token count.
+    ///
+    /// Uses llama-server's `POST /tokenize` endpoint for accurate
+    /// token counting. This is more accurate than heuristic estimation
+    /// because it uses the actual model's tokenizer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LlmError`] on connection failure, timeout, or invalid response.
+    pub async fn tokenize(&self, content: &str) -> Result<usize, LlmError> {
+        let body = serde_json::json!({
+            "content": content,
+        });
+
+        let response = self
+            .http
+            .post(self.tokenize_url())
+            .json(&body)
+            .send()
+            .await
+            .map_err(classify_reqwest_error)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(LlmError::ServerError {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let resp: crate::types::TokenizeResponse = response
+            .json()
+            .await
+            .map_err(|e| LlmError::InvalidResponse(e.to_string()))?;
+
+        Ok(resp.tokens.len())
     }
 
     /// Send a non-streaming chat completion request.

--- a/crates/tmg-llm/src/lib.rs
+++ b/crates/tmg-llm/src/lib.rs
@@ -12,5 +12,5 @@ pub use pool::{EndpointHealth, LlmPool};
 pub use pool_config::{LoadBalanceStrategy, PoolConfig, PoolConfigError};
 pub use types::{
     ChatMessage, ChatRequest, ChatResponse, FunctionCall, FunctionDefinition, Role, StreamEvent,
-    ToolCall, ToolCallAccumulator, ToolCallIndexError, ToolDefinition, ToolKind,
+    TokenizeResponse, ToolCall, ToolCallAccumulator, ToolCallIndexError, ToolDefinition, ToolKind,
 };

--- a/crates/tmg-llm/src/types.rs
+++ b/crates/tmg-llm/src/types.rs
@@ -241,6 +241,17 @@ pub enum StreamEvent {
 }
 
 // ---------------------------------------------------------------------------
+// Tokenize response
+// ---------------------------------------------------------------------------
+
+/// Response from the llama-server `POST /tokenize` endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TokenizeResponse {
+    /// The token ids produced by the tokenizer.
+    pub tokens: Vec<i64>,
+}
+
+// ---------------------------------------------------------------------------
 // Tool call accumulator
 // ---------------------------------------------------------------------------
 

--- a/crates/tmg-tools/src/lib.rs
+++ b/crates/tmg-tools/src/lib.rs
@@ -6,9 +6,11 @@
 
 pub mod error;
 mod path_util;
+pub mod signatures;
 pub mod tools;
 pub mod types;
 
 pub use error::ToolError;
+pub use signatures::{Signature, extract_signatures, format_signatures};
 pub use tools::default_registry;
 pub use types::{Tool, ToolRegistry, ToolResult};

--- a/crates/tmg-tools/src/signatures.rs
+++ b/crates/tmg-tools/src/signatures.rs
@@ -33,6 +33,7 @@ pub struct Signature {
 /// are found.
 // TODO: integrate into `ContextCompressor` in tmg-core to replace large
 // tool-result file contents with structural summaries during compression.
+#[must_use]
 pub fn extract_signatures(filename: &str, source: &str) -> Option<Vec<Signature>> {
     let ext = filename.rsplit('.').next()?;
     match ext {
@@ -47,6 +48,7 @@ pub fn extract_signatures(filename: &str, source: &str) -> Option<Vec<Signature>
 ///
 /// The output shows line numbers and definition types, suitable for
 /// inclusion in compressed context.
+#[must_use]
 pub fn format_signatures(signatures: &[Signature]) -> String {
     let mut buf = String::new();
     for sig in signatures {

--- a/crates/tmg-tools/src/signatures.rs
+++ b/crates/tmg-tools/src/signatures.rs
@@ -1,0 +1,367 @@
+//! Extract function signatures and type definitions from source files.
+//!
+//! Provides a lightweight, regex-based extraction of structural definitions
+//! (function signatures, struct/class/trait definitions, impl blocks) from
+//! source code. This is used by the context compression system to replace
+//! full file contents with a structural summary, reducing token usage.
+//!
+//! Supported languages:
+//! - Rust (`.rs`)
+//! - Python (`.py`)
+//! - JavaScript / TypeScript (`.js`, `.jsx`, `.ts`, `.tsx`)
+
+use std::fmt::Write as _;
+
+use regex::Regex;
+
+/// A single extracted signature from a source file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signature {
+    /// The line number (1-based) where this signature starts.
+    pub line: usize,
+    /// The kind of definition (e.g., "fn", "struct", "class").
+    pub kind: &'static str,
+    /// The extracted signature text.
+    pub text: String,
+}
+
+/// Detect language from a file extension and extract signatures.
+///
+/// Returns `None` if the file extension is not recognized as a
+/// supported language. Returns an empty `Vec` if no signatures
+/// are found.
+pub fn extract_signatures(filename: &str, source: &str) -> Option<Vec<Signature>> {
+    let ext = filename.rsplit('.').next()?;
+    match ext {
+        "rs" => Some(extract_rust(source)),
+        "py" => Some(extract_python(source)),
+        "js" | "jsx" | "ts" | "tsx" | "mjs" | "mts" => Some(extract_javascript(source)),
+        _ => None,
+    }
+}
+
+/// Format extracted signatures into a condensed string summary.
+///
+/// The output shows line numbers and definition types, suitable for
+/// inclusion in compressed context.
+pub fn format_signatures(signatures: &[Signature]) -> String {
+    let mut buf = String::new();
+    for sig in signatures {
+        let _ = writeln!(buf, "L{}: [{}] {}", sig.line, sig.kind, sig.text);
+    }
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// Rust
+// ---------------------------------------------------------------------------
+
+fn extract_rust(source: &str) -> Vec<Signature> {
+    let mut sigs = Vec::new();
+
+    // Match function definitions (pub/pub(crate)/async/unsafe/const fn)
+    let fn_re = Regex::new(
+        r"(?m)^[[:blank:]]*((?:pub(?:\([^)]*\))?\s+)?(?:(?:async|unsafe|const)\s+)*fn\s+\w+[^{;]*)",
+    )
+    .ok();
+
+    // Match struct/enum/trait/type definitions
+    let type_re = Regex::new(
+        r"(?m)^[[:blank:]]*((?:pub(?:\([^)]*\))?\s+)?(?:struct|enum|trait|type|union)\s+\w+[^{;=]*)"
+    ).ok();
+
+    // Match impl blocks
+    let impl_re = Regex::new(
+        r"(?m)^[[:blank:]]*(impl(?:<[^>]*>)?\s+(?:\w+(?:::\w+)*(?:<[^>]*>)?\s+for\s+)?\w+(?:::\w+)*(?:<[^>]*>)?)"
+    ).ok();
+
+    // Match macro definitions
+    let macro_re =
+        Regex::new(r"(?m)^[[:blank:]]*((?:pub(?:\([^)]*\))?\s+)?macro_rules!\s+\w+)").ok();
+
+    if let Some(re) = &fn_re {
+        collect_matches(source, re, "fn", &mut sigs);
+    }
+    if let Some(re) = &type_re {
+        collect_matches(source, re, "type", &mut sigs);
+    }
+    if let Some(re) = &impl_re {
+        collect_matches(source, re, "impl", &mut sigs);
+    }
+    if let Some(re) = &macro_re {
+        collect_matches(source, re, "macro", &mut sigs);
+    }
+
+    sigs.sort_by_key(|s| s.line);
+    sigs
+}
+
+// ---------------------------------------------------------------------------
+// Python
+// ---------------------------------------------------------------------------
+
+fn extract_python(source: &str) -> Vec<Signature> {
+    let mut sigs = Vec::new();
+
+    // Match function/method definitions
+    let fn_re =
+        Regex::new(r"(?m)^[[:blank:]]*((?:async\s+)?def\s+\w+\s*\([^)]*\)(?:\s*->\s*[^\n:]+)?)")
+            .ok();
+
+    // Match class definitions
+    let class_re = Regex::new(r"(?m)^[[:blank:]]*(class\s+\w+(?:\([^)]*\))?)").ok();
+
+    if let Some(re) = &fn_re {
+        collect_matches(source, re, "def", &mut sigs);
+    }
+    if let Some(re) = &class_re {
+        collect_matches(source, re, "class", &mut sigs);
+    }
+
+    sigs.sort_by_key(|s| s.line);
+    sigs
+}
+
+// ---------------------------------------------------------------------------
+// JavaScript / TypeScript
+// ---------------------------------------------------------------------------
+
+fn extract_javascript(source: &str) -> Vec<Signature> {
+    let mut sigs = Vec::new();
+
+    // Match function declarations
+    let fn_re = Regex::new(
+        r"(?m)^[[:blank:]]*((?:export\s+)?(?:async\s+)?function\s*\*?\s*\w+\s*(?:<[^>]*>)?\s*\([^)]*\)(?:\s*:\s*[^\n{]+)?)"
+    ).ok();
+
+    // Match arrow functions assigned to const/let/var
+    let arrow_re = Regex::new(
+        r"(?m)^[[:blank:]]*((?:export\s+)?(?:const|let|var)\s+\w+\s*(?::\s*[^=]+)?\s*=\s*(?:async\s+)?(?:\([^)]*\)|[a-zA-Z_]\w*)(?:\s*:\s*[^\n=>]+)?\s*=>)"
+    ).ok();
+
+    // Match class declarations
+    let class_re = Regex::new(
+        r"(?m)^[[:blank:]]*((?:export\s+)?(?:abstract\s+)?class\s+\w+(?:<[^>]*>)?(?:\s+extends\s+\w+(?:<[^>]*>)?)?(?:\s+implements\s+[^\n{]+)?)"
+    ).ok();
+
+    // Match interface declarations (TypeScript)
+    let iface_re = Regex::new(
+        r"(?m)^[[:blank:]]*((?:export\s+)?interface\s+\w+(?:<[^>]*>)?(?:\s+extends\s+[^\n{]+)?)",
+    )
+    .ok();
+
+    // Match type alias declarations (TypeScript)
+    let type_re = Regex::new(r"(?m)^[[:blank:]]*((?:export\s+)?type\s+\w+(?:<[^>]*>)?\s*=)").ok();
+
+    if let Some(re) = &fn_re {
+        collect_matches(source, re, "function", &mut sigs);
+    }
+    if let Some(re) = &arrow_re {
+        collect_matches(source, re, "const fn", &mut sigs);
+    }
+    if let Some(re) = &class_re {
+        collect_matches(source, re, "class", &mut sigs);
+    }
+    if let Some(re) = &iface_re {
+        collect_matches(source, re, "interface", &mut sigs);
+    }
+    if let Some(re) = &type_re {
+        collect_matches(source, re, "type", &mut sigs);
+    }
+
+    sigs.sort_by_key(|s| s.line);
+    sigs
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Collect regex matches from source, computing line numbers.
+fn collect_matches(source: &str, re: &Regex, kind: &'static str, sigs: &mut Vec<Signature>) {
+    for m in re.find_iter(source) {
+        let start = m.start();
+        let line = source[..start].matches('\n').count() + 1;
+        let text = m.as_str().trim().to_owned();
+        // Skip very short matches that are likely false positives.
+        if text.len() > 3 {
+            sigs.push(Signature { line, kind, text });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_function_signatures() {
+        let source = r#"
+pub fn hello(name: &str) -> String {
+    format!("Hello, {name}")
+}
+
+async fn fetch_data(url: &str) -> Result<Data, Error> {
+    todo!()
+}
+
+pub(crate) unsafe fn raw_ptr() -> *const u8 {
+    std::ptr::null()
+}
+"#;
+        let sigs = extract_rust(source);
+        assert!(sigs.len() >= 3, "expected >= 3 sigs, got {}", sigs.len());
+        assert!(sigs.iter().any(|s| s.text.contains("pub fn hello")));
+        assert!(sigs.iter().any(|s| s.text.contains("async fn fetch_data")));
+        assert!(sigs.iter().any(|s| s.text.contains("unsafe fn raw_ptr")));
+    }
+
+    #[test]
+    fn rust_type_definitions() {
+        let source = r"
+pub struct MyStruct {
+    field: String,
+}
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+pub trait Drawable {
+    fn draw(&self);
+}
+
+impl Drawable for MyStruct {
+    fn draw(&self) {}
+}
+";
+        let sigs = extract_rust(source);
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "type" && s.text.contains("struct MyStruct"))
+        );
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "type" && s.text.contains("enum Color"))
+        );
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "type" && s.text.contains("trait Drawable"))
+        );
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "impl" && s.text.contains("impl Drawable for MyStruct"))
+        );
+    }
+
+    #[test]
+    fn python_signatures() {
+        let source = r"
+class MyClass(BaseClass):
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def fetch(self, url: str) -> dict:
+        pass
+
+def standalone_func(x: int, y: int) -> int:
+    return x + y
+";
+        let sigs = extract_python(source);
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "class" && s.text.contains("class MyClass"))
+        );
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "def" && s.text.contains("def __init__"))
+        );
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "def" && s.text.contains("async def fetch"))
+        );
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "def" && s.text.contains("def standalone_func"))
+        );
+    }
+
+    #[test]
+    fn javascript_signatures() {
+        let source = r"
+export function greet(name: string): string {
+    return `Hello, ${name}`;
+}
+
+export async function fetchData(url: string): Promise<Data> {
+    return await fetch(url);
+}
+
+const add = (a: number, b: number): number => a + b;
+
+export class UserService extends BaseService implements Serializable {
+    constructor(private db: Database) {}
+}
+
+interface Config {
+    host: string;
+    port: number;
+}
+
+export type Result<T> = { ok: true; value: T } | { ok: false; error: Error };
+";
+        let sigs = extract_javascript(source);
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "function" && s.text.contains("function greet"))
+        );
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "function" && s.text.contains("async function fetchData"))
+        );
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "class" && s.text.contains("class UserService"))
+        );
+        assert!(
+            sigs.iter()
+                .any(|s| s.kind == "interface" && s.text.contains("interface Config"))
+        );
+    }
+
+    #[test]
+    fn detect_language_from_extension() {
+        assert!(extract_signatures("main.rs", "fn main() {}").is_some());
+        assert!(extract_signatures("app.py", "def main(): pass").is_some());
+        assert!(extract_signatures("index.ts", "function main() {}").is_some());
+        assert!(extract_signatures("app.tsx", "function App() {}").is_some());
+        assert!(extract_signatures("data.json", "{}").is_none());
+    }
+
+    #[test]
+    fn format_signatures_output() {
+        let sigs = vec![
+            Signature {
+                line: 1,
+                kind: "fn",
+                text: "pub fn hello(name: &str) -> String".to_owned(),
+            },
+            Signature {
+                line: 5,
+                kind: "type",
+                text: "pub struct Config".to_owned(),
+            },
+        ];
+        let formatted = format_signatures(&sigs);
+        assert!(formatted.contains("L1: [fn] pub fn hello"));
+        assert!(formatted.contains("L5: [type] pub struct Config"));
+    }
+
+    #[test]
+    fn empty_source_returns_empty() {
+        let sigs = extract_rust("");
+        assert!(sigs.is_empty());
+    }
+}

--- a/crates/tmg-tools/src/signatures.rs
+++ b/crates/tmg-tools/src/signatures.rs
@@ -11,6 +11,7 @@
 //! - JavaScript / TypeScript (`.js`, `.jsx`, `.ts`, `.tsx`)
 
 use std::fmt::Write as _;
+use std::sync::LazyLock;
 
 use regex::Regex;
 
@@ -30,6 +31,8 @@ pub struct Signature {
 /// Returns `None` if the file extension is not recognized as a
 /// supported language. Returns an empty `Vec` if no signatures
 /// are found.
+// TODO: integrate into `ContextCompressor` in tmg-core to replace large
+// tool-result file contents with structural summaries during compression.
 pub fn extract_signatures(filename: &str, source: &str) -> Option<Vec<Signature>> {
     let ext = filename.rsplit('.').next()?;
     match ext {
@@ -57,40 +60,39 @@ pub fn format_signatures(signatures: &[Signature]) -> String {
 // ---------------------------------------------------------------------------
 
 fn extract_rust(source: &str) -> Vec<Signature> {
+    // Compile-time-known patterns: compiled once via LazyLock.
+    // unwrap is safe here because these are known-valid regex literals.
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static FN_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?m)^[[:blank:]]*((?:pub(?:\([^)]*\))?\s+)?(?:(?:async|unsafe|const)\s+)*fn\s+\w+[^{;]*)",
+        )
+        .unwrap()
+    });
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static TYPE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?m)^[[:blank:]]*((?:pub(?:\([^)]*\))?\s+)?(?:struct|enum|trait|type|union)\s+\w+[^{;=]*)",
+        )
+        .unwrap()
+    });
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static IMPL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?m)^[[:blank:]]*(impl(?:<[^>]*>)?\s+(?:\w+(?:::\w+)*(?:<[^>]*>)?\s+for\s+)?\w+(?:::\w+)*(?:<[^>]*>)?)",
+        )
+        .unwrap()
+    });
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static MACRO_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?m)^[[:blank:]]*((?:pub(?:\([^)]*\))?\s+)?macro_rules!\s+\w+)").unwrap()
+    });
+
     let mut sigs = Vec::new();
-
-    // Match function definitions (pub/pub(crate)/async/unsafe/const fn)
-    let fn_re = Regex::new(
-        r"(?m)^[[:blank:]]*((?:pub(?:\([^)]*\))?\s+)?(?:(?:async|unsafe|const)\s+)*fn\s+\w+[^{;]*)",
-    )
-    .ok();
-
-    // Match struct/enum/trait/type definitions
-    let type_re = Regex::new(
-        r"(?m)^[[:blank:]]*((?:pub(?:\([^)]*\))?\s+)?(?:struct|enum|trait|type|union)\s+\w+[^{;=]*)"
-    ).ok();
-
-    // Match impl blocks
-    let impl_re = Regex::new(
-        r"(?m)^[[:blank:]]*(impl(?:<[^>]*>)?\s+(?:\w+(?:::\w+)*(?:<[^>]*>)?\s+for\s+)?\w+(?:::\w+)*(?:<[^>]*>)?)"
-    ).ok();
-
-    // Match macro definitions
-    let macro_re =
-        Regex::new(r"(?m)^[[:blank:]]*((?:pub(?:\([^)]*\))?\s+)?macro_rules!\s+\w+)").ok();
-
-    if let Some(re) = &fn_re {
-        collect_matches(source, re, "fn", &mut sigs);
-    }
-    if let Some(re) = &type_re {
-        collect_matches(source, re, "type", &mut sigs);
-    }
-    if let Some(re) = &impl_re {
-        collect_matches(source, re, "impl", &mut sigs);
-    }
-    if let Some(re) = &macro_re {
-        collect_matches(source, re, "macro", &mut sigs);
-    }
+    collect_matches(source, &FN_RE, "fn", &mut sigs);
+    collect_matches(source, &TYPE_RE, "type", &mut sigs);
+    collect_matches(source, &IMPL_RE, "impl", &mut sigs);
+    collect_matches(source, &MACRO_RE, "macro", &mut sigs);
 
     sigs.sort_by_key(|s| s.line);
     sigs
@@ -101,22 +103,18 @@ fn extract_rust(source: &str) -> Vec<Signature> {
 // ---------------------------------------------------------------------------
 
 fn extract_python(source: &str) -> Vec<Signature> {
-    let mut sigs = Vec::new();
-
-    // Match function/method definitions
-    let fn_re =
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static FN_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?m)^[[:blank:]]*((?:async\s+)?def\s+\w+\s*\([^)]*\)(?:\s*->\s*[^\n:]+)?)")
-            .ok();
+            .unwrap()
+    });
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static CLASS_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?m)^[[:blank:]]*(class\s+\w+(?:\([^)]*\))?)").unwrap());
 
-    // Match class definitions
-    let class_re = Regex::new(r"(?m)^[[:blank:]]*(class\s+\w+(?:\([^)]*\))?)").ok();
-
-    if let Some(re) = &fn_re {
-        collect_matches(source, re, "def", &mut sigs);
-    }
-    if let Some(re) = &class_re {
-        collect_matches(source, re, "class", &mut sigs);
-    }
+    let mut sigs = Vec::new();
+    collect_matches(source, &FN_RE, "def", &mut sigs);
+    collect_matches(source, &CLASS_RE, "class", &mut sigs);
 
     sigs.sort_by_key(|s| s.line);
     sigs
@@ -127,47 +125,45 @@ fn extract_python(source: &str) -> Vec<Signature> {
 // ---------------------------------------------------------------------------
 
 fn extract_javascript(source: &str) -> Vec<Signature> {
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static FN_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?m)^[[:blank:]]*((?:export\s+)?(?:async\s+)?function\s*\*?\s*\w+\s*(?:<[^>]*>)?\s*\([^)]*\)(?:\s*:\s*[^\n{]+)?)",
+        )
+        .unwrap()
+    });
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static ARROW_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?m)^[[:blank:]]*((?:export\s+)?(?:const|let|var)\s+\w+\s*(?::\s*[^=]+)?\s*=\s*(?:async\s+)?(?:\([^)]*\)|[a-zA-Z_]\w*)(?:\s*:\s*[^\n=>]+)?\s*=>)",
+        )
+        .unwrap()
+    });
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static CLASS_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?m)^[[:blank:]]*((?:export\s+)?(?:abstract\s+)?class\s+\w+(?:<[^>]*>)?(?:\s+extends\s+\w+(?:<[^>]*>)?)?(?:\s+implements\s+[^\n{]+)?)",
+        )
+        .unwrap()
+    });
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static IFACE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?m)^[[:blank:]]*((?:export\s+)?interface\s+\w+(?:<[^>]*>)?(?:\s+extends\s+[^\n{]+)?)",
+        )
+        .unwrap()
+    });
+    #[expect(clippy::unwrap_used, reason = "compile-time-known regex pattern")]
+    static TYPE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?m)^[[:blank:]]*((?:export\s+)?type\s+\w+(?:<[^>]*>)?\s*=)").unwrap()
+    });
+
     let mut sigs = Vec::new();
-
-    // Match function declarations
-    let fn_re = Regex::new(
-        r"(?m)^[[:blank:]]*((?:export\s+)?(?:async\s+)?function\s*\*?\s*\w+\s*(?:<[^>]*>)?\s*\([^)]*\)(?:\s*:\s*[^\n{]+)?)"
-    ).ok();
-
-    // Match arrow functions assigned to const/let/var
-    let arrow_re = Regex::new(
-        r"(?m)^[[:blank:]]*((?:export\s+)?(?:const|let|var)\s+\w+\s*(?::\s*[^=]+)?\s*=\s*(?:async\s+)?(?:\([^)]*\)|[a-zA-Z_]\w*)(?:\s*:\s*[^\n=>]+)?\s*=>)"
-    ).ok();
-
-    // Match class declarations
-    let class_re = Regex::new(
-        r"(?m)^[[:blank:]]*((?:export\s+)?(?:abstract\s+)?class\s+\w+(?:<[^>]*>)?(?:\s+extends\s+\w+(?:<[^>]*>)?)?(?:\s+implements\s+[^\n{]+)?)"
-    ).ok();
-
-    // Match interface declarations (TypeScript)
-    let iface_re = Regex::new(
-        r"(?m)^[[:blank:]]*((?:export\s+)?interface\s+\w+(?:<[^>]*>)?(?:\s+extends\s+[^\n{]+)?)",
-    )
-    .ok();
-
-    // Match type alias declarations (TypeScript)
-    let type_re = Regex::new(r"(?m)^[[:blank:]]*((?:export\s+)?type\s+\w+(?:<[^>]*>)?\s*=)").ok();
-
-    if let Some(re) = &fn_re {
-        collect_matches(source, re, "function", &mut sigs);
-    }
-    if let Some(re) = &arrow_re {
-        collect_matches(source, re, "const fn", &mut sigs);
-    }
-    if let Some(re) = &class_re {
-        collect_matches(source, re, "class", &mut sigs);
-    }
-    if let Some(re) = &iface_re {
-        collect_matches(source, re, "interface", &mut sigs);
-    }
-    if let Some(re) = &type_re {
-        collect_matches(source, re, "type", &mut sigs);
-    }
+    collect_matches(source, &FN_RE, "function", &mut sigs);
+    collect_matches(source, &ARROW_RE, "const fn", &mut sigs);
+    collect_matches(source, &CLASS_RE, "class", &mut sigs);
+    collect_matches(source, &IFACE_RE, "interface", &mut sigs);
+    collect_matches(source, &TYPE_RE, "type", &mut sigs);
 
     sigs.sort_by_key(|s| s.line);
     sigs

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use tmg_agents::{AgentType, CustomAgentDef, SubagentManager, SubagentSummary, truncate_str};
-use tmg_core::{AgentLoop, CoreError, StreamSink};
+use tmg_core::{AgentLoop, CoreError, StreamSink, format_context_usage};
 use tmg_llm::Role;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -53,12 +53,14 @@ pub enum TurnMessage {
         is_error: bool,
     },
     /// The turn completed successfully. Contains the `AgentLoop` back
-    /// and the turn count for context display.
+    /// and context usage information.
     Done {
         /// The agent loop returned after the turn completes.
         agent: AgentLoop,
-        /// Number of user turns so far (for context usage display).
-        user_turns: usize,
+        /// Current token count in the context.
+        token_count: usize,
+        /// Maximum context tokens configured.
+        max_tokens: usize,
     },
     /// The turn failed with an error. Contains the `AgentLoop` back.
     Error {
@@ -136,11 +138,16 @@ pub struct App {
 
     /// Custom agent definitions for display in `/agents` list.
     custom_agents: Vec<CustomAgentDef>,
+
+    /// Whether a `/compact` command is pending execution.
+    pending_compact: bool,
 }
 
 impl App {
     /// Create a new `App` with the given agent loop and model name.
     pub fn new(agent: AgentLoop, model_name: &str, project_root: PathBuf, cwd: PathBuf) -> Self {
+        let max_tokens = agent.context_config().max_context_tokens;
+        let context_usage = format_context_usage(0, max_tokens);
         Self {
             agent: Some(agent),
             chat_entries: Vec::new(),
@@ -151,7 +158,7 @@ impl App {
             should_exit: false,
             streaming: false,
             model_name: model_name.to_owned(),
-            context_usage: "0 / ? tokens".to_owned(),
+            context_usage,
             project_root,
             cwd,
             error_message: None,
@@ -159,6 +166,7 @@ impl App {
             subagent_manager: None,
             subagent_summaries: Vec::new(),
             custom_agents: Vec::new(),
+            pending_compact: false,
         }
     }
 
@@ -362,6 +370,19 @@ impl App {
         Ok(Some(text))
     }
 
+    /// Whether the `/compact` command needs to run asynchronously.
+    ///
+    /// Set to `true` when the user types `/compact` and cleared after
+    /// the background task picks it up.
+    pub fn needs_compact(&self) -> bool {
+        self.pending_compact
+    }
+
+    /// Clear the pending compact flag.
+    pub fn clear_pending_compact(&mut self) {
+        self.pending_compact = false;
+    }
+
     /// Handle a slash command. Returns `Ok(())` if handled.
     fn handle_slash_command(&mut self, cmd: &str) -> Result<(), CoreError> {
         match cmd.trim() {
@@ -374,6 +395,17 @@ impl App {
                 self.chat_scroll = 0;
                 if let Some(agent) = &mut self.agent {
                     agent.clear_history(&self.project_root, &self.cwd)?;
+                }
+            }
+            "compact" => {
+                if self.agent.is_some() {
+                    self.pending_compact = true;
+                    self.chat_entries.push(ChatEntry {
+                        role: Role::System,
+                        text: "Compressing context...".to_owned(),
+                    });
+                } else {
+                    self.error_message = Some("Cannot compact while a turn is running".to_owned());
                 }
             }
             "agents" => {
@@ -477,14 +509,17 @@ impl App {
 
             match result {
                 Ok(()) => {
-                    let user_turns = agent
-                        .history()
-                        .iter()
-                        .filter(|m| m.role() == Role::User)
-                        .count();
+                    let token_count = agent.token_count();
+                    let max_tokens = agent.context_config().max_context_tokens;
                     // Ignore send errors -- the receiver may have been
                     // dropped if the app is shutting down.
-                    let _ = tx.send(TurnMessage::Done { agent, user_turns }).await;
+                    let _ = tx
+                        .send(TurnMessage::Done {
+                            agent,
+                            token_count,
+                            max_tokens,
+                        })
+                        .await;
                 }
                 Err(CoreError::Cancelled) => {
                     let _ = tx
@@ -556,11 +591,15 @@ impl App {
                     });
                     changed = true;
                 }
-                Ok(TurnMessage::Done { agent, user_turns }) => {
+                Ok(TurnMessage::Done {
+                    agent,
+                    token_count,
+                    max_tokens,
+                }) => {
                     self.agent = Some(agent);
                     self.streaming = false;
                     self.turn_handle = None;
-                    self.context_usage = format!("{user_turns} turns");
+                    self.context_usage = format_context_usage(token_count, max_tokens);
                     self.set_chat_scroll(0);
                     return true;
                 }
@@ -607,6 +646,24 @@ impl App {
         if let Some(handle) = &self.turn_handle {
             handle.turn_cancel.cancel();
         }
+    }
+
+    /// Return a mutable reference to the agent loop, if available.
+    pub fn agent_mut(&mut self) -> Option<&mut AgentLoop> {
+        self.agent.as_mut()
+    }
+
+    /// Update the context usage display string.
+    pub fn update_context_usage(&mut self, usage: String) {
+        self.context_usage = usage;
+    }
+
+    /// Push a system-role message to the chat display.
+    pub fn push_system_message(&mut self, text: String) {
+        self.chat_entries.push(ChatEntry {
+            role: Role::System,
+            text,
+        });
     }
 
     /// Set an error message to display in the TUI.

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -852,6 +852,16 @@ impl StreamSink for ChannelStreamSink {
             })
             .map_err(|_| CoreError::Cancelled)
     }
+
+    fn on_warning(&mut self, message: &str) -> Result<(), CoreError> {
+        self.tx
+            .try_send(TurnMessage::ToolResult {
+                name: "system".to_owned(),
+                output: format!("warning: {message}"),
+                is_error: true,
+            })
+            .map_err(|_| CoreError::Cancelled)
+    }
 }
 
 #[cfg(test)]

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -71,6 +71,24 @@ pub enum TurnMessage {
         /// Whether the error was a cancellation.
         cancelled: bool,
     },
+    /// The `/compact` background task completed successfully.
+    CompactDone {
+        /// The agent loop returned after compaction.
+        agent: AgentLoop,
+        /// Current token count after compression.
+        token_count: usize,
+        /// Maximum context tokens configured.
+        max_tokens: usize,
+    },
+    /// The `/compact` background task failed.
+    CompactError {
+        /// The agent loop returned after compaction failure.
+        agent: AgentLoop,
+        /// The error message.
+        message: String,
+        /// Whether the error was a cancellation.
+        cancelled: bool,
+    },
 }
 
 /// Handle for a running conversation turn background task.
@@ -383,6 +401,66 @@ impl App {
         self.pending_compact = false;
     }
 
+    /// Start context compression in a background task.
+    ///
+    /// Takes ownership of the agent for the duration, similar to
+    /// [`start_turn`]. Results are communicated via `TurnMessage::CompactDone`
+    /// or `TurnMessage::CompactError`.
+    pub fn start_compact(&mut self, parent_cancel: &CancellationToken) {
+        let Some(mut agent) = self.agent.take() else {
+            return;
+        };
+
+        let turn_cancel = parent_cancel.child_token();
+        agent.set_cancel_token(turn_cancel.clone());
+
+        self.streaming = true;
+
+        let (tx, rx) = mpsc::channel::<TurnMessage>(16);
+
+        let join = tokio::spawn(async move {
+            let result = agent.compact().await;
+
+            match result {
+                Ok(()) => {
+                    let token_count = agent.token_count();
+                    let max_tokens = agent.context_config().max_context_tokens;
+                    let _ = tx
+                        .send(TurnMessage::CompactDone {
+                            agent,
+                            token_count,
+                            max_tokens,
+                        })
+                        .await;
+                }
+                Err(CoreError::Cancelled) => {
+                    let _ = tx
+                        .send(TurnMessage::CompactError {
+                            agent,
+                            message: "Context compression cancelled.".to_owned(),
+                            cancelled: true,
+                        })
+                        .await;
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(TurnMessage::CompactError {
+                            agent,
+                            message: format!("Context compression failed: {e}"),
+                            cancelled: false,
+                        })
+                        .await;
+                }
+            }
+        });
+
+        self.turn_handle = Some(TurnHandle {
+            rx,
+            turn_cancel,
+            _join: join,
+        });
+    }
+
     /// Handle a slash command. Returns `Ok(())` if handled.
     fn handle_slash_command(&mut self, cmd: &str) -> Result<(), CoreError> {
         match cmd.trim() {
@@ -553,6 +631,10 @@ impl App {
     ///
     /// Returns `true` if a redraw is needed (i.e., at least one message
     /// was received).
+    #[expect(
+        clippy::too_many_lines,
+        reason = "message dispatch loop handles all TurnMessage variants; splitting would obscure control flow"
+    )]
     pub fn drain_turn_messages(&mut self) -> bool {
         let Some(handle) = &mut self.turn_handle else {
             return false;
@@ -620,6 +702,34 @@ impl App {
                             }
                         }
                     }
+                    self.set_chat_scroll(0);
+                    return true;
+                }
+                Ok(TurnMessage::CompactDone {
+                    agent,
+                    token_count,
+                    max_tokens,
+                }) => {
+                    self.agent = Some(agent);
+                    self.streaming = false;
+                    self.turn_handle = None;
+                    self.context_usage = format_context_usage(token_count, max_tokens);
+                    self.chat_entries.push(ChatEntry {
+                        role: Role::System,
+                        text: "Context compressed successfully.".to_owned(),
+                    });
+                    self.set_chat_scroll(0);
+                    return true;
+                }
+                Ok(TurnMessage::CompactError {
+                    agent,
+                    message,
+                    cancelled: _,
+                }) => {
+                    self.agent = Some(agent);
+                    self.streaming = false;
+                    self.turn_handle = None;
+                    self.error_message = Some(message);
                     self.set_chat_scroll(0);
                     return true;
                 }

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -6,8 +6,6 @@ use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::DefaultTerminal;
 use tokio_util::sync::CancellationToken;
 
-use tmg_core::format_context_usage;
-
 use crate::app::App;
 use crate::error::TuiError;
 use crate::ui;
@@ -55,10 +53,10 @@ pub async fn run_event_loop(
         // Drain any pending turn messages before drawing.
         app.drain_turn_messages();
 
-        // Handle pending /compact command asynchronously.
-        if app.needs_compact() {
+        // Handle pending /compact command as a background task.
+        if app.needs_compact() && !app.is_streaming() {
             app.clear_pending_compact();
-            run_compact(app, &cancel).await;
+            app.start_compact(&cancel);
         }
 
         // Refresh subagent summaries at a throttled rate (once per second)
@@ -203,32 +201,4 @@ fn submit_and_start_turn(app: &mut App, cancel: &CancellationToken) {
     };
 
     app.start_turn(user_input, cancel);
-}
-
-/// Run the `/compact` command: compresses context in the background.
-///
-/// Takes temporary ownership of the agent, runs compression, and
-/// updates the context usage display.
-async fn run_compact(app: &mut App, cancel: &CancellationToken) {
-    // Borrow the agent mutably for the compact operation.
-    // We need to take it temporarily if we want to spawn, but since
-    // compact is quick relative to a full turn and CancellationToken
-    // handles interruption, we can run it inline.
-    if let Some(agent) = app.agent_mut() {
-        agent.set_cancel_token(cancel.child_token());
-        match agent.compact().await {
-            Ok(()) => {
-                let token_count = agent.token_count();
-                let max_tokens = agent.context_config().max_context_tokens;
-                app.update_context_usage(format_context_usage(token_count, max_tokens));
-                app.push_system_message("Context compressed successfully.".to_owned());
-            }
-            Err(tmg_core::CoreError::Cancelled) => {
-                app.set_error("Context compression cancelled.".to_owned());
-            }
-            Err(e) => {
-                app.set_error(format!("Context compression failed: {e}"));
-            }
-        }
-    }
 }

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -6,6 +6,8 @@ use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::DefaultTerminal;
 use tokio_util::sync::CancellationToken;
 
+use tmg_core::format_context_usage;
+
 use crate::app::App;
 use crate::error::TuiError;
 use crate::ui;
@@ -52,6 +54,12 @@ pub async fn run_event_loop(
     loop {
         // Drain any pending turn messages before drawing.
         app.drain_turn_messages();
+
+        // Handle pending /compact command asynchronously.
+        if app.needs_compact() {
+            app.clear_pending_compact();
+            run_compact(app, &cancel).await;
+        }
 
         // Refresh subagent summaries at a throttled rate (once per second)
         // to avoid excessive lock contention with the manager mutex.
@@ -195,4 +203,32 @@ fn submit_and_start_turn(app: &mut App, cancel: &CancellationToken) {
     };
 
     app.start_turn(user_input, cancel);
+}
+
+/// Run the `/compact` command: compresses context in the background.
+///
+/// Takes temporary ownership of the agent, runs compression, and
+/// updates the context usage display.
+async fn run_compact(app: &mut App, cancel: &CancellationToken) {
+    // Borrow the agent mutably for the compact operation.
+    // We need to take it temporarily if we want to spawn, but since
+    // compact is quick relative to a full turn and CancellationToken
+    // handles interruption, we can run it inline.
+    if let Some(agent) = app.agent_mut() {
+        agent.set_cancel_token(cancel.child_token());
+        match agent.compact().await {
+            Ok(()) => {
+                let token_count = agent.token_count();
+                let max_tokens = agent.context_config().max_context_tokens;
+                app.update_context_usage(format_context_usage(token_count, max_tokens));
+                app.push_system_message("Context compressed successfully.".to_owned());
+            }
+            Err(tmg_core::CoreError::Cancelled) => {
+                app.set_error("Context compression cancelled.".to_owned());
+            }
+            Err(e) => {
+                app.set_error(format!("Context compression failed: {e}"));
+            }
+        }
+    }
 }

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -19,15 +19,34 @@ struct Cli {
     /// Model name to use.
     #[arg(long, default_value = "default")]
     model: String,
+
+    /// Maximum context window tokens.
+    #[arg(long, default_value = "8192")]
+    max_context_tokens: usize,
+
+    /// Context compression threshold (0.0-1.0). Compression auto-triggers
+    /// when context usage exceeds this fraction of `max_context_tokens`.
+    #[arg(long, default_value = "0.8")]
+    context_compression_threshold: f64,
+
+    /// Maximum tokens for a single tool result before truncation.
+    #[arg(long, default_value = "4096")]
+    max_tool_result_tokens: usize,
 }
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    let context_config = tmg_core::ContextConfig {
+        max_context_tokens: cli.max_context_tokens,
+        compression_threshold: cli.context_compression_threshold,
+        max_tool_result_tokens: cli.max_tool_result_tokens,
+    };
+
     if let Some(prompt) = cli.prompt {
         run_prompt(&cli.endpoint, &cli.model, &prompt)?;
     } else {
-        run_tui(&cli.endpoint, &cli.model)?;
+        run_tui(&cli.endpoint, &cli.model, context_config)?;
     }
 
     Ok(())
@@ -91,7 +110,11 @@ fn run_prompt(endpoint: &str, model: &str, prompt: &str) -> anyhow::Result<()> {
 /// and input area. The TUI handles multi-turn conversations with
 /// streaming LLM responses. Includes subagent support via
 /// `spawn_agent` tool, with custom agent definitions from TOML.
-fn run_tui(endpoint: &str, model: &str) -> anyhow::Result<()> {
+fn run_tui(
+    endpoint: &str,
+    model: &str,
+    context_config: tmg_core::ContextConfig,
+) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let config = tmg_llm::LlmClientConfig::new(endpoint, model);
@@ -133,8 +156,14 @@ fn run_tui(endpoint: &str, model: &str) -> anyhow::Result<()> {
             custom_agent_defs.clone(),
         ));
 
-        let agent =
-            tmg_core::AgentLoop::new(client, registry, cancel.clone(), &project_root, &cwd)?;
+        let agent = tmg_core::AgentLoop::with_context_config(
+            client,
+            registry,
+            cancel.clone(),
+            &project_root,
+            &cwd,
+            context_config,
+        )?;
 
         tmg_tui::run(
             agent,


### PR DESCRIPTION
## Summary

Implements context window management for local LLM's limited context, addressing all requirements from #12.

- **Token counting**: Added `POST /tokenize` endpoint support to `LlmClient` for accurate token counting via llama-server. `TokenCounter` runs async background updates so TUI rendering is never blocked.
- **TUI context display**: Header shows real-time `ctx: 2.1k/8k` format using cached token counts.
- **Context compression**: Auto-triggers when usage exceeds configurable threshold (default 80%). Uses LLM to summarize old turns while preserving recent messages. `CancellationToken`-interruptible.
- **`/compact` slash command**: Manual context compression from TUI.
- **Tool result truncation**: Tool results exceeding `max_tool_result_tokens` (default 4096) are truncated with beginning/end preserved.
- **Signature extraction**: Regex-based extraction of function signatures, class/struct/trait definitions for Rust, Python, and JavaScript/TypeScript (`tmg-tools::signatures`).
- **CLI config**: `--max-context-tokens`, `--context-compression-threshold`, `--max-tool-result-tokens` flags.

## Crates modified

| Crate | Changes |
|-------|---------|
| `tmg-llm` | `LlmClient::tokenize()`, `TokenizeResponse` type |
| `tmg-core` | New `context` module (`ContextConfig`, `TokenCounter`, `ContextCompressor`, `truncate_tool_result`, `format_context_usage`); agent loop integration |
| `tmg-tools` | New `signatures` module (Rust/Python/JS/TS extraction) |
| `tmg-tui` | `/compact` command, `ctx: X/Y` header display, token count wiring |
| `tmg-cli` | Context config CLI flags |

## Test plan

- [x] Unit tests for `ContextConfig` (defaults, compression trigger calculation)
- [x] Unit tests for token estimation heuristic
- [x] Unit tests for context usage formatting (`format_context_usage`, `format_token_count`)
- [x] Unit tests for tool result truncation (short passthrough, long truncation)
- [x] Unit tests for message serialization for token counting
- [x] Unit tests for Rust signature extraction (functions, structs, enums, traits, impls)
- [x] Unit tests for Python signature extraction (functions, classes, async methods)
- [x] Unit tests for JavaScript/TypeScript signature extraction (functions, classes, interfaces, type aliases)
- [x] All existing tests continue to pass (230 total, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)