### PR TITLE
CLI entry point and tsumugi.toml config loading (#14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,14 +1663,20 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
+ "serde",
+ "tempfile",
+ "thiserror",
  "tmg-agents",
  "tmg-core",
  "tmg-llm",
+ "tmg-skills",
  "tmg-tools",
  "tmg-tui",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "tmg-agents",
  "tmg-core",
  "tmg-llm",
+ "tmg-sandbox",
  "tmg-skills",
  "tmg-tools",
  "tmg-tui",

--- a/crates/tmg-sandbox/src/mode.rs
+++ b/crates/tmg-sandbox/src/mode.rs
@@ -44,6 +44,21 @@ impl SandboxMode {
     }
 }
 
+impl std::str::FromStr for SandboxMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "read_only" => Ok(Self::ReadOnly),
+            "workspace_write" => Ok(Self::WorkspaceWrite),
+            "full" => Ok(Self::Full),
+            other => Err(format!(
+                "invalid sandbox mode: {other:?} (expected \"read_only\", \"workspace_write\", or \"full\")"
+            )),
+        }
+    }
+}
+
 impl std::fmt::Display for SandboxMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -8,14 +8,22 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+dirs = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["signal", "sync"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
+toml = { workspace = true }
 tmg-agents = { workspace = true }
 tmg-core = { workspace = true }
 tmg-llm = { workspace = true }
+tmg-skills = { workspace = true }
 tmg-tools = { workspace = true }
 tmg-tui = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -18,6 +18,7 @@ toml = { workspace = true }
 tmg-agents = { workspace = true }
 tmg-core = { workspace = true }
 tmg-llm = { workspace = true }
+tmg-sandbox = { workspace = true }
 tmg-skills = { workspace = true }
 tmg-tools = { workspace = true }
 tmg-tui = { workspace = true }

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -1,0 +1,657 @@
+//! Configuration loading and merging for tsumugi.
+//!
+//! This module implements the `tsumugi.toml` configuration file loading,
+//! merging across multiple sources, and validation. The configuration
+//! priority (highest to lowest) is:
+//!
+//! 1. CLI arguments
+//! 2. Environment variables (`TMG_*` prefix)
+//! 3. Project-local config (`.tsumugi/tsumugi.toml`)
+//! 4. Global config (`~/.config/tsumugi/tsumugi.toml`)
+//! 5. Built-in defaults
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ConfigError;
+
+// ---------------------------------------------------------------------------
+// Section types
+// ---------------------------------------------------------------------------
+
+/// LLM connection settings from `[llm]` section.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LlmConfig {
+    /// llama-server endpoint URL.
+    #[serde(default = "default_endpoint")]
+    pub endpoint: String,
+
+    /// Model name to use in requests.
+    #[serde(default = "default_model")]
+    pub model: String,
+
+    /// Maximum context window tokens.
+    #[serde(default = "default_max_context_tokens")]
+    pub max_context_tokens: usize,
+
+    /// Fraction of max context at which compression auto-triggers (0.0..=1.0).
+    #[serde(default = "default_compression_threshold")]
+    pub compression_threshold: f64,
+
+    /// Maximum tokens allowed in a single tool result before truncation.
+    #[serde(default = "default_max_tool_result_tokens")]
+    pub max_tool_result_tokens: usize,
+
+    /// Tool calling mode: `native`, `prompt_based`, or `auto`.
+    #[serde(default)]
+    pub tool_calling: String,
+}
+
+fn default_endpoint() -> String {
+    "http://localhost:8080".to_owned()
+}
+
+fn default_model() -> String {
+    "default".to_owned()
+}
+
+const fn default_max_context_tokens() -> usize {
+    8192
+}
+
+const fn default_compression_threshold() -> f64 {
+    0.8
+}
+
+const fn default_max_tool_result_tokens() -> usize {
+    4096
+}
+
+impl Default for LlmConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: default_endpoint(),
+            model: default_model(),
+            max_context_tokens: default_max_context_tokens(),
+            compression_threshold: default_compression_threshold(),
+            max_tool_result_tokens: default_max_tool_result_tokens(),
+            tool_calling: String::new(),
+        }
+    }
+}
+
+/// Sandbox settings from `[sandbox]` section.
+///
+/// This mirrors the fields of [`tmg_sandbox::SandboxConfig`] but uses
+/// `Option` wrappers so that partial TOML sections can be deserialized
+/// and merged independently.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct SandboxConfigSection {
+    /// Sandbox operating mode: `read_only`, `workspace_write`, or `full`.
+    #[serde(default)]
+    pub mode: Option<String>,
+
+    /// Domains allowed for outbound network access.
+    #[serde(default)]
+    pub allowed_domains: Option<Vec<String>>,
+
+    /// Maximum execution time in seconds for shell commands.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+
+    /// OOM score adjustment for child processes (Linux only).
+    #[serde(default)]
+    pub oom_score_adj: Option<i32>,
+}
+
+/// TUI display settings from `[tui]` section.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct TuiConfig {
+    /// Whether to show the token usage indicator in the header.
+    #[serde(default)]
+    pub show_token_usage: Option<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// Top-level config
+// ---------------------------------------------------------------------------
+
+/// Root configuration, corresponding to the entire `tsumugi.toml` file.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct TsumugiConfig {
+    /// LLM connection settings.
+    #[serde(default)]
+    pub llm: LlmConfig,
+
+    /// Sandbox settings.
+    #[serde(default)]
+    pub sandbox: SandboxConfigSection,
+
+    /// TUI display settings.
+    #[serde(default)]
+    pub tui: TuiConfig,
+
+    /// Skill discovery settings.
+    #[serde(default)]
+    pub skills: tmg_skills::SkillsConfig,
+}
+
+// ---------------------------------------------------------------------------
+// Merging
+// ---------------------------------------------------------------------------
+
+impl LlmConfig {
+    /// Merge `other` into `self`. Non-default fields in `other` take
+    /// precedence.
+    fn merge_from(&mut self, other: &Self) {
+        let defaults = Self::default();
+
+        if other.endpoint != defaults.endpoint {
+            self.endpoint.clone_from(&other.endpoint);
+        }
+        if other.model != defaults.model {
+            self.model.clone_from(&other.model);
+        }
+        if other.max_context_tokens != defaults.max_context_tokens {
+            self.max_context_tokens = other.max_context_tokens;
+        }
+        if (other.compression_threshold - defaults.compression_threshold).abs() > f64::EPSILON {
+            self.compression_threshold = other.compression_threshold;
+        }
+        if other.max_tool_result_tokens != defaults.max_tool_result_tokens {
+            self.max_tool_result_tokens = other.max_tool_result_tokens;
+        }
+        if !other.tool_calling.is_empty() {
+            self.tool_calling.clone_from(&other.tool_calling);
+        }
+    }
+}
+
+impl SandboxConfigSection {
+    /// Merge `other` into `self`. `Some` fields in `other` take precedence.
+    fn merge_from(&mut self, other: &Self) {
+        if other.mode.is_some() {
+            self.mode.clone_from(&other.mode);
+        }
+        if other.allowed_domains.is_some() {
+            self.allowed_domains.clone_from(&other.allowed_domains);
+        }
+        if other.timeout_secs.is_some() {
+            self.timeout_secs = other.timeout_secs;
+        }
+        if other.oom_score_adj.is_some() {
+            self.oom_score_adj = other.oom_score_adj;
+        }
+    }
+}
+
+impl TuiConfig {
+    /// Merge `other` into `self`. `Some` fields in `other` take precedence.
+    fn merge_from(&mut self, other: &Self) {
+        if other.show_token_usage.is_some() {
+            self.show_token_usage = other.show_token_usage;
+        }
+    }
+}
+
+impl TsumugiConfig {
+    /// Merge `other` into `self`. Fields explicitly set in `other` take
+    /// precedence.
+    pub fn merge_from(&mut self, other: &Self) {
+        self.llm.merge_from(&other.llm);
+        self.sandbox.merge_from(&other.sandbox);
+        self.tui.merge_from(&other.tui);
+        // For skills, non-empty discovery_paths in other replaces self.
+        if !other.skills.discovery_paths.is_empty() {
+            self.skills
+                .discovery_paths
+                .clone_from(&other.skills.discovery_paths);
+        }
+        // Explicit false overrides default true.
+        if !other.skills.compat_claude {
+            self.skills.compat_claude = false;
+        }
+        if !other.skills.compat_agent_skills {
+            self.skills.compat_agent_skills = false;
+        }
+    }
+
+    /// Apply environment variable overrides (`TMG_*` prefix).
+    ///
+    /// This accepts an environment lookup function so that tests can
+    /// inject values without modifying the process environment (which is
+    /// `unsafe` in Edition 2024).
+    pub fn apply_env_overrides(&mut self, env_fn: &dyn Fn(&str) -> Option<String>) {
+        if let Some(v) = env_fn("TMG_LLM_ENDPOINT") {
+            self.llm.endpoint = v;
+        }
+        if let Some(v) = env_fn("TMG_LLM_MODEL") {
+            self.llm.model = v;
+        }
+        if let Some(v) = env_fn("TMG_LLM_MAX_CONTEXT_TOKENS") {
+            if let Ok(n) = v.parse::<usize>() {
+                self.llm.max_context_tokens = n;
+            }
+        }
+        if let Some(v) = env_fn("TMG_LLM_COMPRESSION_THRESHOLD") {
+            if let Ok(n) = v.parse::<f64>() {
+                self.llm.compression_threshold = n;
+            }
+        }
+        if let Some(v) = env_fn("TMG_LLM_MAX_TOOL_RESULT_TOKENS") {
+            if let Ok(n) = v.parse::<usize>() {
+                self.llm.max_tool_result_tokens = n;
+            }
+        }
+        if let Some(v) = env_fn("TMG_LLM_TOOL_CALLING") {
+            self.llm.tool_calling = v;
+        }
+        if let Some(v) = env_fn("TMG_SANDBOX_MODE") {
+            self.sandbox.mode = Some(v);
+        }
+        if let Some(v) = env_fn("TMG_SANDBOX_TIMEOUT_SECS") {
+            if let Ok(n) = v.parse::<u64>() {
+                self.sandbox.timeout_secs = Some(n);
+            }
+        }
+    }
+
+    /// Validate the configuration, returning a structured error on failure.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        // Validate endpoint is a valid URL.
+        let endpoint = self.llm.endpoint.trim();
+        if !endpoint.starts_with("http://") && !endpoint.starts_with("https://") {
+            return Err(ConfigError::InvalidValue {
+                field: "llm.endpoint".to_owned(),
+                value: self.llm.endpoint.clone(),
+                reason: "must start with http:// or https://".to_owned(),
+            });
+        }
+
+        // Validate model is not empty.
+        if self.llm.model.trim().is_empty() {
+            return Err(ConfigError::InvalidValue {
+                field: "llm.model".to_owned(),
+                value: self.llm.model.clone(),
+                reason: "must not be empty".to_owned(),
+            });
+        }
+
+        // Validate compression_threshold is in range.
+        if !(0.0..=1.0).contains(&self.llm.compression_threshold) {
+            return Err(ConfigError::InvalidValue {
+                field: "llm.compression_threshold".to_owned(),
+                value: self.llm.compression_threshold.to_string(),
+                reason: "must be between 0.0 and 1.0".to_owned(),
+            });
+        }
+
+        // Validate tool_calling mode if specified.
+        if !self.llm.tool_calling.is_empty() {
+            let valid = ["native", "prompt_based", "auto"];
+            if !valid.contains(&self.llm.tool_calling.as_str()) {
+                return Err(ConfigError::InvalidValue {
+                    field: "llm.tool_calling".to_owned(),
+                    value: self.llm.tool_calling.clone(),
+                    reason: "must be one of: native, prompt_based, auto".to_owned(),
+                });
+            }
+        }
+
+        // Validate sandbox mode if specified.
+        if let Some(ref mode) = self.sandbox.mode {
+            let valid = ["read_only", "workspace_write", "full"];
+            if !valid.contains(&mode.as_str()) {
+                return Err(ConfigError::InvalidValue {
+                    field: "sandbox.mode".to_owned(),
+                    value: mode.clone(),
+                    reason: "must be one of: read_only, workspace_write, full".to_owned(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File loading
+// ---------------------------------------------------------------------------
+
+/// Load a single `tsumugi.toml` file from the given path.
+///
+/// Returns `Ok(None)` if the file does not exist, `Err` if it exists
+/// but cannot be read or parsed.
+fn load_toml_file(path: &Path) -> Result<Option<TsumugiConfig>, ConfigError> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(ConfigError::Io {
+                path: path.to_owned(),
+                source: e,
+            });
+        }
+    };
+
+    let config: TsumugiConfig = toml::from_str(&content).map_err(|e| ConfigError::Parse {
+        path: path.to_owned(),
+        source: e,
+    })?;
+
+    Ok(Some(config))
+}
+
+/// Resolve the global config path (`~/.config/tsumugi/tsumugi.toml`).
+fn global_config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("tsumugi").join("tsumugi.toml"))
+}
+
+/// Resolve the project-local config path (`.tsumugi/tsumugi.toml`
+/// relative to the current directory).
+fn project_config_path() -> Option<PathBuf> {
+    std::env::current_dir()
+        .ok()
+        .map(|d| d.join(".tsumugi").join("tsumugi.toml"))
+}
+
+/// Load configuration from all sources and merge them according to
+/// the priority chain.
+///
+/// If `config_path` is `Some`, only that file is loaded (no global or
+/// project-local discovery). Environment variable overrides are always
+/// applied.
+pub fn load_config(config_path: Option<&Path>) -> Result<TsumugiConfig, ConfigError> {
+    load_config_with_env(config_path, &|key| std::env::var(key).ok())
+}
+
+/// Load configuration with a custom environment lookup function.
+///
+/// This is the testable core of [`load_config`].
+pub fn load_config_with_env(
+    config_path: Option<&Path>,
+    env_fn: &dyn Fn(&str) -> Option<String>,
+) -> Result<TsumugiConfig, ConfigError> {
+    let mut config = TsumugiConfig::default();
+
+    if let Some(path) = config_path {
+        // Explicit --config path: only load that file.
+        let Some(file_config) = load_toml_file(path)? else {
+            return Err(ConfigError::NotFound {
+                path: path.to_owned(),
+            });
+        };
+        config = file_config;
+    } else {
+        // Load global config.
+        if let Some(global_path) = global_config_path() {
+            if let Some(global) = load_toml_file(&global_path)? {
+                config = global;
+            }
+        }
+
+        // Merge project-local config (higher priority).
+        if let Some(project_path) = project_config_path() {
+            if let Some(project) = load_toml_file(&project_path)? {
+                config.merge_from(&project);
+            }
+        }
+    }
+
+    // Apply environment variable overrides.
+    config.apply_env_overrides(env_fn);
+
+    Ok(config)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_valid() {
+        let config = TsumugiConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn merge_project_overrides_global() {
+        let mut global = TsumugiConfig::default();
+        global.llm.endpoint = "http://global:8080".to_owned();
+        global.llm.model = "global-model".to_owned();
+
+        let mut project = TsumugiConfig::default();
+        project.llm.endpoint = "http://project:9090".to_owned();
+        // model stays default, should not override global
+
+        global.merge_from(&project);
+
+        assert_eq!(global.llm.endpoint, "http://project:9090");
+        assert_eq!(global.llm.model, "global-model");
+    }
+
+    #[test]
+    fn env_overrides_apply() {
+        let mut config = TsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            match key {
+                "TMG_LLM_ENDPOINT" => Some("http://env:1234".to_owned()),
+                "TMG_LLM_MODEL" => Some("env-model".to_owned()),
+                "TMG_LLM_MAX_CONTEXT_TOKENS" => Some("16384".to_owned()),
+                "TMG_SANDBOX_MODE" => Some("read_only".to_owned()),
+                _ => None,
+            }
+        };
+
+        config.apply_env_overrides(&env_fn);
+
+        assert_eq!(config.llm.endpoint, "http://env:1234");
+        assert_eq!(config.llm.model, "env-model");
+        assert_eq!(config.llm.max_context_tokens, 16384);
+        assert_eq!(config.sandbox.mode.as_deref(), Some("read_only"));
+    }
+
+    #[test]
+    fn invalid_endpoint_rejected() {
+        let mut config = TsumugiConfig::default();
+        config.llm.endpoint = "not-a-url".to_owned();
+
+        let Err(err) = config.validate() else {
+            panic!("expected validation to fail for invalid endpoint");
+        };
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref field, .. } if field == "llm.endpoint"),
+            "expected InvalidValue for llm.endpoint, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn empty_model_rejected() {
+        let mut config = TsumugiConfig::default();
+        config.llm.model = "  ".to_owned();
+
+        let Err(err) = config.validate() else {
+            panic!("expected validation to fail for empty model");
+        };
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref field, .. } if field == "llm.model"),
+            "expected InvalidValue for llm.model, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_compression_threshold_rejected() {
+        let mut config = TsumugiConfig::default();
+        config.llm.compression_threshold = 1.5;
+
+        let Err(err) = config.validate() else {
+            panic!("expected validation to fail for invalid threshold");
+        };
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref field, .. } if field == "llm.compression_threshold"),
+            "expected InvalidValue for compression_threshold, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_tool_calling_rejected() {
+        let mut config = TsumugiConfig::default();
+        config.llm.tool_calling = "invalid".to_owned();
+
+        let Err(err) = config.validate() else {
+            panic!("expected validation to fail for invalid tool_calling");
+        };
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref field, .. } if field == "llm.tool_calling"),
+            "expected InvalidValue for llm.tool_calling, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_sandbox_mode_rejected() {
+        let mut config = TsumugiConfig::default();
+        config.sandbox.mode = Some("bad".to_owned());
+
+        let Err(err) = config.validate() else {
+            panic!("expected validation to fail for invalid sandbox mode");
+        };
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref field, .. } if field == "sandbox.mode"),
+            "expected InvalidValue for sandbox.mode, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_nonexistent_explicit_path_is_error() {
+        let result = load_config_with_env(Some(Path::new("/nonexistent/tsumugi.toml")), &|_| None);
+        assert!(matches!(result, Err(ConfigError::NotFound { .. })));
+    }
+
+    #[test]
+    fn load_from_toml_string() {
+        let toml_str = r#"
+[llm]
+endpoint = "http://custom:1234"
+model = "my-model"
+max_context_tokens = 4096
+
+[sandbox]
+mode = "read_only"
+timeout_secs = 60
+
+[tui]
+show_token_usage = true
+
+[skills]
+discovery_paths = ["/extra"]
+compat_claude = false
+"#;
+        let config: TsumugiConfig = toml::from_str(toml_str).unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(config.llm.endpoint, "http://custom:1234");
+        assert_eq!(config.llm.model, "my-model");
+        assert_eq!(config.llm.max_context_tokens, 4096);
+        assert_eq!(config.sandbox.mode.as_deref(), Some("read_only"));
+        assert_eq!(config.sandbox.timeout_secs, Some(60));
+        assert_eq!(config.tui.show_token_usage, Some(true));
+        assert!(!config.skills.compat_claude);
+    }
+
+    #[test]
+    fn load_with_env_overrides_full_chain() {
+        // Simulate: global has endpoint, env overrides model.
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let config_path = dir.path().join("tsumugi.toml");
+        std::fs::write(
+            &config_path,
+            "[llm]\nendpoint = \"http://file:8080\"\nmodel = \"file-model\"\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let env_fn = |key: &str| -> Option<String> {
+            if key == "TMG_LLM_MODEL" {
+                Some("env-model".to_owned())
+            } else {
+                None
+            }
+        };
+
+        let config =
+            load_config_with_env(Some(&config_path), &env_fn).unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(config.llm.endpoint, "http://file:8080");
+        assert_eq!(config.llm.model, "env-model");
+    }
+
+    #[test]
+    fn parse_error_includes_path() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let config_path = dir.path().join("bad.toml");
+        std::fs::write(&config_path, "[[invalid toml").unwrap_or_else(|e| panic!("{e}"));
+
+        let result = load_config_with_env(Some(&config_path), &|_| None);
+        assert!(
+            matches!(result, Err(ConfigError::Parse { ref path, .. }) if path == &config_path),
+            "expected Parse error with path, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn sandbox_section_merge() {
+        let mut base = TsumugiConfig::default();
+        base.sandbox.timeout_secs = Some(30);
+        base.sandbox.mode = Some("workspace_write".to_owned());
+
+        let mut overlay = TsumugiConfig::default();
+        overlay.sandbox.mode = Some("read_only".to_owned());
+        // timeout_secs is None, should not override
+
+        base.merge_from(&overlay);
+
+        assert_eq!(base.sandbox.mode.as_deref(), Some("read_only"));
+        assert_eq!(base.sandbox.timeout_secs, Some(30));
+    }
+
+    #[test]
+    fn tui_section_merge() {
+        let mut base = TsumugiConfig::default();
+        base.tui.show_token_usage = Some(false);
+
+        let mut overlay = TsumugiConfig::default();
+        overlay.tui.show_token_usage = Some(true);
+
+        base.merge_from(&overlay);
+        assert_eq!(base.tui.show_token_usage, Some(true));
+    }
+
+    #[test]
+    fn valid_tool_calling_modes_accepted() {
+        for mode in ["native", "prompt_based", "auto"] {
+            let mut config = TsumugiConfig::default();
+            config.llm.tool_calling = mode.to_owned();
+            assert!(config.validate().is_ok(), "mode {mode} should be valid");
+        }
+    }
+
+    #[test]
+    fn valid_sandbox_modes_accepted() {
+        for mode in ["read_only", "workspace_write", "full"] {
+            let mut config = TsumugiConfig::default();
+            config.sandbox.mode = Some(mode.to_owned());
+            assert!(config.validate().is_ok(), "mode {mode} should be valid");
+        }
+    }
+
+    #[test]
+    fn empty_tool_calling_is_valid() {
+        let config = TsumugiConfig::default();
+        // Default empty tool_calling should pass validation (means "auto").
+        assert!(config.validate().is_ok());
+    }
+}

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -13,39 +13,238 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use tmg_llm::ToolCallingMode;
+use tmg_sandbox::SandboxMode;
 
 use crate::error::ConfigError;
 
 // ---------------------------------------------------------------------------
-// Section types
+// Partial types for deserialization / merging
+// ---------------------------------------------------------------------------
+
+/// Partial LLM config used for deserialization from TOML.
+///
+/// All fields are `Option` so we can distinguish "not set" from
+/// "explicitly set to the default value".
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PartialLlmConfig {
+    pub endpoint: Option<String>,
+    pub model: Option<String>,
+    pub max_context_tokens: Option<usize>,
+    pub compression_threshold: Option<f64>,
+    pub max_tool_result_tokens: Option<usize>,
+    pub tool_calling: Option<ToolCallingMode>,
+}
+
+impl PartialLlmConfig {
+    /// Merge `other` into `self`. `Some` fields in `other` take precedence.
+    fn merge_from(&mut self, other: &Self) {
+        if other.endpoint.is_some() {
+            self.endpoint.clone_from(&other.endpoint);
+        }
+        if other.model.is_some() {
+            self.model.clone_from(&other.model);
+        }
+        if other.max_context_tokens.is_some() {
+            self.max_context_tokens = other.max_context_tokens;
+        }
+        if other.compression_threshold.is_some() {
+            self.compression_threshold = other.compression_threshold;
+        }
+        if other.max_tool_result_tokens.is_some() {
+            self.max_tool_result_tokens = other.max_tool_result_tokens;
+        }
+        if other.tool_calling.is_some() {
+            self.tool_calling = other.tool_calling;
+        }
+    }
+
+    /// Convert to final `LlmConfig`, filling in defaults for unset fields.
+    fn into_final(self) -> LlmConfig {
+        LlmConfig {
+            endpoint: self.endpoint.unwrap_or_else(default_endpoint),
+            model: self.model.unwrap_or_else(default_model),
+            max_context_tokens: self
+                .max_context_tokens
+                .unwrap_or(default_max_context_tokens()),
+            compression_threshold: self
+                .compression_threshold
+                .unwrap_or(default_compression_threshold()),
+            max_tool_result_tokens: self
+                .max_tool_result_tokens
+                .unwrap_or(default_max_tool_result_tokens()),
+            tool_calling: self.tool_calling.unwrap_or_default(),
+        }
+    }
+}
+
+/// Partial skills config used for deserialization from TOML.
+///
+/// Boolean fields use `Option<bool>` so that an explicit `false` in a
+/// project-local config can override a global `true`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PartialSkillsConfig {
+    #[serde(default)]
+    pub discovery_paths: Vec<PathBuf>,
+    pub compat_claude: Option<bool>,
+    pub compat_agent_skills: Option<bool>,
+}
+
+impl PartialSkillsConfig {
+    /// Merge `other` into `self`. `Some` fields and non-empty paths in
+    /// `other` take precedence.
+    fn merge_from(&mut self, other: &Self) {
+        if !other.discovery_paths.is_empty() {
+            self.discovery_paths.clone_from(&other.discovery_paths);
+        }
+        if other.compat_claude.is_some() {
+            self.compat_claude = other.compat_claude;
+        }
+        if other.compat_agent_skills.is_some() {
+            self.compat_agent_skills = other.compat_agent_skills;
+        }
+    }
+
+    /// Convert to final `SkillsConfig`, filling in defaults for unset fields.
+    fn into_final(self) -> tmg_skills::SkillsConfig {
+        tmg_skills::SkillsConfig {
+            discovery_paths: self.discovery_paths,
+            compat_claude: self.compat_claude.unwrap_or(true),
+            compat_agent_skills: self.compat_agent_skills.unwrap_or(true),
+        }
+    }
+}
+
+/// Partial top-level config used for deserialization and merging.
+///
+/// Deserialized from TOML, merged across sources, then converted to
+/// the final [`TsumugiConfig`] via [`into_final`](Self::into_final).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PartialTsumugiConfig {
+    #[serde(default)]
+    pub llm: PartialLlmConfig,
+    #[serde(default)]
+    pub sandbox: SandboxConfigSection,
+    #[serde(default)]
+    pub tui: TuiConfig,
+    #[serde(default)]
+    pub skills: PartialSkillsConfig,
+}
+
+impl PartialTsumugiConfig {
+    /// Merge `other` into `self`. Fields explicitly set in `other` take
+    /// precedence.
+    fn merge_from(&mut self, other: &Self) {
+        self.llm.merge_from(&other.llm);
+        self.sandbox.merge_from(&other.sandbox);
+        self.tui.merge_from(&other.tui);
+        self.skills.merge_from(&other.skills);
+    }
+
+    /// Apply environment variable overrides (`TMG_*` prefix).
+    ///
+    /// Returns an error if a numeric environment variable is present but
+    /// cannot be parsed.
+    fn apply_env_overrides(
+        &mut self,
+        env_fn: &dyn Fn(&str) -> Option<String>,
+    ) -> Result<(), ConfigError> {
+        if let Some(v) = env_fn("TMG_LLM_ENDPOINT") {
+            self.llm.endpoint = Some(v);
+        }
+        if let Some(v) = env_fn("TMG_LLM_MODEL") {
+            self.llm.model = Some(v);
+        }
+        if let Some(v) = env_fn("TMG_LLM_MAX_CONTEXT_TOKENS") {
+            let n = v.parse::<usize>().map_err(|_| ConfigError::InvalidValue {
+                field: "TMG_LLM_MAX_CONTEXT_TOKENS".to_owned(),
+                value: v,
+                reason: "must be a non-negative integer".to_owned(),
+            })?;
+            self.llm.max_context_tokens = Some(n);
+        }
+        if let Some(v) = env_fn("TMG_LLM_COMPRESSION_THRESHOLD") {
+            let n = v.parse::<f64>().map_err(|_| ConfigError::InvalidValue {
+                field: "TMG_LLM_COMPRESSION_THRESHOLD".to_owned(),
+                value: v,
+                reason: "must be a floating-point number".to_owned(),
+            })?;
+            self.llm.compression_threshold = Some(n);
+        }
+        if let Some(v) = env_fn("TMG_LLM_MAX_TOOL_RESULT_TOKENS") {
+            let n = v.parse::<usize>().map_err(|_| ConfigError::InvalidValue {
+                field: "TMG_LLM_MAX_TOOL_RESULT_TOKENS".to_owned(),
+                value: v,
+                reason: "must be a non-negative integer".to_owned(),
+            })?;
+            self.llm.max_tool_result_tokens = Some(n);
+        }
+        if let Some(v) = env_fn("TMG_LLM_TOOL_CALLING") {
+            let mode = v
+                .parse::<ToolCallingMode>()
+                .map_err(|_| ConfigError::InvalidValue {
+                    field: "TMG_LLM_TOOL_CALLING".to_owned(),
+                    value: v,
+                    reason: "must be one of: native, prompt_based, auto".to_owned(),
+                })?;
+            self.llm.tool_calling = Some(mode);
+        }
+        if let Some(v) = env_fn("TMG_SANDBOX_MODE") {
+            let mode = v
+                .parse::<SandboxMode>()
+                .map_err(|_| ConfigError::InvalidValue {
+                    field: "TMG_SANDBOX_MODE".to_owned(),
+                    value: v,
+                    reason: "must be one of: read_only, workspace_write, full".to_owned(),
+                })?;
+            self.sandbox.mode = Some(mode);
+        }
+        if let Some(v) = env_fn("TMG_SANDBOX_TIMEOUT_SECS") {
+            let n = v.parse::<u64>().map_err(|_| ConfigError::InvalidValue {
+                field: "TMG_SANDBOX_TIMEOUT_SECS".to_owned(),
+                value: v,
+                reason: "must be a non-negative integer".to_owned(),
+            })?;
+            self.sandbox.timeout_secs = Some(n);
+        }
+        Ok(())
+    }
+
+    /// Convert to final [`TsumugiConfig`], filling defaults for unset fields.
+    fn into_final(self) -> TsumugiConfig {
+        TsumugiConfig {
+            llm: self.llm.into_final(),
+            sandbox: self.sandbox,
+            tui: self.tui,
+            skills: self.skills.into_final(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section types (final, validated)
 // ---------------------------------------------------------------------------
 
 /// LLM connection settings from `[llm]` section.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LlmConfig {
     /// llama-server endpoint URL.
-    #[serde(default = "default_endpoint")]
     pub endpoint: String,
 
     /// Model name to use in requests.
-    #[serde(default = "default_model")]
     pub model: String,
 
     /// Maximum context window tokens.
-    #[serde(default = "default_max_context_tokens")]
     pub max_context_tokens: usize,
 
     /// Fraction of max context at which compression auto-triggers (0.0..=1.0).
-    #[serde(default = "default_compression_threshold")]
     pub compression_threshold: f64,
 
     /// Maximum tokens allowed in a single tool result before truncation.
-    #[serde(default = "default_max_tool_result_tokens")]
     pub max_tool_result_tokens: usize,
 
-    /// Tool calling mode: `native`, `prompt_based`, or `auto`.
-    #[serde(default)]
-    pub tool_calling: String,
+    /// Tool calling mode.
+    pub tool_calling: ToolCallingMode,
 }
 
 fn default_endpoint() -> String {
@@ -76,7 +275,7 @@ impl Default for LlmConfig {
             max_context_tokens: default_max_context_tokens(),
             compression_threshold: default_compression_threshold(),
             max_tool_result_tokens: default_max_tool_result_tokens(),
-            tool_calling: String::new(),
+            tool_calling: ToolCallingMode::default(),
         }
     }
 }
@@ -88,9 +287,9 @@ impl Default for LlmConfig {
 /// and merged independently.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct SandboxConfigSection {
-    /// Sandbox operating mode: `read_only`, `workspace_write`, or `full`.
+    /// Sandbox operating mode.
     #[serde(default)]
-    pub mode: Option<String>,
+    pub mode: Option<SandboxMode>,
 
     /// Domains allowed for outbound network access.
     #[serde(default)]
@@ -114,7 +313,7 @@ pub struct TuiConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Top-level config
+// Top-level config (final, validated)
 // ---------------------------------------------------------------------------
 
 /// Root configuration, corresponding to the entire `tsumugi.toml` file.
@@ -138,41 +337,14 @@ pub struct TsumugiConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Merging
+// Merging (SandboxConfigSection, TuiConfig -- still needed for partial merges)
 // ---------------------------------------------------------------------------
-
-impl LlmConfig {
-    /// Merge `other` into `self`. Non-default fields in `other` take
-    /// precedence.
-    fn merge_from(&mut self, other: &Self) {
-        let defaults = Self::default();
-
-        if other.endpoint != defaults.endpoint {
-            self.endpoint.clone_from(&other.endpoint);
-        }
-        if other.model != defaults.model {
-            self.model.clone_from(&other.model);
-        }
-        if other.max_context_tokens != defaults.max_context_tokens {
-            self.max_context_tokens = other.max_context_tokens;
-        }
-        if (other.compression_threshold - defaults.compression_threshold).abs() > f64::EPSILON {
-            self.compression_threshold = other.compression_threshold;
-        }
-        if other.max_tool_result_tokens != defaults.max_tool_result_tokens {
-            self.max_tool_result_tokens = other.max_tool_result_tokens;
-        }
-        if !other.tool_calling.is_empty() {
-            self.tool_calling.clone_from(&other.tool_calling);
-        }
-    }
-}
 
 impl SandboxConfigSection {
     /// Merge `other` into `self`. `Some` fields in `other` take precedence.
     fn merge_from(&mut self, other: &Self) {
         if other.mode.is_some() {
-            self.mode.clone_from(&other.mode);
+            self.mode = other.mode;
         }
         if other.allowed_domains.is_some() {
             self.allowed_domains.clone_from(&other.allowed_domains);
@@ -195,68 +367,11 @@ impl TuiConfig {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
 impl TsumugiConfig {
-    /// Merge `other` into `self`. Fields explicitly set in `other` take
-    /// precedence.
-    pub fn merge_from(&mut self, other: &Self) {
-        self.llm.merge_from(&other.llm);
-        self.sandbox.merge_from(&other.sandbox);
-        self.tui.merge_from(&other.tui);
-        // For skills, non-empty discovery_paths in other replaces self.
-        if !other.skills.discovery_paths.is_empty() {
-            self.skills
-                .discovery_paths
-                .clone_from(&other.skills.discovery_paths);
-        }
-        // Explicit false overrides default true.
-        if !other.skills.compat_claude {
-            self.skills.compat_claude = false;
-        }
-        if !other.skills.compat_agent_skills {
-            self.skills.compat_agent_skills = false;
-        }
-    }
-
-    /// Apply environment variable overrides (`TMG_*` prefix).
-    ///
-    /// This accepts an environment lookup function so that tests can
-    /// inject values without modifying the process environment (which is
-    /// `unsafe` in Edition 2024).
-    pub fn apply_env_overrides(&mut self, env_fn: &dyn Fn(&str) -> Option<String>) {
-        if let Some(v) = env_fn("TMG_LLM_ENDPOINT") {
-            self.llm.endpoint = v;
-        }
-        if let Some(v) = env_fn("TMG_LLM_MODEL") {
-            self.llm.model = v;
-        }
-        if let Some(v) = env_fn("TMG_LLM_MAX_CONTEXT_TOKENS") {
-            if let Ok(n) = v.parse::<usize>() {
-                self.llm.max_context_tokens = n;
-            }
-        }
-        if let Some(v) = env_fn("TMG_LLM_COMPRESSION_THRESHOLD") {
-            if let Ok(n) = v.parse::<f64>() {
-                self.llm.compression_threshold = n;
-            }
-        }
-        if let Some(v) = env_fn("TMG_LLM_MAX_TOOL_RESULT_TOKENS") {
-            if let Ok(n) = v.parse::<usize>() {
-                self.llm.max_tool_result_tokens = n;
-            }
-        }
-        if let Some(v) = env_fn("TMG_LLM_TOOL_CALLING") {
-            self.llm.tool_calling = v;
-        }
-        if let Some(v) = env_fn("TMG_SANDBOX_MODE") {
-            self.sandbox.mode = Some(v);
-        }
-        if let Some(v) = env_fn("TMG_SANDBOX_TIMEOUT_SECS") {
-            if let Ok(n) = v.parse::<u64>() {
-                self.sandbox.timeout_secs = Some(n);
-            }
-        }
-    }
-
     /// Validate the configuration, returning a structured error on failure.
     pub fn validate(&self) -> Result<(), ConfigError> {
         // Validate endpoint is a valid URL.
@@ -287,29 +402,9 @@ impl TsumugiConfig {
             });
         }
 
-        // Validate tool_calling mode if specified.
-        if !self.llm.tool_calling.is_empty() {
-            let valid = ["native", "prompt_based", "auto"];
-            if !valid.contains(&self.llm.tool_calling.as_str()) {
-                return Err(ConfigError::InvalidValue {
-                    field: "llm.tool_calling".to_owned(),
-                    value: self.llm.tool_calling.clone(),
-                    reason: "must be one of: native, prompt_based, auto".to_owned(),
-                });
-            }
-        }
-
-        // Validate sandbox mode if specified.
-        if let Some(ref mode) = self.sandbox.mode {
-            let valid = ["read_only", "workspace_write", "full"];
-            if !valid.contains(&mode.as_str()) {
-                return Err(ConfigError::InvalidValue {
-                    field: "sandbox.mode".to_owned(),
-                    value: mode.clone(),
-                    reason: "must be one of: read_only, workspace_write, full".to_owned(),
-                });
-            }
-        }
+        // No need to validate tool_calling or sandbox.mode -- they are
+        // already strongly typed enums that reject invalid values at
+        // deserialization time.
 
         Ok(())
     }
@@ -323,7 +418,7 @@ impl TsumugiConfig {
 ///
 /// Returns `Ok(None)` if the file does not exist, `Err` if it exists
 /// but cannot be read or parsed.
-fn load_toml_file(path: &Path) -> Result<Option<TsumugiConfig>, ConfigError> {
+fn load_toml_file(path: &Path) -> Result<Option<PartialTsumugiConfig>, ConfigError> {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -335,21 +430,30 @@ fn load_toml_file(path: &Path) -> Result<Option<TsumugiConfig>, ConfigError> {
         }
     };
 
-    let config: TsumugiConfig = toml::from_str(&content).map_err(|e| ConfigError::Parse {
-        path: path.to_owned(),
-        source: e,
-    })?;
+    let config: PartialTsumugiConfig =
+        toml::from_str(&content).map_err(|e| ConfigError::Parse {
+            path: path.to_owned(),
+            source: e,
+        })?;
 
     Ok(Some(config))
 }
 
 /// Resolve the global config path (`~/.config/tsumugi/tsumugi.toml`).
+///
+/// Returns `None` if the platform config directory cannot be determined
+/// (e.g. `$HOME` is not set). This is intentional: the caller falls
+/// through to the next source in the priority chain.
 fn global_config_path() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("tsumugi").join("tsumugi.toml"))
 }
 
 /// Resolve the project-local config path (`.tsumugi/tsumugi.toml`
 /// relative to the current directory).
+///
+/// Returns `None` if the current working directory cannot be determined
+/// (e.g. it has been deleted). This is intentional: the caller falls
+/// through to the next source in the priority chain.
 fn project_config_path() -> Option<PathBuf> {
     std::env::current_dir()
         .ok()
@@ -373,7 +477,7 @@ pub fn load_config_with_env(
     config_path: Option<&Path>,
     env_fn: &dyn Fn(&str) -> Option<String>,
 ) -> Result<TsumugiConfig, ConfigError> {
-    let mut config = TsumugiConfig::default();
+    let mut config = PartialTsumugiConfig::default();
 
     if let Some(path) = config_path {
         // Explicit --config path: only load that file.
@@ -400,9 +504,9 @@ pub fn load_config_with_env(
     }
 
     // Apply environment variable overrides.
-    config.apply_env_overrides(env_fn);
+    config.apply_env_overrides(env_fn)?;
 
-    Ok(config)
+    Ok(config.into_final())
 }
 
 // ---------------------------------------------------------------------------
@@ -422,23 +526,77 @@ mod tests {
 
     #[test]
     fn merge_project_overrides_global() {
-        let mut global = TsumugiConfig::default();
-        global.llm.endpoint = "http://global:8080".to_owned();
-        global.llm.model = "global-model".to_owned();
+        let mut global = PartialTsumugiConfig::default();
+        global.llm.endpoint = Some("http://global:8080".to_owned());
+        global.llm.model = Some("global-model".to_owned());
 
-        let mut project = TsumugiConfig::default();
-        project.llm.endpoint = "http://project:9090".to_owned();
-        // model stays default, should not override global
+        let mut project = PartialTsumugiConfig::default();
+        project.llm.endpoint = Some("http://project:9090".to_owned());
+        // model stays None, should not override global
 
         global.merge_from(&project);
+        let final_config = global.into_final();
 
-        assert_eq!(global.llm.endpoint, "http://project:9090");
-        assert_eq!(global.llm.model, "global-model");
+        assert_eq!(final_config.llm.endpoint, "http://project:9090");
+        assert_eq!(final_config.llm.model, "global-model");
+    }
+
+    #[test]
+    fn merge_explicitly_set_default_value_still_overrides() {
+        // Fix #2: explicitly setting a value equal to the default must still
+        // override the other layer's non-default value.
+        let mut global = PartialTsumugiConfig::default();
+        global.llm.max_context_tokens = Some(16384);
+
+        let mut project = PartialTsumugiConfig::default();
+        // Explicitly set back to the default value of 8192.
+        project.llm.max_context_tokens = Some(default_max_context_tokens());
+
+        global.merge_from(&project);
+        let final_config = global.into_final();
+
+        assert_eq!(
+            final_config.llm.max_context_tokens,
+            default_max_context_tokens()
+        );
+    }
+
+    #[test]
+    fn skills_compat_override_false_over_true() {
+        // Fix #1: project-local `compat_claude = false` must override global `true`.
+        let mut global = PartialTsumugiConfig::default();
+        global.skills.compat_claude = Some(true);
+        global.skills.compat_agent_skills = Some(true);
+
+        let mut project = PartialTsumugiConfig::default();
+        project.skills.compat_claude = Some(false);
+        // compat_agent_skills not set in project, should remain true.
+
+        global.merge_from(&project);
+        let final_config = global.into_final();
+
+        assert!(!final_config.skills.compat_claude);
+        assert!(final_config.skills.compat_agent_skills);
+    }
+
+    #[test]
+    fn skills_compat_override_true_over_false() {
+        // Fix #1: project-local `compat_claude = true` must override global `false`.
+        let mut global = PartialTsumugiConfig::default();
+        global.skills.compat_claude = Some(false);
+
+        let mut project = PartialTsumugiConfig::default();
+        project.skills.compat_claude = Some(true);
+
+        global.merge_from(&project);
+        let final_config = global.into_final();
+
+        assert!(final_config.skills.compat_claude);
     }
 
     #[test]
     fn env_overrides_apply() {
-        let mut config = TsumugiConfig::default();
+        let mut config = PartialTsumugiConfig::default();
         let env_fn = |key: &str| -> Option<String> {
             match key {
                 "TMG_LLM_ENDPOINT" => Some("http://env:1234".to_owned()),
@@ -449,12 +607,82 @@ mod tests {
             }
         };
 
-        config.apply_env_overrides(&env_fn);
+        config
+            .apply_env_overrides(&env_fn)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let final_config = config.into_final();
 
-        assert_eq!(config.llm.endpoint, "http://env:1234");
-        assert_eq!(config.llm.model, "env-model");
-        assert_eq!(config.llm.max_context_tokens, 16384);
-        assert_eq!(config.sandbox.mode.as_deref(), Some("read_only"));
+        assert_eq!(final_config.llm.endpoint, "http://env:1234");
+        assert_eq!(final_config.llm.model, "env-model");
+        assert_eq!(final_config.llm.max_context_tokens, 16384);
+        assert_eq!(final_config.sandbox.mode, Some(SandboxMode::ReadOnly));
+    }
+
+    #[test]
+    fn env_override_bad_numeric_returns_error() {
+        // Fix #3: unparseable numeric env vars must produce errors.
+        let mut config = PartialTsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            if key == "TMG_LLM_MAX_CONTEXT_TOKENS" {
+                Some("not_a_number".to_owned())
+            } else {
+                None
+            }
+        };
+
+        let result = config.apply_env_overrides(&env_fn);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::InvalidValue { ref field, .. })
+                    if field == "TMG_LLM_MAX_CONTEXT_TOKENS"
+            ),
+            "expected InvalidValue error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn env_override_bad_tool_calling_returns_error() {
+        let mut config = PartialTsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            if key == "TMG_LLM_TOOL_CALLING" {
+                Some("invalid_mode".to_owned())
+            } else {
+                None
+            }
+        };
+
+        let result = config.apply_env_overrides(&env_fn);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::InvalidValue { ref field, .. })
+                    if field == "TMG_LLM_TOOL_CALLING"
+            ),
+            "expected InvalidValue error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn env_override_bad_sandbox_mode_returns_error() {
+        let mut config = PartialTsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            if key == "TMG_SANDBOX_MODE" {
+                Some("invalid_mode".to_owned())
+            } else {
+                None
+            }
+        };
+
+        let result = config.apply_env_overrides(&env_fn);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::InvalidValue { ref field, .. })
+                    if field == "TMG_SANDBOX_MODE"
+            ),
+            "expected InvalidValue error, got {result:?}"
+        );
     }
 
     #[test]
@@ -500,34 +728,6 @@ mod tests {
     }
 
     #[test]
-    fn invalid_tool_calling_rejected() {
-        let mut config = TsumugiConfig::default();
-        config.llm.tool_calling = "invalid".to_owned();
-
-        let Err(err) = config.validate() else {
-            panic!("expected validation to fail for invalid tool_calling");
-        };
-        assert!(
-            matches!(err, ConfigError::InvalidValue { ref field, .. } if field == "llm.tool_calling"),
-            "expected InvalidValue for llm.tool_calling, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn invalid_sandbox_mode_rejected() {
-        let mut config = TsumugiConfig::default();
-        config.sandbox.mode = Some("bad".to_owned());
-
-        let Err(err) = config.validate() else {
-            panic!("expected validation to fail for invalid sandbox mode");
-        };
-        assert!(
-            matches!(err, ConfigError::InvalidValue { ref field, .. } if field == "sandbox.mode"),
-            "expected InvalidValue for sandbox.mode, got {err:?}"
-        );
-    }
-
-    #[test]
     fn load_nonexistent_explicit_path_is_error() {
         let result = load_config_with_env(Some(Path::new("/nonexistent/tsumugi.toml")), &|_| None);
         assert!(matches!(result, Err(ConfigError::NotFound { .. })));
@@ -540,6 +740,7 @@ mod tests {
 endpoint = "http://custom:1234"
 model = "my-model"
 max_context_tokens = 4096
+tool_calling = "native"
 
 [sandbox]
 mode = "read_only"
@@ -552,12 +753,15 @@ show_token_usage = true
 discovery_paths = ["/extra"]
 compat_claude = false
 "#;
-        let config: TsumugiConfig = toml::from_str(toml_str).unwrap_or_else(|e| panic!("{e}"));
+        let partial: PartialTsumugiConfig =
+            toml::from_str(toml_str).unwrap_or_else(|e| panic!("{e}"));
+        let config = partial.into_final();
 
         assert_eq!(config.llm.endpoint, "http://custom:1234");
         assert_eq!(config.llm.model, "my-model");
         assert_eq!(config.llm.max_context_tokens, 4096);
-        assert_eq!(config.sandbox.mode.as_deref(), Some("read_only"));
+        assert_eq!(config.llm.tool_calling, ToolCallingMode::Native);
+        assert_eq!(config.sandbox.mode, Some(SandboxMode::ReadOnly));
         assert_eq!(config.sandbox.timeout_secs, Some(60));
         assert_eq!(config.tui.show_token_usage, Some(true));
         assert!(!config.skills.compat_claude);
@@ -604,54 +808,64 @@ compat_claude = false
 
     #[test]
     fn sandbox_section_merge() {
-        let mut base = TsumugiConfig::default();
+        let mut base = PartialTsumugiConfig::default();
         base.sandbox.timeout_secs = Some(30);
-        base.sandbox.mode = Some("workspace_write".to_owned());
+        base.sandbox.mode = Some(SandboxMode::WorkspaceWrite);
 
-        let mut overlay = TsumugiConfig::default();
-        overlay.sandbox.mode = Some("read_only".to_owned());
+        let mut overlay = PartialTsumugiConfig::default();
+        overlay.sandbox.mode = Some(SandboxMode::ReadOnly);
         // timeout_secs is None, should not override
 
         base.merge_from(&overlay);
+        let final_config = base.into_final();
 
-        assert_eq!(base.sandbox.mode.as_deref(), Some("read_only"));
-        assert_eq!(base.sandbox.timeout_secs, Some(30));
+        assert_eq!(final_config.sandbox.mode, Some(SandboxMode::ReadOnly));
+        assert_eq!(final_config.sandbox.timeout_secs, Some(30));
     }
 
     #[test]
     fn tui_section_merge() {
-        let mut base = TsumugiConfig::default();
+        let mut base = PartialTsumugiConfig::default();
         base.tui.show_token_usage = Some(false);
 
-        let mut overlay = TsumugiConfig::default();
+        let mut overlay = PartialTsumugiConfig::default();
         overlay.tui.show_token_usage = Some(true);
 
         base.merge_from(&overlay);
-        assert_eq!(base.tui.show_token_usage, Some(true));
+        let final_config = base.into_final();
+        assert_eq!(final_config.tui.show_token_usage, Some(true));
     }
 
     #[test]
     fn valid_tool_calling_modes_accepted() {
-        for mode in ["native", "prompt_based", "auto"] {
+        for mode in [
+            ToolCallingMode::Native,
+            ToolCallingMode::PromptBased,
+            ToolCallingMode::Auto,
+        ] {
             let mut config = TsumugiConfig::default();
-            config.llm.tool_calling = mode.to_owned();
+            config.llm.tool_calling = mode;
             assert!(config.validate().is_ok(), "mode {mode} should be valid");
         }
     }
 
     #[test]
     fn valid_sandbox_modes_accepted() {
-        for mode in ["read_only", "workspace_write", "full"] {
+        for mode in [
+            SandboxMode::ReadOnly,
+            SandboxMode::WorkspaceWrite,
+            SandboxMode::Full,
+        ] {
             let mut config = TsumugiConfig::default();
-            config.sandbox.mode = Some(mode.to_owned());
+            config.sandbox.mode = Some(mode);
             assert!(config.validate().is_ok(), "mode {mode} should be valid");
         }
     }
 
     #[test]
-    fn empty_tool_calling_is_valid() {
+    fn default_tool_calling_is_auto() {
         let config = TsumugiConfig::default();
-        // Default empty tool_calling should pass validation (means "auto").
+        assert_eq!(config.llm.tool_calling, ToolCallingMode::Auto);
         assert!(config.validate().is_ok());
     }
 }

--- a/tmg-cli/src/error.rs
+++ b/tmg-cli/src/error.rs
@@ -1,0 +1,43 @@
+//! Structured error types for configuration loading.
+
+use std::path::PathBuf;
+
+/// Errors that can occur during configuration loading and validation.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// The specified configuration file was not found.
+    #[error("configuration file not found: {path}")]
+    NotFound {
+        /// Path that was looked up.
+        path: PathBuf,
+    },
+
+    /// I/O error while reading a configuration file.
+    #[error("failed to read configuration file {path}: {source}")]
+    Io {
+        /// Path of the file that caused the error.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// TOML parse error.
+    #[error("failed to parse configuration file {path}: {source}")]
+    Parse {
+        /// Path of the file that caused the error.
+        path: PathBuf,
+        /// Underlying TOML deserialization error.
+        source: toml::de::Error,
+    },
+
+    /// A configuration field has an invalid value.
+    #[error("invalid value for {field}: {value:?} ({reason})")]
+    InvalidValue {
+        /// Dotted field path (e.g. `llm.endpoint`).
+        field: String,
+        /// The invalid value.
+        value: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+}

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -1,37 +1,50 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
 use tokio::sync::Mutex;
 
+mod config;
+mod error;
+
+use config::TsumugiConfig;
+
 /// tsumugi - a local-LLM-powered coding agent
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Cli {
-    /// Send a one-shot prompt to the LLM server and stream the response to stdout.
+    /// Send a one-shot prompt to the LLM server and stream the response
+    /// to stdout.
     #[arg(long)]
     prompt: Option<String>,
 
-    /// LLM server endpoint URL.
-    #[arg(long, default_value = "http://localhost:8080")]
-    endpoint: String,
+    /// LLM server endpoint URL. Overrides config file and environment.
+    #[arg(long)]
+    endpoint: Option<String>,
 
-    /// Model name to use.
-    #[arg(long, default_value = "default")]
-    model: String,
+    /// Model name to use. Overrides config file and environment.
+    #[arg(long)]
+    model: Option<String>,
+
+    /// Path to a `tsumugi.toml` configuration file.
+    /// When specified, only this file is loaded (no global/project-local
+    /// discovery).
+    #[arg(long)]
+    config: Option<PathBuf>,
 
     /// Maximum context window tokens.
-    #[arg(long, default_value = "8192")]
-    max_context_tokens: usize,
+    #[arg(long)]
+    max_context_tokens: Option<usize>,
 
     /// Context compression threshold (0.0-1.0). Compression auto-triggers
     /// when context usage exceeds this fraction of `max_context_tokens`.
-    #[arg(long, default_value = "0.8")]
-    context_compression_threshold: f64,
+    #[arg(long)]
+    context_compression_threshold: Option<f64>,
 
     /// Maximum tokens for a single tool result before truncation.
-    #[arg(long, default_value = "4096")]
-    max_tool_result_tokens: usize,
+    #[arg(long)]
+    max_tool_result_tokens: Option<usize>,
 
     /// Tool calling mode: "native", "prompt_based", or "auto".
     ///
@@ -42,26 +55,78 @@ struct Cli {
         clippy::doc_markdown,
         reason = "clap renders doc comments as --help text; backticks would show literally"
     )]
-    #[arg(long, default_value = "auto")]
-    tool_calling: tmg_core::ToolCallingMode,
+    #[arg(long)]
+    tool_calling: Option<String>,
+}
+
+impl Cli {
+    /// Apply CLI overrides to the loaded configuration.
+    ///
+    /// CLI options have the highest priority in the merge chain.
+    fn apply_to(&self, config: &mut TsumugiConfig) {
+        if let Some(ref endpoint) = self.endpoint {
+            config.llm.endpoint.clone_from(endpoint);
+        }
+        if let Some(ref model) = self.model {
+            config.llm.model.clone_from(model);
+        }
+        if let Some(max_ctx) = self.max_context_tokens {
+            config.llm.max_context_tokens = max_ctx;
+        }
+        if let Some(threshold) = self.context_compression_threshold {
+            config.llm.compression_threshold = threshold;
+        }
+        if let Some(max_tool) = self.max_tool_result_tokens {
+            config.llm.max_tool_result_tokens = max_tool;
+        }
+        if let Some(ref tc) = self.tool_calling {
+            config.llm.tool_calling.clone_from(tc);
+        }
+    }
 }
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    // Load and merge configuration: global -> project-local -> env -> CLI.
+    let mut config =
+        config::load_config(cli.config.as_deref()).context("loading tsumugi configuration")?;
+    cli.apply_to(&mut config);
+    config.validate().context("validating configuration")?;
+
+    let tool_calling_mode = resolve_tool_calling_mode(&config.llm.tool_calling)
+        .context("resolving tool_calling mode")?;
+
     let context_config = tmg_core::ContextConfig {
-        max_context_tokens: cli.max_context_tokens,
-        compression_threshold: cli.context_compression_threshold,
-        max_tool_result_tokens: cli.max_tool_result_tokens,
+        max_context_tokens: config.llm.max_context_tokens,
+        compression_threshold: config.llm.compression_threshold,
+        max_tool_result_tokens: config.llm.max_tool_result_tokens,
     };
 
     if let Some(prompt) = cli.prompt {
-        run_prompt(&cli.endpoint, &cli.model, &prompt)?;
+        run_prompt(&config.llm.endpoint, &config.llm.model, &prompt)?;
     } else {
-        run_tui(&cli.endpoint, &cli.model, context_config, cli.tool_calling)?;
+        run_tui(
+            &config.llm.endpoint,
+            &config.llm.model,
+            context_config,
+            tool_calling_mode,
+        )?;
     }
 
     Ok(())
+}
+
+/// Resolve a tool-calling mode string to the enum value.
+///
+/// Empty string maps to `Auto` (the default).
+fn resolve_tool_calling_mode(s: &str) -> anyhow::Result<tmg_core::ToolCallingMode> {
+    match s {
+        "" | "auto" => Ok(tmg_core::ToolCallingMode::Auto),
+        "native" => Ok(tmg_core::ToolCallingMode::Native),
+        "prompt_based" => Ok(tmg_core::ToolCallingMode::PromptBased),
+        other => anyhow::bail!("unknown tool_calling mode: {other:?}"),
+    }
 }
 
 /// Run a one-shot streaming prompt against the LLM server.

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
+use tmg_llm::ToolCallingMode;
 use tokio::sync::Mutex;
 
 mod config;
@@ -56,7 +57,7 @@ struct Cli {
         reason = "clap renders doc comments as --help text; backticks would show literally"
     )]
     #[arg(long)]
-    tool_calling: Option<String>,
+    tool_calling: Option<ToolCallingMode>,
 }
 
 impl Cli {
@@ -79,8 +80,8 @@ impl Cli {
         if let Some(max_tool) = self.max_tool_result_tokens {
             config.llm.max_tool_result_tokens = max_tool;
         }
-        if let Some(ref tc) = self.tool_calling {
-            config.llm.tool_calling.clone_from(tc);
+        if let Some(tc) = self.tool_calling {
+            config.llm.tool_calling = tc;
         }
     }
 }
@@ -93,9 +94,6 @@ fn main() -> anyhow::Result<()> {
         config::load_config(cli.config.as_deref()).context("loading tsumugi configuration")?;
     cli.apply_to(&mut config);
     config.validate().context("validating configuration")?;
-
-    let tool_calling_mode = resolve_tool_calling_mode(&config.llm.tool_calling)
-        .context("resolving tool_calling mode")?;
 
     let context_config = tmg_core::ContextConfig {
         max_context_tokens: config.llm.max_context_tokens,
@@ -110,23 +108,11 @@ fn main() -> anyhow::Result<()> {
             &config.llm.endpoint,
             &config.llm.model,
             context_config,
-            tool_calling_mode,
+            config.llm.tool_calling,
         )?;
     }
 
     Ok(())
-}
-
-/// Resolve a tool-calling mode string to the enum value.
-///
-/// Empty string maps to `Auto` (the default).
-fn resolve_tool_calling_mode(s: &str) -> anyhow::Result<tmg_core::ToolCallingMode> {
-    match s {
-        "" | "auto" => Ok(tmg_core::ToolCallingMode::Auto),
-        "native" => Ok(tmg_core::ToolCallingMode::Native),
-        "prompt_based" => Ok(tmg_core::ToolCallingMode::PromptBased),
-        other => anyhow::bail!("unknown tool_calling mode: {other:?}"),
-    }
 }
 
 /// Run a one-shot streaming prompt against the LLM server.


### PR DESCRIPTION
## Summary

- Add `tsumugi.toml` configuration file loading with multi-source merging: global (`~/.config/tsumugi/tsumugi.toml`) -> project-local (`.tsumugi/tsumugi.toml`) -> env vars (`TMG_*`) -> CLI args
- Define config sections: `[llm]`, `[sandbox]`, `[tui]`, `[skills]` with serde deserialization and merge logic
- Add `--config <PATH>` CLI option; make `--endpoint` and `--model` optional (resolved from config chain)
- Implement structured `ConfigError` with `thiserror` 2.x including file path and field context
- Validate endpoint URL format, non-empty model, compression threshold range, tool-calling mode, and sandbox mode
- Use config injection pattern (`env_fn` closure) for environment variable tests to avoid `unsafe` `set_var` in Edition 2024

## Crates modified

- **tmg-cli**: New `config` and `error` modules; updated `Cargo.toml` (added `dirs`, `serde`, `thiserror`, `toml`, `tmg-skills`, `tempfile`); refactored `main.rs` to load config before dispatching

## Test plan

- [x] 17 unit tests covering config merging, env overrides, validation errors, TOML parsing, and file loading
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` passes (275 tests total)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)