### PR TITLE
Add --event-log flag and Claude Code verification skills

### DIFF
--- a/.claude/agents/issue-implementer.md
+++ b/.claude/agents/issue-implementer.md
@@ -80,6 +80,49 @@ Execute the following checks in order:
 - Use `#[expect(lint, reason = "...")]` instead of `#[allow(...)]` for intentional suppressions — `#[expect]` warns when the suppression becomes stale
 - Ensure no `todo!()`, `unimplemented!()`, `dbg!()`, or `println!()` in non-debug code
 
+## 4.5. Runtime Verification (動作確認)
+
+QA チェック通過後、変更がランタイム動作に影響する場合は実際にバイナリを動かして検証する。
+LLM サーバー (`llama-server`) が稼働している場合のみ実行する。未稼働の場合はスキップして記録する。
+
+### ワンショットモード検証
+
+変更内容に応じたプロンプトで `--event-log` 付きワンショット実行を行い、イベントログを検証する:
+
+```bash
+# LLM サーバー疎通確認
+curl -s --max-time 5 "${TMG_LLM_ENDPOINT:-http://localhost:8080}/health" && LLM_AVAILABLE=1 || LLM_AVAILABLE=0
+```
+
+LLM が利用可能な場合:
+
+```bash
+timeout 120 ./target/debug/tmg --prompt "<変更に関連するテストプロンプト>" --event-log /tmp/tmg-verify.jsonl 2>&1
+```
+
+イベントログ (`/tmp/tmg-verify.jsonl`) を読んで以下を確認:
+- `token` イベントが存在する (レスポンスが返っている)
+- `is_error: true` のイベントがない
+- `done` イベントで正常終了している
+- 変更に関連するツール呼び出しがある場合、`tool_call` → `tool_result` ペアが正しい
+
+### TUI モード検証 (任意)
+
+TUI に影響する変更の場合、ユーザーに手動確認を案内する:
+> TUI の動作確認が必要です。PR 作成後に `/run-tui` で検証してください。
+
+### 検証結果の記録
+
+PR 本文に検証結果を追記する:
+
+```
+### Runtime Verification
+- LLM server: available / unavailable (skipped)
+- One-shot mode: PASS / FAIL / SKIP
+  - Events: N tokens, M tool calls, 0 errors
+- TUI mode: manual verification recommended / N/A
+```
+
 ## 5. Worktree Cleanup
 
 - After PR creation, remove the worktree using `git worktree remove`
@@ -132,7 +175,8 @@ Before marking the task complete, verify:
 - [ ] Worktree was created and later removed successfully
 - [ ] Issue requirements were fully addressed
 - [ ] All quality checks (build, clippy, fmt, test) passed
-- [ ] PR was created with proper description and issue linkage
+- [ ] Runtime verification completed (one-shot mode with --event-log) or skipped with reason
+- [ ] PR was created with proper description, issue linkage, and runtime verification results
 - [ ] No uncommitted changes remain
 - [ ] Crate boundaries and workspace structure are respected
 

--- a/.claude/agents/issue-implementer.md
+++ b/.claude/agents/issue-implementer.md
@@ -82,34 +82,65 @@ Execute the following checks in order:
 
 ## 4.5. Runtime Verification (動作確認)
 
-QA チェック通過後、変更がランタイム動作に影響する場合は実際にバイナリを動かして検証する。
+QA チェック通過後、実際にバイナリを動かしてランタイム動作を検証する。
 LLM サーバー (`llama-server`) が稼働している場合のみ実行する。未稼働の場合はスキップして記録する。
 
-### ワンショットモード検証
+### 前提: LLM サーバー疎通確認
+
+```bash
+curl -s --max-time 5 "${TMG_LLM_ENDPOINT:-http://localhost:8080}/health" && echo "LLM_AVAILABLE" || echo "LLM_UNAVAILABLE"
+```
+
+LLM が利用不可能な場合は **ワンショット・TUI 両方をスキップ** して「LLM unavailable — runtime verification skipped」と記録する。
+
+### Step A: ワンショットモード検証
 
 変更内容に応じたプロンプトで `--event-log` 付きワンショット実行を行い、イベントログを検証する:
 
 ```bash
-# LLM サーバー疎通確認
-curl -s --max-time 5 "${TMG_LLM_ENDPOINT:-http://localhost:8080}/health" && LLM_AVAILABLE=1 || LLM_AVAILABLE=0
+timeout 120 ./target/debug/tmg --prompt "<変更に関連するテストプロンプト>" --event-log /tmp/tmg-verify-oneshot.jsonl 2>&1
 ```
 
-LLM が利用可能な場合:
-
-```bash
-timeout 120 ./target/debug/tmg --prompt "<変更に関連するテストプロンプト>" --event-log /tmp/tmg-verify.jsonl 2>&1
-```
-
-イベントログ (`/tmp/tmg-verify.jsonl`) を読んで以下を確認:
+イベントログ (`/tmp/tmg-verify-oneshot.jsonl`) を Read で読んで以下を確認:
 - `token` イベントが存在する (レスポンスが返っている)
 - `is_error: true` のイベントがない
 - `done` イベントで正常終了している
 - 変更に関連するツール呼び出しがある場合、`tool_call` → `tool_result` ペアが正しい
 
-### TUI モード検証 (任意)
+### Step B: TUI モード検証
 
-TUI に影響する変更の場合、ユーザーに手動確認を案内する:
-> TUI の動作確認が必要です。PR 作成後に `/run-tui` で検証してください。
+`expect` コマンドで TUI を起動し、テストプロンプトを送信して `--event-log` でイベントを記録する。
+TUI の描画内容ではなく、**イベントログ** で動作を判定する。
+
+```bash
+expect -c '
+  set timeout 120
+  spawn ./target/debug/tmg --event-log /tmp/tmg-verify-tui.jsonl
+  sleep 3
+  send "<変更に関連するテストプロンプト>\r"
+  sleep 30
+  send "\x03"
+  expect eof
+' 2>&1
+```
+
+- `sleep 3`: TUI の初期化待ち
+- `send "...\r"`: テストプロンプトを入力して Enter
+- `sleep 30`: LLM レスポンスとツール実行の完了待ち (長めに取る)
+- `send "\x03"`: Ctrl+C で正常終了
+
+**expect が使えない場合** は `script` コマンドにフォールバック:
+
+```bash
+script -q /dev/null bash -c '
+  timeout 60 sh -c "sleep 3 && echo \"<テストプロンプト>\" && sleep 30 && kill -INT \$\$" | ./target/debug/tmg --event-log /tmp/tmg-verify-tui.jsonl
+' 2>&1 || true
+```
+
+イベントログ (`/tmp/tmg-verify-tui.jsonl`) を Read で読んで以下を確認:
+- `token` イベントが存在する (TUI 経由でも LLM レスポンスが返っている)
+- ワンショットと同様にエラーがないこと
+- TUI 終了後にターミナルエスケープシーケンスの異常がないこと (expect の出力を確認)
 
 ### 検証結果の記録
 
@@ -120,8 +151,11 @@ PR 本文に検証結果を追記する:
 - LLM server: available / unavailable (skipped)
 - One-shot mode: PASS / FAIL / SKIP
   - Events: N tokens, M tool calls, 0 errors
-- TUI mode: manual verification recommended / N/A
+- TUI mode: PASS / FAIL / SKIP
+  - Events: N tokens, M tool calls, 0 errors
 ```
+
+検証失敗時は原因を調査し、コード修正が必要なら修正→QA再実行→再検証の流れで対応する。
 
 ## 5. Worktree Cleanup
 

--- a/.claude/skills/auto-issue-worker/SKILL.md
+++ b/.claude/skills/auto-issue-worker/SKILL.md
@@ -46,7 +46,7 @@ Task tool:
 
 ### Step 2.5 — Runtime Verification (動作確認)
 
-PR が作成されたら、ワンショットモードで動作確認を行う。
+PR が作成されたら、ワンショット **と** TUI の両方で動作確認を行う。
 LLM サーバーが稼働している場合のみ実行する。
 
 ```bash
@@ -54,25 +54,48 @@ LLM サーバーが稼働している場合のみ実行する。
 curl -s --max-time 5 "${TMG_LLM_ENDPOINT:-http://localhost:8080}/health" && echo "LLM available" || echo "LLM unavailable"
 ```
 
-**LLM が利用可能な場合:**
+**LLM が利用不可能な場合:** 両方スキップして「LLM unavailable — runtime verification skipped」と記録する。
 
-issue の内容に応じた適切なテストプロンプトを選び、ワンショットで実行:
+**LLM が利用可能な場合、以下を順に実行:**
+
+#### A. ワンショットモード検証
+
+issue の内容に応じた適切なテストプロンプトで実行:
 
 ```bash
-timeout 120 ./target/debug/tmg --prompt "<issue に関連するプロンプト>" --event-log /tmp/tmg-issue-<number>.jsonl 2>&1
+timeout 120 ./target/debug/tmg --prompt "<issue に関連するプロンプト>" --event-log /tmp/tmg-issue-<number>-oneshot.jsonl 2>&1
 ```
 
-イベントログ (`/tmp/tmg-issue-<number>.jsonl`) を読んで検証:
-- `token` イベントが存在するか (LLM レスポンスが返っている)
+イベントログを読んで検証:
+- `token` イベントが存在するか
 - `is_error: true` のイベントがないか
 - `done` イベントで正常終了しているか
 
+#### B. TUI モード検証
+
+`expect` で TUI を起動し、テストプロンプトを送って動作を検証する:
+
+```bash
+expect -c '
+  set timeout 120
+  spawn ./target/debug/tmg --event-log /tmp/tmg-issue-<number>-tui.jsonl
+  sleep 3
+  send "<issue に関連するプロンプト>\r"
+  sleep 30
+  send "\x03"
+  expect eof
+' 2>&1
+```
+
+イベントログ (`/tmp/tmg-issue-<number>-tui.jsonl`) を読んで検証:
+- ワンショットと同様に `token` / `done` イベントの存在確認
+- `is_error: true` がないこと
+- TUI 経由でもエージェントループが正常に動作していること
+
 **検証に失敗した場合:**
 1. issue-implementer エージェントに修正を依頼
-2. 修正後に再度 runtime verification を実行
+2. 修正後に再度 runtime verification を実行 (ワンショット + TUI)
 3. 最大 2 回のリトライで解決しない場合はユーザーにフラグを立てて次の issue に進む
-
-**LLM が利用不可能な場合:** スキップして「LLM unavailable — runtime verification skipped」と記録する。
 
 ### Step 3 — Review the PR
 

--- a/.claude/skills/auto-issue-worker/SKILL.md
+++ b/.claude/skills/auto-issue-worker/SKILL.md
@@ -44,6 +44,36 @@ Task tool:
 - The agent will create a worktree, implement the change, run quality checks (`cargo build/clippy --all-targets --all-features/fmt/test --workspace`, plus `cargo deny check` if dependencies changed), and create a PR.
 - Capture the resulting PR number/URL from the agent's output.
 
+### Step 2.5 — Runtime Verification (動作確認)
+
+PR が作成されたら、ワンショットモードで動作確認を行う。
+LLM サーバーが稼働している場合のみ実行する。
+
+```bash
+# LLM サーバー疎通確認
+curl -s --max-time 5 "${TMG_LLM_ENDPOINT:-http://localhost:8080}/health" && echo "LLM available" || echo "LLM unavailable"
+```
+
+**LLM が利用可能な場合:**
+
+issue の内容に応じた適切なテストプロンプトを選び、ワンショットで実行:
+
+```bash
+timeout 120 ./target/debug/tmg --prompt "<issue に関連するプロンプト>" --event-log /tmp/tmg-issue-<number>.jsonl 2>&1
+```
+
+イベントログ (`/tmp/tmg-issue-<number>.jsonl`) を読んで検証:
+- `token` イベントが存在するか (LLM レスポンスが返っている)
+- `is_error: true` のイベントがないか
+- `done` イベントで正常終了しているか
+
+**検証に失敗した場合:**
+1. issue-implementer エージェントに修正を依頼
+2. 修正後に再度 runtime verification を実行
+3. 最大 2 回のリトライで解決しない場合はユーザーにフラグを立てて次の issue に進む
+
+**LLM が利用不可能な場合:** スキップして「LLM unavailable — runtime verification skipped」と記録する。
+
 ### Step 3 — Review the PR
 
 Delegate code review to the **code-reviewer** agent:
@@ -85,5 +115,5 @@ Go back to **Step 1** to pick the next issue.
 - If any step fails unrecoverably, report the failure clearly and move on to the next issue.
 - Do not modify issues that have the `wontfix` or `on-hold` label — skip them.
 - Respect issue dependencies (依存 section): skip issues whose dependencies are not yet closed.
-- Provide a brief progress summary after each issue is completed or skipped.
-- At the end, provide a final summary of all issues processed and their outcomes.
+- Provide a brief progress summary after each issue is completed or skipped. Include runtime verification results (PASS / FAIL / SKIP).
+- At the end, provide a final summary of all issues processed and their outcomes, including runtime verification status for each.

--- a/.claude/skills/run-oneshot/SKILL.md
+++ b/.claude/skills/run-oneshot/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: run-oneshot
+description: |
+  tsumugiをワンショットモードで実行し、動作確認を行う。
+  --event-log でイベントを記録し、stdout出力とログの両方から動作を検証する。
+  `/run-oneshot` で起動。引数にプロンプト文字列を指定可能。
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# tsumugi ワンショット実行スキル
+
+tsumugiバイナリ (`tmg`) をワンショットモード (`--prompt`) で実行し、`--event-log` による構造化イベントログで動作を検証する。
+
+## 前提条件の確認
+
+### 1. バイナリのビルド
+
+```bash
+cargo build --workspace 2>&1
+```
+
+ビルドに失敗した場合はエラーを報告して終了。
+
+### 2. LLMサーバーの稼働確認
+
+設定ファイルまたは環境変数からエンドポイントを取得し、疎通を確認する。
+
+```bash
+# 設定ファイルの確認 (優先順: プロジェクトローカル → グローバル)
+cat .tsumugi/tsumugi.toml 2>/dev/null || cat ~/.config/tsumugi/tsumugi.toml 2>/dev/null || echo "no config"
+
+# 環境変数の確認
+echo "TMG_LLM_ENDPOINT=${TMG_LLM_ENDPOINT:-未設定}"
+echo "TMG_LLM_MODEL=${TMG_LLM_MODEL:-未設定}"
+```
+
+エンドポイントが判明したら疎通チェック:
+
+```bash
+curl -s --max-time 5 <endpoint>/health || curl -s --max-time 5 <endpoint>/v1/models
+```
+
+**サーバーが起動していない場合**はユーザーに案内して終了する。
+
+### 3. ワンショット実行
+
+イベントログを有効にして実行する。プロンプトが引数で指定されていればそれを使い、なければデフォルトを使用。
+
+```bash
+timeout 120 ./target/debug/tmg --prompt "<prompt>" --event-log /tmp/tmg-oneshot.jsonl 2>&1
+```
+
+**デフォルトのテストプロンプト:**
+- 基本応答: `"Hello, what is 2+2?"`
+
+### 4. 出力とイベントログの検証
+
+**stdout 出力の確認:**
+- レスポンスが空でないこと
+- `[done: ...]` が出力されていること
+- パニックやエラーがないこと
+
+**イベントログの確認:**
+
+```
+Read /tmp/tmg-oneshot.jsonl
+```
+
+イベントログは JSON Lines 形式:
+```jsonl
+{"elapsed_ms":0,"event":{"type":"thinking","token":"..."}}
+{"elapsed_ms":150,"event":{"type":"token","token":"..."}}
+{"elapsed_ms":200,"event":{"type":"tool_call","name":"file_read","arguments":"{...}"}}
+{"elapsed_ms":1200,"event":{"type":"tool_result","name":"file_read","output":"...","is_error":false}}
+{"elapsed_ms":3000,"event":{"type":"done"}}
+```
+
+### 5. レポート
+
+```
+## ワンショット実行レポート
+
+- エンドポイント: <endpoint>
+- モデル: <model>
+- プロンプト: "<prompt>"
+
+### 結果: PASS / FAIL
+
+### stdout 出力 (抜粋)
+<出力の要点>
+
+### イベントログサマリ
+- 総イベント数: N
+- token イベント: N
+- tool_call: N
+- 合計所要時間: Nms
+
+### 問題点 (あれば)
+<問題の詳細>
+```
+
+## ルール
+
+- コードの変更は行わない (read-only)
+- LLMサーバーが未起動の場合は実行せず案内のみ行う
+- 出力が非常に長い場合は要点を抜粋する
+- タイムアウトは 2 分

--- a/.claude/skills/run-tui/SKILL.md
+++ b/.claude/skills/run-tui/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: run-tui
+description: |
+  tsumugiをTUIモードで起動し、対話的な動作確認を行う。
+  --event-log でイベントログを出力し、Claudeがログファイルを読んで動作を検証する。
+  `/run-tui` で起動。引数にテストしたいプロンプトを指定可能。
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# tsumugi TUI 実行スキル
+
+tsumugiバイナリ (`tmg`) をTUIモードで起動し、`--event-log` による構造化イベントログで動作を検証する。
+
+## 前提条件の確認
+
+### 1. バイナリのビルド
+
+```bash
+cargo build --workspace 2>&1
+```
+
+ビルドに失敗した場合はエラーを報告して終了。
+
+### 2. LLMサーバーの稼働確認
+
+設定ファイルまたは環境変数からエンドポイントを取得し、疎通を確認する。
+
+```bash
+# 設定ファイルの確認
+cat .tsumugi/tsumugi.toml 2>/dev/null || cat ~/.config/tsumugi/tsumugi.toml 2>/dev/null || echo "no config"
+
+# 環境変数の確認
+echo "TMG_LLM_ENDPOINT=${TMG_LLM_ENDPOINT:-未設定}"
+echo "TMG_LLM_MODEL=${TMG_LLM_MODEL:-未設定}"
+```
+
+エンドポイントが判明したら疎通チェック:
+
+```bash
+curl -s --max-time 5 <endpoint>/health || curl -s --max-time 5 <endpoint>/v1/models
+```
+
+**サーバーが起動していない場合**はユーザーに案内して終了する。
+
+### 3. TUI起動
+
+TUIはインタラクティブなので、ユーザーに `!` コマンドでの起動を案内する。
+**必ず `--event-log` フラグを付ける:**
+
+> 以下のコマンドでTUIを起動してください:
+> ```
+> ! ./target/debug/tmg --event-log /tmp/tmg-events.jsonl
+> ```
+> TUI操作後、Ctrl+C で終了してください。
+
+### 4. イベントログの検証
+
+ユーザーがTUIを終了したら、イベントログを読んで動作を検証する:
+
+```bash
+# Read tool で /tmp/tmg-events.jsonl を読む
+```
+
+イベントログは JSON Lines 形式で、各行が1イベント:
+
+```jsonl
+{"elapsed_ms":0,"event":{"type":"thinking","token":"..."}}
+{"elapsed_ms":150,"event":{"type":"token","token":"..."}}
+{"elapsed_ms":200,"event":{"type":"tool_call","name":"file_read","arguments":"{...}"}}
+{"elapsed_ms":1200,"event":{"type":"tool_result","name":"file_read","output":"...","is_error":false}}
+{"elapsed_ms":3000,"event":{"type":"done"}}
+```
+
+**イベントタイプ:**
+- `thinking` — LLMの思考トークン
+- `token` — LLMの応答テキストトークン
+- `tool_call` — ツール呼び出し (name + arguments)
+- `tool_result` — ツール実行結果 (name + output + is_error)
+- `done` — ターン完了
+- `warning` — 非致命的警告
+
+### 5. 検証観点
+
+イベントログから以下を確認する:
+
+- **レスポンス生成**: `token` イベントが存在するか
+- **ツール実行**: `tool_call` → `tool_result` のペアが正しいか
+- **エラー**: `is_error: true` のイベントがないか
+- **完了**: `done` イベントで正常終了しているか
+- **レイテンシ**: `elapsed_ms` の値からレスポンス速度が妥当か
+
+## テストシナリオ
+
+ユーザーに以下のシナリオでの操作を提案する:
+
+### 基本応答テスト
+> TUIで「Hello」と入力 → ログに `token` イベントが記録されることを確認
+
+### ツール実行テスト
+> TUIで「Cargo.toml を読んで」と入力 → `tool_call` (file_read) と `tool_result` が記録されることを確認
+
+### 日本語テスト
+> TUIで日本語の指示を入力 → `token` イベントで日本語が正しく出力されることを確認
+
+## レポートフォーマット
+
+```
+## TUI 動作確認レポート
+
+- エンドポイント: <endpoint>
+- モデル: <model>
+- イベントログ: /tmp/tmg-events.jsonl
+
+| 確認項目 | 結果 |
+|----------|------|
+| TUI起動・終了 | PASS / FAIL |
+| LLMレスポンス | PASS / FAIL |
+| ツール呼び出し | PASS / FAIL / N/A |
+| エラーなし | PASS / FAIL |
+
+### イベントサマリ
+- 総イベント数: N
+- token イベント: N
+- tool_call / tool_result: N
+- 合計所要時間: Nms
+
+### 問題点 (あれば)
+<問題の詳細>
+```
+
+## ルール
+
+- コードの変更は行わない (read-only)
+- LLMサーバーが未起動の場合は実行せず案内のみ行う
+- TUI起動はユーザーに `!` コマンドで委ねる
+- 検証はイベントログファイルの `Read` で行う (画面キャプチャは使わない)

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: verify
+description: |
+  tsumugiプロジェクトの動作確認を行う。ビルド、lint、フォーマット、テスト、
+  バイナリのスモークテストを順に実行し、結果をレポートする。
+  `/verify` で起動。
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# tsumugi 動作確認スキル
+
+tsumugi (local-LLM-powered coding agent) プロジェクトの品質ゲートを一括で実行し、結果をレポートする。
+
+## 実行手順
+
+以下のステップを順に実行し、各ステップの成否を記録する。
+**いずれかのステップが失敗しても、残りのステップは続行する。**
+
+### Step 1 — ビルド
+
+```bash
+cargo build --workspace --all-targets 2>&1
+```
+
+- 成功: `Compiling` / `Finished` で終了
+- 失敗: コンパイルエラーを記録
+
+### Step 2 — Clippy (lint)
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings 2>&1
+```
+
+- 成功: warning なし
+- 失敗: 警告/エラーを記録
+
+### Step 3 — フォーマットチェック
+
+```bash
+cargo fmt --all -- --check 2>&1
+```
+
+- 成功: 差分なし
+- 失敗: フォーマット違反のファイル一覧を記録
+
+### Step 4 — テスト
+
+```bash
+cargo test --workspace 2>&1
+```
+
+- 成功: 全テスト pass
+- 失敗: 失敗したテスト名とエラーメッセージを記録
+
+### Step 5 — バイナリ スモークテスト
+
+ビルドが成功している場合のみ実行:
+
+```bash
+./target/debug/tmg --help 2>&1
+```
+
+- 成功: ヘルプテキストが出力される
+- 失敗: 実行時エラーを記録
+
+### Step 6 — 依存関係チェック (任意)
+
+`cargo-deny` がインストールされている場合のみ:
+
+```bash
+command -v cargo-deny && cargo deny check 2>&1 || echo "cargo-deny not installed, skipping"
+```
+
+## レポートフォーマット
+
+全ステップ完了後、以下の形式でサマリを出力する:
+
+```
+## 動作確認レポート
+
+| ステップ | 結果 |
+|----------|------|
+| ビルド | PASS / FAIL |
+| Clippy | PASS / FAIL |
+| フォーマット | PASS / FAIL |
+| テスト | PASS / FAIL (N passed, M failed) |
+| スモークテスト | PASS / FAIL / SKIP |
+| 依存関係チェック | PASS / FAIL / SKIP |
+
+### 問題の詳細
+(失敗したステップがあれば、エラー内容と修正の方針を記載)
+```
+
+## ルール
+
+- 各コマンドのタイムアウトは 5 分とする
+- 失敗したステップがあっても残りは必ず実行する (fail-forward)
+- エラー出力が長い場合は要点のみ抜粋する
+- 修正が必要な場合は、具体的なファイルパスと修正方針を提案する
+- このスキルはコードの変更を行わない (read-only)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,7 @@ name = "tmg-core"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "serde",
  "serde_json",
  "thiserror",
  "tmg-llm",

--- a/crates/tmg-core/Cargo.toml
+++ b/crates/tmg-core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 tmg-llm = { workspace = true }
 tmg-tools = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/tmg-core/src/event_log.rs
+++ b/crates/tmg-core/src/event_log.rs
@@ -1,0 +1,254 @@
+//! Structured event logging for agent loop diagnostics.
+//!
+//! Provides [`EventLogWriter`] for writing JSON Lines event logs, and
+//! [`TeeStreamSink`] for transparently logging events while forwarding
+//! them to another [`StreamSink`].
+
+use std::fs::File;
+use std::io::{BufWriter, Write as _};
+use std::path::Path;
+use std::time::Instant;
+
+use serde::Serialize;
+
+use crate::agent_loop::StreamSink;
+use crate::error::CoreError;
+
+// ---------------------------------------------------------------------------
+// Event types
+// ---------------------------------------------------------------------------
+
+/// A single logged event with elapsed time.
+#[derive(Serialize)]
+struct EventRecord<'a> {
+    elapsed_ms: u128,
+    event: &'a EventKind,
+}
+
+/// The kind of event that occurred during a conversation turn.
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum EventKind {
+    #[serde(rename = "thinking")]
+    Thinking { token: String },
+    #[serde(rename = "token")]
+    Token { token: String },
+    #[serde(rename = "done")]
+    Done,
+    #[serde(rename = "tool_call")]
+    ToolCall { name: String, arguments: String },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        name: String,
+        output: String,
+        is_error: bool,
+    },
+    #[serde(rename = "warning")]
+    Warning { message: String },
+}
+
+// ---------------------------------------------------------------------------
+// EventLogWriter
+// ---------------------------------------------------------------------------
+
+/// Writes structured events to a JSON Lines file.
+pub struct EventLogWriter {
+    writer: BufWriter<File>,
+    start: Instant,
+}
+
+impl EventLogWriter {
+    /// Open (or create) a file at `path` for writing events.
+    /// Truncates the file if it already exists.
+    pub fn new(path: &Path) -> std::io::Result<Self> {
+        let file = File::create(path)?;
+        Ok(Self {
+            writer: BufWriter::new(file),
+            start: Instant::now(),
+        })
+    }
+
+    /// Open a file at `path` in append mode for writing events.
+    /// Creates the file if it does not exist.
+    pub fn open_append(path: &Path) -> std::io::Result<Self> {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        Ok(Self {
+            writer: BufWriter::new(file),
+            start: Instant::now(),
+        })
+    }
+
+    /// Log a thinking token event.
+    pub fn write_thinking(&mut self, token: &str) {
+        let event = EventKind::Thinking {
+            token: token.to_owned(),
+        };
+        self.write_event(&event);
+    }
+
+    /// Log a content token event.
+    pub fn write_token(&mut self, token: &str) {
+        let event = EventKind::Token {
+            token: token.to_owned(),
+        };
+        self.write_event(&event);
+    }
+
+    /// Log a tool call event.
+    pub fn write_tool_call(&mut self, name: &str, arguments: &str) {
+        let event = EventKind::ToolCall {
+            name: name.to_owned(),
+            arguments: arguments.to_owned(),
+        };
+        self.write_event(&event);
+    }
+
+    /// Log a tool result event.
+    pub fn write_tool_result(&mut self, name: &str, output: &str, is_error: bool) {
+        let event = EventKind::ToolResult {
+            name: name.to_owned(),
+            output: output.to_owned(),
+            is_error,
+        };
+        self.write_event(&event);
+    }
+
+    /// Log a done event.
+    pub fn write_done(&mut self) {
+        self.write_event(&EventKind::Done);
+    }
+
+    /// Write one event record as a JSON line. Flushes immediately for
+    /// real-time observability. Errors are silently ignored so that
+    /// logging never disrupts the agent loop.
+    fn write_event(&mut self, event: &EventKind) {
+        let record = EventRecord {
+            elapsed_ms: self.start.elapsed().as_millis(),
+            event,
+        };
+        // Best-effort: ignore serialization and I/O errors.
+        if serde_json::to_writer(&mut self.writer, &record).is_ok() {
+            let _ = self.writer.write_all(b"\n");
+            let _ = self.writer.flush();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TeeStreamSink
+// ---------------------------------------------------------------------------
+
+/// A [`StreamSink`] that logs every event to an [`EventLogWriter`] before
+/// forwarding it to an inner sink.
+pub struct TeeStreamSink<S> {
+    inner: S,
+    log: EventLogWriter,
+}
+
+impl<S: StreamSink> TeeStreamSink<S> {
+    /// Create a new tee that writes events to `log` and forwards to `inner`.
+    pub fn new(inner: S, log: EventLogWriter) -> Self {
+        Self { inner, log }
+    }
+}
+
+impl<S: StreamSink> StreamSink for TeeStreamSink<S> {
+    fn on_thinking(&mut self, token: &str) -> Result<(), CoreError> {
+        self.log.write_thinking(token);
+        self.inner.on_thinking(token)
+    }
+
+    fn on_token(&mut self, token: &str) -> Result<(), CoreError> {
+        self.log.write_token(token);
+        self.inner.on_token(token)
+    }
+
+    fn on_done(&mut self) -> Result<(), CoreError> {
+        self.log.write_done();
+        self.inner.on_done()
+    }
+
+    fn on_tool_call(&mut self, name: &str, arguments: &str) -> Result<(), CoreError> {
+        self.log.write_tool_call(name, arguments);
+        self.inner.on_tool_call(name, arguments)
+    }
+
+    fn on_tool_result(
+        &mut self,
+        name: &str,
+        output: &str,
+        is_error: bool,
+    ) -> Result<(), CoreError> {
+        self.log.write_tool_result(name, output, is_error);
+        self.inner.on_tool_result(name, output, is_error)
+    }
+
+    fn on_warning(&mut self, message: &str) -> Result<(), CoreError> {
+        let event = EventKind::Warning {
+            message: message.to_owned(),
+        };
+        self.log.write_event(&event);
+        self.inner.on_warning(message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read as _;
+
+    /// A no-op sink for testing the tee.
+    struct NullSink;
+
+    impl StreamSink for NullSink {
+        fn on_token(&mut self, _token: &str) -> Result<(), CoreError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn event_log_writes_jsonl() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = std::env::temp_dir().join("tmg-event-log-test");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("test.jsonl");
+
+        {
+            let log = EventLogWriter::new(&path)?;
+            let mut tee = TeeStreamSink::new(NullSink, log);
+            tee.on_token("hello")?;
+            tee.on_tool_call("file_read", r#"{"path":"Cargo.toml"}"#)?;
+            tee.on_tool_result("file_read", "[workspace]", false)?;
+            tee.on_done()?;
+        }
+
+        let mut contents = String::new();
+        File::open(&path)?.read_to_string(&mut contents)?;
+
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 4);
+
+        // Verify each line is valid JSON with expected type field.
+        let first: serde_json::Value = serde_json::from_str(lines[0])?;
+        assert_eq!(first["event"]["type"], "token");
+        assert_eq!(first["event"]["token"], "hello");
+        assert!(first["elapsed_ms"].is_number());
+
+        let second: serde_json::Value = serde_json::from_str(lines[1])?;
+        assert_eq!(second["event"]["type"], "tool_call");
+
+        let third: serde_json::Value = serde_json::from_str(lines[2])?;
+        assert_eq!(third["event"]["type"], "tool_result");
+
+        let fourth: serde_json::Value = serde_json::from_str(lines[3])?;
+        assert_eq!(fourth["event"]["type"], "done");
+
+        // Cleanup.
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+
+        Ok(())
+    }
+}

--- a/crates/tmg-core/src/lib.rs
+++ b/crates/tmg-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod agent_loop;
 pub mod context;
 pub mod error;
+pub mod event_log;
 pub mod message;
 pub mod prompt;
 
@@ -11,6 +12,7 @@ pub use context::{
     ContextCompressor, ContextConfig, TokenCounter, format_context_usage, truncate_tool_result,
 };
 pub use error::CoreError;
+pub use event_log::{EventLogWriter, TeeStreamSink};
 pub use message::Message;
 
 // Re-export ToolCallingMode from tmg-llm for downstream consumers.

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -104,6 +104,10 @@ struct TurnHandle {
 }
 
 /// The main application state.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "TUI state flags are independent and rarely change together"
+)]
 pub struct App {
     /// The agent loop driving LLM conversations.
     ///
@@ -164,11 +168,20 @@ pub struct App {
 
     /// Whether the model is currently in the thinking/reasoning phase.
     thinking: bool,
+
+    /// Optional path for structured event logging (JSON Lines).
+    event_log_path: Option<PathBuf>,
 }
 
 impl App {
     /// Create a new `App` with the given agent loop and model name.
-    pub fn new(agent: AgentLoop, model_name: &str, project_root: PathBuf, cwd: PathBuf) -> Self {
+    pub fn new(
+        agent: AgentLoop,
+        model_name: &str,
+        project_root: PathBuf,
+        cwd: PathBuf,
+        event_log: Option<PathBuf>,
+    ) -> Self {
         let max_tokens = agent.context_config().max_context_tokens;
         let context_usage = format_context_usage(0, max_tokens);
         Self {
@@ -191,6 +204,7 @@ impl App {
             custom_agents: Vec::new(),
             pending_compact: false,
             thinking: false,
+            event_log_path: event_log,
         }
     }
 
@@ -592,9 +606,21 @@ impl App {
 
         let (tx, rx) = mpsc::channel::<TurnMessage>(256);
 
+        // Open the event log writer if configured (append mode so all
+        // turns accumulate in a single file).
+        let event_log_writer = self.event_log_path.as_deref().and_then(|path| {
+            tmg_core::EventLogWriter::open_append(path).ok()
+        });
+
         let join = tokio::spawn(async move {
-            let mut sink = ChannelStreamSink { tx: tx.clone() };
-            let result = agent.turn(&user_input, &mut sink).await;
+            let channel_sink = ChannelStreamSink { tx: tx.clone() };
+            let result = if let Some(log) = event_log_writer {
+                let mut tee = tmg_core::TeeStreamSink::new(channel_sink, log);
+                agent.turn(&user_input, &mut tee).await
+            } else {
+                let mut sink = channel_sink;
+                agent.turn(&user_input, &mut sink).await
+            };
 
             match result {
                 Ok(()) => {

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -39,10 +39,15 @@ use tokio_util::sync::CancellationToken;
 /// * `cwd` - Current working directory for prompt file loading.
 /// * `subagent_manager` - Optional shared subagent manager for status display.
 /// * `custom_agents` - Custom agent definitions for `/agents` list display.
+/// * `event_log` - Optional path to write structured event log (JSON Lines).
 ///
 /// # Errors
 ///
 /// Returns `TuiError` on terminal I/O failure or agent errors.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "entry point collecting all setup parameters; a config struct would add indirection without clarity"
+)]
 pub async fn run(
     agent: AgentLoop,
     model_name: &str,
@@ -51,6 +56,7 @@ pub async fn run(
     cwd: PathBuf,
     subagent_manager: Option<Arc<Mutex<SubagentManager>>>,
     custom_agents: Vec<CustomAgentDef>,
+    event_log: Option<PathBuf>,
 ) -> Result<(), TuiError> {
     let mut terminal = ratatui::init();
 
@@ -82,7 +88,7 @@ pub async fn run(
         original_hook(info);
     }));
 
-    let mut app = App::new(agent, model_name, project_root, cwd);
+    let mut app = App::new(agent, model_name, project_root, cwd, event_log);
 
     if let Some(manager) = subagent_manager {
         app.set_subagent_manager(manager);

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -58,6 +58,12 @@ struct Cli {
     )]
     #[arg(long)]
     tool_calling: Option<ToolCallingMode>,
+
+    /// Path to write structured event log (JSON Lines format).
+    /// Enables diagnostics by recording every agent event (tokens,
+    /// tool calls, results) to the specified file.
+    #[arg(long)]
+    event_log: Option<PathBuf>,
 }
 
 impl Cli {
@@ -102,13 +108,19 @@ fn main() -> anyhow::Result<()> {
     };
 
     if let Some(prompt) = cli.prompt {
-        run_prompt(&config.llm.endpoint, &config.llm.model, &prompt)?;
+        run_prompt(
+            &config.llm.endpoint,
+            &config.llm.model,
+            &prompt,
+            cli.event_log.as_deref(),
+        )?;
     } else {
         run_tui(
             &config.llm.endpoint,
             &config.llm.model,
             context_config,
             config.llm.tool_calling,
+            cli.event_log,
         )?;
     }
 
@@ -123,9 +135,19 @@ fn main() -> anyhow::Result<()> {
     clippy::print_stdout,
     reason = "integration check: intentional stdout streaming output"
 )]
-fn run_prompt(endpoint: &str, model: &str, prompt: &str) -> anyhow::Result<()> {
+fn run_prompt(
+    endpoint: &str,
+    model: &str,
+    prompt: &str,
+    event_log: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
     use std::io::Write as _;
     use tokio_stream::StreamExt as _;
+
+    let mut log_writer = event_log
+        .map(tmg_core::EventLogWriter::new)
+        .transpose()
+        .context("opening event log file")?;
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
@@ -144,20 +166,32 @@ fn run_prompt(endpoint: &str, model: &str, prompt: &str) -> anyhow::Result<()> {
 
         while let Some(event) = stream.next().await {
             match event? {
-                tmg_llm::StreamEvent::ThinkingDelta(_) => {
+                tmg_llm::StreamEvent::ThinkingDelta(token) => {
+                    if let Some(ref mut log) = log_writer {
+                        log.write_thinking(&token);
+                    }
                     // Thinking tokens are not displayed in one-shot mode.
                 }
                 tmg_llm::StreamEvent::ContentDelta(text) => {
+                    if let Some(ref mut log) = log_writer {
+                        log.write_token(&text);
+                    }
                     print!("{text}");
                     std::io::stdout().flush()?;
                 }
                 tmg_llm::StreamEvent::ToolCallComplete(tc) => {
+                    if let Some(ref mut log) = log_writer {
+                        log.write_tool_call(&tc.function.name, &tc.function.arguments);
+                    }
                     println!(
                         "\n[tool_call] {}({})",
                         tc.function.name, tc.function.arguments
                     );
                 }
                 tmg_llm::StreamEvent::Done(reason) => {
+                    if let Some(ref mut log) = log_writer {
+                        log.write_done();
+                    }
                     println!();
                     if let Some(r) = reason {
                         println!("[done: {r}]");
@@ -181,6 +215,7 @@ fn run_tui(
     model: &str,
     context_config: tmg_core::ContextConfig,
     tool_calling_mode: tmg_core::ToolCallingMode,
+    event_log: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
@@ -241,6 +276,7 @@ fn run_tui(
             cwd,
             Some(subagent_manager),
             custom_agent_defs,
+            event_log,
         )
         .await?;
 


### PR DESCRIPTION
## Summary

- `--event-log <path>` フラグを追加し、エージェントループのイベント（トークン、ツール呼び出し、結果等）をJSON Lines形式でファイルに出力する機能を実装
- `EventLogWriter` + `TeeStreamSink` を `tmg-core` に追加。既存の `StreamSink` トレイトを活用し、AgentLoop 本体は変更なし
- Claude Code の動作確認スキル `/verify`, `/run-oneshot`, `/run-tui` を追加

## Test plan

- [x] `cargo build --workspace` pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass
- [x] `cargo test --workspace` pass (新規テスト `event_log_writes_jsonl` 含む)
- [ ] ワンショット: `./target/debug/tmg --prompt "hello" --event-log /tmp/test.jsonl` でログが出力される
- [ ] TUI: `./target/debug/tmg --event-log /tmp/tui.jsonl` で操作後にログが記録される
- [ ] `--event-log` なしで従来通り動作する (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)