### PR TITLE
Add tmg-harness crate with Run/Session model and startup integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "tracing",
  "uuid",
 ]
 
@@ -2039,7 +2040,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +171,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +241,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossterm"
@@ -481,9 +508,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -609,6 +649,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +794,8 @@ checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -807,6 +879,12 @@ dependencies = [
  "libc",
  "thiserror",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1002,6 +1080,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1192,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1364,6 +1458,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1669,6 +1769,7 @@ dependencies = [
  "thiserror",
  "tmg-agents",
  "tmg-core",
+ "tmg-harness",
  "tmg-llm",
  "tmg-sandbox",
  "tmg-skills",
@@ -1693,6 +1794,19 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+]
+
+[[package]]
+name = "tmg-harness"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -1764,6 +1878,7 @@ dependencies = [
  "thiserror",
  "tmg-agents",
  "tmg-core",
+ "tmg-harness",
  "tmg-llm",
  "tokio",
  "tokio-util",
@@ -1984,6 +2099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2133,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2049,7 +2181,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2108,6 +2249,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,6 +2281,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2172,10 +2347,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2347,6 +2575,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ clap = { version = "4", features = ["derive"] }
 thiserror = "2"
 anyhow = "1"
 
+# Logging / diagnostics
+tracing = "0.1"
+
 # Random
 rand = "0.9"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/tmg-agents",
     "crates/tmg-sandbox",
     "crates/tmg-tui",
+    "crates/tmg-harness",
     "tmg-cli",
 ]
 
@@ -59,6 +60,12 @@ unicode-width = "0.2"
 # Platform directories
 dirs = "6"
 
+# Time
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
+
+# UUID
+uuid = { version = "1", features = ["v4"] }
+
 # Testing
 tempfile = "3"
 proptest = "1"
@@ -75,6 +82,7 @@ tmg-skills = { path = "crates/tmg-skills" }
 tmg-agents = { path = "crates/tmg-agents" }
 tmg-sandbox = { path = "crates/tmg-sandbox" }
 tmg-tui = { path = "crates/tmg-tui" }
+tmg-harness = { path = "crates/tmg-harness" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/tmg-harness/Cargo.toml
+++ b/crates/tmg-harness/Cargo.toml
@@ -11,6 +11,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tmg-harness/Cargo.toml
+++ b/crates/tmg-harness/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tmg-harness"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tmg-harness/src/error.rs
+++ b/crates/tmg-harness/src/error.rs
@@ -1,0 +1,56 @@
+//! Error types for the harness layer.
+//!
+//! Errors are surfaced from [`RunStore`](crate::store::RunStore) and
+//! [`RunRunner`](crate::runner::RunRunner) operations. Each variant
+//! captures enough context (path, run id) to be actionable when
+//! propagated to the CLI.
+
+use std::path::PathBuf;
+
+/// Errors that can occur when manipulating runs and sessions.
+#[derive(Debug, thiserror::Error)]
+pub enum HarnessError {
+    /// I/O error while accessing a run directory or `run.toml`.
+    #[error("I/O error at {path}: {source}")]
+    Io {
+        /// Path being accessed when the error occurred.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// Failed to serialize a [`Run`](crate::run::Run) to TOML.
+    #[error("failed to serialize run.toml at {path}: {source}")]
+    Serialize {
+        /// Target file path.
+        path: PathBuf,
+        /// Underlying serialization error.
+        source: toml::ser::Error,
+    },
+
+    /// Failed to deserialize `run.toml` from disk.
+    #[error("failed to parse run.toml at {path}: {source}")]
+    Deserialize {
+        /// Source file path.
+        path: PathBuf,
+        /// Underlying deserialization error.
+        source: toml::de::Error,
+    },
+
+    /// A requested run could not be found.
+    #[error("run not found: {run_id}")]
+    RunNotFound {
+        /// The run id that was looked up.
+        run_id: String,
+    },
+}
+
+impl HarnessError {
+    /// Construct an [`HarnessError::Io`] from a path and `std::io::Error`.
+    pub fn io(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        Self::Io {
+            path: path.into(),
+            source,
+        }
+    }
+}

--- a/crates/tmg-harness/src/error.rs
+++ b/crates/tmg-harness/src/error.rs
@@ -43,6 +43,18 @@ pub enum HarnessError {
         /// The run id that was looked up.
         run_id: String,
     },
+
+    /// The run id stored in `run.toml` did not match the directory it
+    /// was loaded from. This indicates a corrupted or hand-edited run
+    /// directory; we refuse to load rather than silently use the wrong
+    /// id.
+    #[error("run id mismatch: expected {expected}, found {found} in run.toml")]
+    IdMismatch {
+        /// Run id derived from the directory name (what the caller asked for).
+        expected: String,
+        /// Run id actually present inside the loaded `run.toml`.
+        found: String,
+    },
 }
 
 impl HarnessError {

--- a/crates/tmg-harness/src/lib.rs
+++ b/crates/tmg-harness/src/lib.rs
@@ -1,0 +1,29 @@
+//! tsumugi run/session harness.
+//!
+//! This crate introduces the unified "Run" model described in SPEC §9.
+//! Every interaction with `tmg` happens within a [`Run`], whether
+//! ad-hoc (interactive TUI session) or harnessed by a workflow.
+//!
+//! The crate is intentionally minimal in this first slice: it
+//! provides the data model, a TOML-backed [`RunStore`], and a
+//! [`RunRunner`] that the CLI startup sequence uses to attach the
+//! existing `AgentLoop` to a persisted run.
+//!
+//! Forthcoming features (tracked as separate issues):
+//!
+//! - `progress.md` / `session_log.jsonl` writers
+//! - `features.json` schema for harnessed runs
+//! - workflow engine integration and escalation evaluator
+//! - `tmg run` CLI subcommand and richer TUI surface
+
+pub mod error;
+pub mod run;
+pub mod runner;
+pub mod session;
+pub mod store;
+
+pub use error::HarnessError;
+pub use run::{Run, RunId, RunScope, RunStatus, RunSummary};
+pub use runner::RunRunner;
+pub use session::{Session, SessionEndTrigger, SessionHandle};
+pub use store::{RUN_FILENAME, RunStore, WORKSPACE_LINK};

--- a/crates/tmg-harness/src/run.rs
+++ b/crates/tmg-harness/src/run.rs
@@ -1,0 +1,310 @@
+//! Run data model.
+//!
+//! A [`Run`] is the top-level unit of work in tsumugi. Each run has a
+//! unique [`RunId`], a [`RunScope`] indicating whether it is ad-hoc or
+//! managed by a workflow harness, and a [`RunStatus`] tracking its
+//! lifecycle. Multiple [`Session`](crate::session::Session)s may be
+//! associated with a single run; the run's `session_count` and
+//! `last_session_at` are updated each time a session begins.
+//!
+//! The on-disk format is `run.toml` under `.tsumugi/runs/<run-id>/`,
+//! using the structure described in SPEC §9.5.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Short hex identifier for a run, e.g. `"a3f1e2b9"`.
+///
+/// Generated from a UUID v4 by taking the first 8 hex characters of the
+/// simple representation. Short ids are user-friendly for display and
+/// directory naming; full uniqueness is not required because the
+/// directory namespace under `.tsumugi/runs/` is small.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RunId(String);
+
+impl RunId {
+    /// Create a fresh random run id.
+    #[must_use]
+    pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4();
+        let simple = uuid.simple().to_string();
+        // Take the first 8 hex characters for a short, human-friendly id.
+        Self(simple[..8].to_owned())
+    }
+
+    /// Construct a run id from a raw string (e.g. when loading from disk).
+    #[must_use]
+    pub fn from_string(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Return the run id as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Return a short (8-char) version of the run id for display.
+    ///
+    /// If the underlying string is shorter than 8 characters this returns
+    /// the full string.
+    #[must_use]
+    pub fn short(&self) -> &str {
+        let take = self
+            .0
+            .char_indices()
+            .nth(8)
+            .map_or(self.0.len(), |(i, _)| i);
+        &self.0[..take]
+    }
+}
+
+impl Default for RunId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for RunId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Scope of a run. SPEC §9.2 defines a 2-stage model: a run starts as
+/// [`AdHoc`](RunScope::AdHoc) and can later be promoted to
+/// [`Harnessed`](RunScope::Harnessed) when a workflow attaches.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RunScope {
+    /// Free-form interactive run with no workflow attached.
+    AdHoc,
+    /// Run managed by a workflow harness (workflow id, max sessions, etc.).
+    Harnessed {
+        /// Identifier of the workflow definition driving this run.
+        workflow_id: String,
+        /// Optional cap on the number of sessions allowed in this run.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_sessions: Option<u32>,
+    },
+}
+
+impl RunScope {
+    /// Short label for display.
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::AdHoc => "ad-hoc",
+            Self::Harnessed { .. } => "harnessed",
+        }
+    }
+}
+
+/// Lifecycle state of a run. SPEC §9.4.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum RunStatus {
+    /// The run is currently active or being resumed.
+    Running,
+    /// The run was paused (e.g. by user action) and may be resumed.
+    Paused,
+    /// The run completed successfully.
+    Completed,
+    /// The run failed; `reason` carries a human-readable description.
+    Failed {
+        /// Reason for failure.
+        reason: String,
+    },
+    /// The run hit `max_sessions` and stopped without completing.
+    Exhausted,
+}
+
+impl RunStatus {
+    /// Return true if the run is in a terminal state.
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed { .. })
+    }
+
+    /// Return true if the run is unfinished and may be resumed on startup.
+    ///
+    /// SPEC §9.4: `Running` / `Paused` / `Exhausted` are eligible for
+    /// auto-resume because they are not terminal in the same way as
+    /// `Completed` or `Failed`.
+    #[must_use]
+    pub fn is_resumable(&self) -> bool {
+        matches!(self, Self::Running | Self::Paused | Self::Exhausted)
+    }
+}
+
+/// Top-level run record. Persisted as `run.toml`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Run {
+    /// Unique identifier for this run.
+    pub id: RunId,
+    /// Run scope (ad-hoc or harnessed by a workflow).
+    pub scope: RunScope,
+    /// Current lifecycle status.
+    pub status: RunStatus,
+    /// Optional workflow id (mirrored at top level for convenience).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+    /// When the run was created.
+    pub created_at: DateTime<Utc>,
+    /// When the most recent session began, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_session_at: Option<DateTime<Utc>>,
+    /// Number of sessions that have been started under this run.
+    #[serde(default)]
+    pub session_count: u32,
+    /// Optional cap on the number of sessions (mirrors `RunScope::Harnessed`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_sessions: Option<u32>,
+    /// Workspace path for this run (target codebase).
+    pub workspace_path: PathBuf,
+    /// Free-form structured inputs supplied at run creation.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub inputs: BTreeMap<String, serde_json::Value>,
+}
+
+impl Run {
+    /// Construct a new ad-hoc run with default lifecycle state.
+    ///
+    /// `workspace_path` should be the canonicalised path to the user's
+    /// project root; this becomes the symlink target inside the run
+    /// directory.
+    #[must_use]
+    pub fn new_ad_hoc(workspace_path: PathBuf) -> Self {
+        Self {
+            id: RunId::new(),
+            scope: RunScope::AdHoc,
+            status: RunStatus::Running,
+            workflow_id: None,
+            created_at: Utc::now(),
+            last_session_at: None,
+            session_count: 0,
+            max_sessions: None,
+            workspace_path,
+            inputs: BTreeMap::new(),
+        }
+    }
+}
+
+/// Lightweight summary used for listing and TUI header display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunSummary {
+    /// Run id.
+    pub id: RunId,
+    /// Scope label (`"ad-hoc"` or `"harnessed"`).
+    pub scope_label: &'static str,
+    /// Workflow id (only set for harnessed scope).
+    pub workflow_id: Option<String>,
+    /// Current lifecycle status (cloned for cheap display).
+    pub status: RunStatus,
+    /// When the run was created.
+    pub created_at: DateTime<Utc>,
+    /// Last session timestamp, if any.
+    pub last_session_at: Option<DateTime<Utc>>,
+    /// Number of sessions so far.
+    pub session_count: u32,
+}
+
+impl RunSummary {
+    /// Construct a summary from a [`Run`] reference.
+    #[must_use]
+    pub fn from_run(run: &Run) -> Self {
+        let workflow_id = match &run.scope {
+            RunScope::AdHoc => None,
+            RunScope::Harnessed { workflow_id, .. } => Some(workflow_id.clone()),
+        };
+        Self {
+            id: run.id.clone(),
+            scope_label: run.scope.label(),
+            workflow_id,
+            status: run.status.clone(),
+            created_at: run.created_at,
+            last_session_at: run.last_session_at,
+            session_count: run.session_count,
+        }
+    }
+
+    /// Short (8-char) run id for display.
+    #[must_use]
+    pub fn short_id(&self) -> &str {
+        self.id.short()
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_id_is_short_hex() {
+        let id = RunId::new();
+        assert_eq!(id.as_str().len(), 8);
+        assert!(id.as_str().chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn run_id_short_handles_long_strings() {
+        let id = RunId::from_string("abcdef0123456789");
+        assert_eq!(id.short(), "abcdef01");
+    }
+
+    #[test]
+    fn run_id_short_handles_short_strings() {
+        let id = RunId::from_string("abc");
+        assert_eq!(id.short(), "abc");
+    }
+
+    #[test]
+    fn run_status_is_resumable() {
+        assert!(RunStatus::Running.is_resumable());
+        assert!(RunStatus::Paused.is_resumable());
+        assert!(RunStatus::Exhausted.is_resumable());
+        assert!(!RunStatus::Completed.is_resumable());
+        assert!(
+            !RunStatus::Failed {
+                reason: "boom".to_owned(),
+            }
+            .is_resumable()
+        );
+    }
+
+    #[test]
+    fn ad_hoc_run_serializes_round_trip() {
+        let run = Run::new_ad_hoc(PathBuf::from("/tmp/project"));
+        let serialized = toml::to_string(&run).unwrap_or_else(|e| panic!("{e}"));
+        let parsed: Run = toml::from_str(&serialized).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(run, parsed);
+    }
+
+    #[test]
+    fn harnessed_run_round_trip() {
+        let mut run = Run::new_ad_hoc(PathBuf::from("/tmp/project"));
+        run.scope = RunScope::Harnessed {
+            workflow_id: "fix-bug".to_owned(),
+            max_sessions: Some(8),
+        };
+        run.workflow_id = Some("fix-bug".to_owned());
+        run.max_sessions = Some(8);
+        let serialized = toml::to_string(&run).unwrap_or_else(|e| panic!("{e}"));
+        let parsed: Run = toml::from_str(&serialized).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(run, parsed);
+    }
+
+    #[test]
+    fn run_summary_label() {
+        let run = Run::new_ad_hoc(PathBuf::from("/tmp/project"));
+        let summary = RunSummary::from_run(&run);
+        assert_eq!(summary.scope_label, "ad-hoc");
+        assert_eq!(summary.short_id().len(), 8);
+    }
+}

--- a/crates/tmg-harness/src/runner.rs
+++ b/crates/tmg-harness/src/runner.rs
@@ -1,0 +1,121 @@
+//! Minimal run runner used by the CLI startup sequence.
+//!
+//! The eventual `RunRunner` will own a workflow engine, escalator, and
+//! `AgentLoop` driver. This first slice owns just enough state to:
+//!
+//! - hold the active [`Run`] and a reference-counted [`RunStore`] so
+//!   that session lifecycle updates can be persisted from anywhere in
+//!   the CLI / TUI.
+//! - bump `session_count` and `last_session_at` on
+//!   [`begin_session`](RunRunner::begin_session) and persist on both
+//!   begin and [`end_session`](RunRunner::end_session).
+//!
+//! Workflow integration, bootstrap, session log writing, and
+//! escalation are out of scope for this issue and tracked separately.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use crate::error::HarnessError;
+use crate::run::{Run, RunSummary};
+use crate::session::{SessionEndTrigger, SessionHandle};
+use crate::store::RunStore;
+
+/// Minimal harness runner wrapping a [`Run`] and a [`RunStore`].
+#[derive(Debug)]
+pub struct RunRunner {
+    run: Run,
+    store: Arc<RunStore>,
+}
+
+impl RunRunner {
+    /// Construct a runner over the given run and store.
+    #[must_use]
+    pub fn new(run: Run, store: Arc<RunStore>) -> Self {
+        Self { run, store }
+    }
+
+    /// Borrow the active run.
+    #[must_use]
+    pub fn run(&self) -> &Run {
+        &self.run
+    }
+
+    /// Borrow the active run mutably.
+    pub fn run_mut(&mut self) -> &mut Run {
+        &mut self.run
+    }
+
+    /// Lightweight summary of the active run, for header display etc.
+    #[must_use]
+    pub fn summary(&self) -> RunSummary {
+        RunSummary::from_run(&self.run)
+    }
+
+    /// Begin a new session. Increments `session_count`, stamps
+    /// `last_session_at`, and persists the run.
+    pub fn begin_session(&mut self) -> Result<SessionHandle, HarnessError> {
+        self.run.session_count = self.run.session_count.saturating_add(1);
+        self.run.last_session_at = Some(Utc::now());
+        self.store.save(&self.run)?;
+        Ok(SessionHandle {
+            index: self.run.session_count,
+        })
+    }
+
+    /// End the given session. Currently a no-op beyond persisting any
+    /// pending state. The `trigger` argument is reserved for the
+    /// session log writer in the follow-up issue.
+    pub fn end_session(
+        &mut self,
+        _handle: SessionHandle,
+        _trigger: SessionEndTrigger,
+    ) -> Result<(), HarnessError> {
+        self.store.save(&self.run)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+
+    fn make_runner() -> (tempfile::TempDir, RunRunner) {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let store = Arc::new(RunStore::new(tmp.path().join("runs")));
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let runner = RunRunner::new(run, store);
+        (tmp, runner)
+    }
+
+    #[test]
+    fn begin_session_increments_count() {
+        let (_tmp, mut runner) = make_runner();
+        assert_eq!(runner.run().session_count, 0);
+        let handle = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(handle.index, 1);
+        assert_eq!(runner.run().session_count, 1);
+        assert!(runner.run().last_session_at.is_some());
+    }
+
+    #[test]
+    fn end_session_persists_run() {
+        let (_tmp, mut runner) = make_runner();
+        let handle = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        runner
+            .end_session(handle, SessionEndTrigger::Completed)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let store = Arc::clone(&runner.store);
+        let id = runner.run().id.clone();
+        let loaded = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(loaded.session_count, 1);
+        assert_eq!(loaded.workspace_path, runner.run().workspace_path);
+        assert_eq!(loaded.id, id);
+    }
+}

--- a/crates/tmg-harness/src/runner.rs
+++ b/crates/tmg-harness/src/runner.rs
@@ -23,6 +23,12 @@ use crate::session::{SessionEndTrigger, SessionHandle};
 use crate::store::RunStore;
 
 /// Minimal harness runner wrapping a [`Run`] and a [`RunStore`].
+///
+/// **Concurrency:** like [`RunStore`], this runner assumes the owning
+/// process is the only writer to the underlying `runs_dir`. There is
+/// no inter-process locking around session begin/end; running multiple
+/// `tmg` processes against the same `runs_dir` can race on
+/// `session_count` updates. A locking layer is tracked as a follow-up.
 #[derive(Debug)]
 pub struct RunRunner {
     run: Run,

--- a/crates/tmg-harness/src/session.rs
+++ b/crates/tmg-harness/src/session.rs
@@ -1,0 +1,107 @@
+//! Session data model.
+//!
+//! A [`Session`] is one continuous interaction between the user (or a
+//! workflow) and the agent. A [`Run`](crate::run::Run) accumulates one
+//! or more sessions over its lifetime; the run's `session_count` is
+//! incremented every time a new session begins.
+//!
+//! This minimal version of the type does not yet persist session logs
+//! (the file `session_log.jsonl` is introduced in a follow-up issue).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// One session within a [`Run`](crate::run::Run).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Session {
+    /// Sequence number within the parent run (1-indexed).
+    pub index: u32,
+    /// When the session started.
+    pub started_at: DateTime<Utc>,
+    /// When the session ended, if it has.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<DateTime<Utc>>,
+    /// Reason the session ended, when applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_trigger: Option<SessionEndTrigger>,
+}
+
+impl Session {
+    /// Begin a new session at the given sequence number.
+    #[must_use]
+    pub fn begin(index: u32) -> Self {
+        Self {
+            index,
+            started_at: Utc::now(),
+            ended_at: None,
+            end_trigger: None,
+        }
+    }
+
+    /// Mark this session as ended with the given trigger.
+    pub fn end(&mut self, trigger: SessionEndTrigger) {
+        self.ended_at = Some(Utc::now());
+        self.end_trigger = Some(trigger);
+    }
+}
+
+/// Why a session ended. SPEC §9.5.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SessionEndTrigger {
+    /// Normal completion (user closed the TUI / workflow finished).
+    Completed,
+    /// Cancelled by the user (e.g. Ctrl-C).
+    UserCancelled,
+    /// The harness rotated to a new session (e.g. context exhaustion).
+    Rotated {
+        /// Reason for rotation, surfaced to the operator.
+        reason: String,
+    },
+    /// An error terminated the session.
+    Errored {
+        /// Error message.
+        message: String,
+    },
+}
+
+/// Opaque handle returned by `RunRunner::begin_session` and consumed by
+/// `RunRunner::end_session`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionHandle {
+    /// Session sequence number within the run.
+    pub index: u32,
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn begin_session_sets_started() {
+        let session = Session::begin(1);
+        assert_eq!(session.index, 1);
+        assert!(session.ended_at.is_none());
+        assert!(session.end_trigger.is_none());
+    }
+
+    #[test]
+    fn end_session_records_trigger() {
+        let mut session = Session::begin(1);
+        session.end(SessionEndTrigger::Completed);
+        assert!(session.ended_at.is_some());
+        assert_eq!(session.end_trigger, Some(SessionEndTrigger::Completed));
+    }
+
+    #[test]
+    fn session_round_trip_toml() {
+        let mut session = Session::begin(2);
+        session.end(SessionEndTrigger::Rotated {
+            reason: "context full".to_owned(),
+        });
+        let toml = toml::to_string(&session).unwrap_or_else(|e| panic!("{e}"));
+        let parsed: Session = toml::from_str(&toml).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(session, parsed);
+    }
+}

--- a/crates/tmg-harness/src/store.rs
+++ b/crates/tmg-harness/src/store.rs
@@ -31,6 +31,11 @@ pub const WORKSPACE_LINK: &str = "workspace";
 
 /// Persistent store for runs rooted at a directory (typically
 /// `.tsumugi/runs/`).
+///
+/// **Concurrency:** this store assumes a single `tmg` process is
+/// operating against `runs_dir` at a time. There is no inter-process
+/// locking; concurrent writers can race on `run.toml`. A file-lock /
+/// advisory-lock layer is tracked as a follow-up.
 #[derive(Debug, Clone)]
 pub struct RunStore {
     runs_dir: PathBuf,
@@ -97,6 +102,11 @@ impl RunStore {
     }
 
     /// Load a run by id.
+    ///
+    /// The loaded `Run.id` is validated against the requested `run_id`
+    /// (which is also the directory name). A mismatch surfaces
+    /// [`HarnessError::IdMismatch`] rather than silently returning a
+    /// run record with a different id than the directory it lives in.
     pub fn load(&self, run_id: &RunId) -> Result<Run, HarnessError> {
         let path = self.run_file(run_id);
         let content = match fs::read_to_string(&path) {
@@ -108,28 +118,53 @@ impl RunStore {
             }
             Err(e) => return Err(HarnessError::io(&path, e)),
         };
-        toml::from_str(&content).map_err(|e| HarnessError::Deserialize { path, source: e })
+        let loaded: Run =
+            toml::from_str(&content).map_err(|e| HarnessError::Deserialize { path, source: e })?;
+        if loaded.id != *run_id {
+            return Err(HarnessError::IdMismatch {
+                expected: run_id.as_str().to_owned(),
+                found: loaded.id.as_str().to_owned(),
+            });
+        }
+        Ok(loaded)
     }
 
-    /// Persist a run to disk.
+    /// Persist a run to disk atomically.
+    ///
+    /// Writes to `<run-dir>/run.toml.tmp` first, then renames over
+    /// `run.toml`. On most platforms `rename` within the same
+    /// directory is atomic, so concurrent readers will never observe a
+    /// half-written file. If the temp write or rename fails we
+    /// best-effort remove the temp file before returning.
     pub fn save(&self, run: &Run) -> Result<(), HarnessError> {
         let run_dir = self.run_dir(&run.id);
         fs::create_dir_all(&run_dir).map_err(|e| HarnessError::io(&run_dir, e))?;
 
         let path = self.run_file(&run.id);
+        let tmp_path = run_dir.join(format!("{RUN_FILENAME}.tmp"));
         let serialized = toml::to_string_pretty(run).map_err(|e| HarnessError::Serialize {
             path: path.clone(),
             source: e,
         })?;
-        fs::write(&path, serialized).map_err(|e| HarnessError::io(&path, e))?;
+
+        if let Err(e) = fs::write(&tmp_path, serialized) {
+            // Best-effort cleanup; ignore secondary errors.
+            let _ = fs::remove_file(&tmp_path);
+            return Err(HarnessError::io(&tmp_path, e));
+        }
+        if let Err(e) = fs::rename(&tmp_path, &path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(HarnessError::io(&path, e));
+        }
         Ok(())
     }
 
     /// List all runs as lightweight summaries.
     ///
     /// Entries that fail to load (e.g. missing or malformed `run.toml`)
-    /// are skipped silently to avoid breaking startup on a single bad
-    /// run directory.
+    /// are skipped to avoid breaking startup on a single bad run
+    /// directory; a `tracing::warn!` is emitted for each skipped entry
+    /// so operators can investigate.
     pub fn list(&self) -> Result<Vec<RunSummary>, HarnessError> {
         if !self.runs_dir.exists() {
             return Ok(Vec::new());
@@ -147,11 +182,23 @@ impl RunStore {
                 continue;
             }
             let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                tracing::warn!(
+                    path = %entry.path().display(),
+                    "skipping run directory with non-utf8 name"
+                );
                 continue;
             };
-            let run_id = RunId::from_string(name);
-            if let Ok(run) = self.load(&run_id) {
-                summaries.push(RunSummary::from_run(&run));
+            let run_id = RunId::from_string(name.clone());
+            match self.load(&run_id) {
+                Ok(run) => summaries.push(RunSummary::from_run(&run)),
+                Err(err) => {
+                    tracing::warn!(
+                        run_id = %name,
+                        path = %entry.path().display(),
+                        error = %err,
+                        "skipping unreadable run directory in list()"
+                    );
+                }
             }
         }
 
@@ -164,10 +211,68 @@ impl RunStore {
     ///
     /// "Resumable" follows
     /// [`RunStatus::is_resumable`](crate::run::RunStatus::is_resumable):
-    /// `Running`, `Paused`, or `Exhausted`.
-    pub fn latest_resumable(&self) -> Result<Option<RunSummary>, HarnessError> {
+    /// `Running`, `Paused`, or `Exhausted`. When `workspace_path` is
+    /// `Some`, only runs whose stored `workspace_path` matches are
+    /// eligible; this prevents resuming a run from a different project
+    /// when several projects share the same `runs_dir` configuration.
+    pub fn latest_resumable(
+        &self,
+        workspace_path: Option<&Path>,
+    ) -> Result<Option<RunSummary>, HarnessError> {
         let summaries = self.list()?;
-        Ok(summaries.into_iter().find(|s| s.status.is_resumable()))
+        for summary in summaries {
+            if !summary.status.is_resumable() {
+                continue;
+            }
+            if let Some(expected) = workspace_path {
+                // The summary doesn't carry workspace_path; load the
+                // full run to check. This is acceptable: the list is
+                // bounded by the number of run directories and the
+                // first match wins.
+                let run = self.load(&summary.id)?;
+                if run.workspace_path != expected {
+                    continue;
+                }
+            }
+            return Ok(Some(summary));
+        }
+        Ok(None)
+    }
+}
+
+/// Decide what to do when a path already exists at `link`.
+///
+/// If a symlink is already in place we leave it alone. If a regular
+/// file or directory is sitting where the workspace symlink should
+/// be, we surface a `tracing::warn!` and leave the existing entry
+/// alone (returning `Ok(())`) rather than silently overwriting
+/// possibly-important user data. Removing the wrong file is a
+/// destructive action we don't want to take here; the operator can
+/// resolve the conflict manually.
+///
+/// Returns `Some(())` when no further action is needed (entry is a
+/// symlink, or we deferred to a warning), and `None` when the link
+/// path is empty and the caller should create the symlink.
+fn check_existing_link(link: &Path) -> Option<()> {
+    match link.symlink_metadata() {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(_) => {
+            // Some other metadata error (e.g. permission). Treat as
+            // "needs creation" so the symlink syscall returns the
+            // canonical error to the caller.
+            None
+        }
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                Some(())
+            } else {
+                tracing::warn!(
+                    path = %link.display(),
+                    "workspace path exists but is not a symlink; leaving in place"
+                );
+                Some(())
+            }
+        }
     }
 }
 
@@ -176,7 +281,7 @@ impl RunStore {
 /// underlying I/O error and the caller is expected to ignore it.
 #[cfg(unix)]
 fn create_workspace_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
-    if link.exists() || link.symlink_metadata().is_ok() {
+    if check_existing_link(link).is_some() {
         return Ok(());
     }
     std::os::unix::fs::symlink(target, link)
@@ -186,7 +291,7 @@ fn create_workspace_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
 /// that the caller will silently ignore.
 #[cfg(windows)]
 fn create_workspace_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
-    if link.exists() || link.symlink_metadata().is_ok() {
+    if check_existing_link(link).is_some() {
         return Ok(());
     }
     std::os::windows::fs::symlink_dir(target, link)
@@ -303,10 +408,39 @@ mod tests {
             .unwrap_or_else(|e| panic!("{e}"));
 
         let resumable = store
-            .latest_resumable()
+            .latest_resumable(None)
             .unwrap_or_else(|e| panic!("{e}"))
             .unwrap_or_else(|| panic!("expected a resumable run"));
         assert_eq!(resumable.id, running.id);
+    }
+
+    #[test]
+    fn latest_resumable_filters_by_workspace() {
+        let (tmp, store) = make_store();
+        let workspace_a = tmp.path().join("workspace-a");
+        let workspace_b = tmp.path().join("workspace-b");
+
+        // A resumable run exists, but for workspace_a.
+        let run_a = store
+            .create_ad_hoc(workspace_a.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        // Asking for workspace_b's resumable run should return None
+        // (we should fall back to creating a new run).
+        let result = store
+            .latest_resumable(Some(&workspace_b))
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            result.is_none(),
+            "should not resume across different workspace"
+        );
+
+        // Asking for workspace_a should still find it.
+        let result = store
+            .latest_resumable(Some(&workspace_a))
+            .unwrap_or_else(|e| panic!("{e}"))
+            .unwrap_or_else(|| panic!("expected a resumable run for workspace_a"));
+        assert_eq!(result.id, run_a.id);
     }
 
     #[test]
@@ -317,5 +451,43 @@ mod tests {
             result,
             Err(HarnessError::RunNotFound { ref run_id }) if run_id == "deadbeef"
         ));
+    }
+
+    #[test]
+    fn load_detects_id_mismatch() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        // Hand-edit run.toml so the id inside no longer matches the directory.
+        let path = store.run_file(&run.id);
+        let content = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{e}"));
+        let tampered = content.replacen(run.id.as_str(), "ffffffff", 1);
+        std::fs::write(&path, tampered).unwrap_or_else(|e| panic!("{e}"));
+
+        let result = store.load(&run.id);
+        match result {
+            Err(HarnessError::IdMismatch { expected, found }) => {
+                assert_eq!(expected, run.id.as_str());
+                assert_eq!(found, "ffffffff");
+            }
+            other => panic!("expected IdMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn save_writes_no_lingering_tmp_file() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        let run = Run::new_ad_hoc(workspace);
+        store.save(&run).unwrap_or_else(|e| panic!("{e}"));
+
+        let tmp_path = store.run_dir(&run.id).join(format!("{RUN_FILENAME}.tmp"));
+        assert!(
+            !tmp_path.exists(),
+            "atomic save should not leave run.toml.tmp behind"
+        );
     }
 }

--- a/crates/tmg-harness/src/store.rs
+++ b/crates/tmg-harness/src/store.rs
@@ -1,0 +1,321 @@
+//! Persistence layer for runs.
+//!
+//! [`RunStore`] manages the on-disk layout under
+//! `<runs_dir>/<run-id>/` and provides CRUD-style operations for
+//! [`Run`] records. SPEC §9.2 describes the directory structure.
+//!
+//! The minimal version implemented here covers the operations required
+//! by the startup sequence in `tmg-cli`:
+//!
+//! - [`RunStore::create_ad_hoc`] – allocate a new run directory with a
+//!   `workspace` symlink and persisted `run.toml`.
+//! - [`RunStore::load`] – read `run.toml` for an existing run.
+//! - [`RunStore::list`] – enumerate runs as lightweight summaries.
+//! - [`RunStore::save`] – write `run.toml` for an existing run.
+//!
+//! Symlink creation is best-effort: on platforms (or filesystems) where
+//! it is not supported, the run is still usable; only the
+//! `<run-dir>/workspace` shortcut is missing.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::HarnessError;
+use crate::run::{Run, RunId, RunSummary};
+
+/// Filename used for the persistent run record under each run directory.
+pub const RUN_FILENAME: &str = "run.toml";
+
+/// Filename of the workspace symlink under each run directory.
+pub const WORKSPACE_LINK: &str = "workspace";
+
+/// Persistent store for runs rooted at a directory (typically
+/// `.tsumugi/runs/`).
+#[derive(Debug, Clone)]
+pub struct RunStore {
+    runs_dir: PathBuf,
+}
+
+impl RunStore {
+    /// Construct a store rooted at `runs_dir`.
+    ///
+    /// The directory does not need to exist; it will be created lazily
+    /// by [`create_ad_hoc`](Self::create_ad_hoc) and other write paths.
+    #[must_use]
+    pub fn new(runs_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            runs_dir: runs_dir.into(),
+        }
+    }
+
+    /// Return the configured runs directory.
+    #[must_use]
+    pub fn runs_dir(&self) -> &Path {
+        &self.runs_dir
+    }
+
+    /// Path for a run's directory.
+    #[must_use]
+    pub fn run_dir(&self, run_id: &RunId) -> PathBuf {
+        self.runs_dir.join(run_id.as_str())
+    }
+
+    /// Path for a run's `run.toml`.
+    #[must_use]
+    pub fn run_file(&self, run_id: &RunId) -> PathBuf {
+        self.run_dir(run_id).join(RUN_FILENAME)
+    }
+
+    /// Create a fresh ad-hoc run rooted at `workspace_path`.
+    ///
+    /// `initial_request` is currently unused at the persistence level
+    /// but is part of the public API so future revisions can record the
+    /// kicked-off prompt without breaking callers.
+    pub fn create_ad_hoc(
+        &self,
+        workspace_path: PathBuf,
+        initial_request: Option<&str>,
+    ) -> Result<Run, HarnessError> {
+        let mut run = Run::new_ad_hoc(workspace_path);
+        if let Some(req) = initial_request {
+            run.inputs.insert(
+                "initial_request".to_owned(),
+                serde_json::Value::String(req.to_owned()),
+            );
+        }
+
+        let run_dir = self.run_dir(&run.id);
+        fs::create_dir_all(&run_dir).map_err(|e| HarnessError::io(&run_dir, e))?;
+
+        // Best-effort workspace symlink. Failure is non-fatal: the run
+        // is still usable without the convenience link.
+        let link_path = run_dir.join(WORKSPACE_LINK);
+        let _ = create_workspace_symlink(&run.workspace_path, &link_path);
+
+        self.save(&run)?;
+        Ok(run)
+    }
+
+    /// Load a run by id.
+    pub fn load(&self, run_id: &RunId) -> Result<Run, HarnessError> {
+        let path = self.run_file(run_id);
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(HarnessError::RunNotFound {
+                    run_id: run_id.as_str().to_owned(),
+                });
+            }
+            Err(e) => return Err(HarnessError::io(&path, e)),
+        };
+        toml::from_str(&content).map_err(|e| HarnessError::Deserialize { path, source: e })
+    }
+
+    /// Persist a run to disk.
+    pub fn save(&self, run: &Run) -> Result<(), HarnessError> {
+        let run_dir = self.run_dir(&run.id);
+        fs::create_dir_all(&run_dir).map_err(|e| HarnessError::io(&run_dir, e))?;
+
+        let path = self.run_file(&run.id);
+        let serialized = toml::to_string_pretty(run).map_err(|e| HarnessError::Serialize {
+            path: path.clone(),
+            source: e,
+        })?;
+        fs::write(&path, serialized).map_err(|e| HarnessError::io(&path, e))?;
+        Ok(())
+    }
+
+    /// List all runs as lightweight summaries.
+    ///
+    /// Entries that fail to load (e.g. missing or malformed `run.toml`)
+    /// are skipped silently to avoid breaking startup on a single bad
+    /// run directory.
+    pub fn list(&self) -> Result<Vec<RunSummary>, HarnessError> {
+        if !self.runs_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut summaries = Vec::new();
+        let read_dir =
+            fs::read_dir(&self.runs_dir).map_err(|e| HarnessError::io(&self.runs_dir, e))?;
+        for entry in read_dir {
+            let entry = entry.map_err(|e| HarnessError::io(&self.runs_dir, e))?;
+            let file_type = entry
+                .file_type()
+                .map_err(|e| HarnessError::io(entry.path(), e))?;
+            if !file_type.is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            let run_id = RunId::from_string(name);
+            if let Ok(run) = self.load(&run_id) {
+                summaries.push(RunSummary::from_run(&run));
+            }
+        }
+
+        // Sort newest-first for predictable resume behaviour.
+        summaries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(summaries)
+    }
+
+    /// Return the most recent run that is still resumable, or `None`.
+    ///
+    /// "Resumable" follows
+    /// [`RunStatus::is_resumable`](crate::run::RunStatus::is_resumable):
+    /// `Running`, `Paused`, or `Exhausted`.
+    pub fn latest_resumable(&self) -> Result<Option<RunSummary>, HarnessError> {
+        let summaries = self.list()?;
+        Ok(summaries.into_iter().find(|s| s.status.is_resumable()))
+    }
+}
+
+/// Create a `workspace` symlink pointing at `target`. On platforms
+/// without symlink support (or if creation fails), this returns the
+/// underlying I/O error and the caller is expected to ignore it.
+#[cfg(unix)]
+fn create_workspace_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    if link.exists() || link.symlink_metadata().is_ok() {
+        return Ok(());
+    }
+    std::os::unix::fs::symlink(target, link)
+}
+
+/// Windows fallback: try a directory symlink, otherwise return an error
+/// that the caller will silently ignore.
+#[cfg(windows)]
+fn create_workspace_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    if link.exists() || link.symlink_metadata().is_ok() {
+        return Ok(());
+    }
+    std::os::windows::fs::symlink_dir(target, link)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_workspace_symlink(_target: &Path, _link: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "symlinks not supported on this platform",
+    ))
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use crate::run::{RunScope, RunStatus};
+
+    fn make_store() -> (tempfile::TempDir, RunStore) {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let store = RunStore::new(dir.path().join("runs"));
+        (dir, store)
+    }
+
+    #[test]
+    fn create_ad_hoc_writes_run_toml() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace.clone(), Some("hello"))
+            .unwrap_or_else(|e| panic!("{e}"));
+        let path = store.run_file(&run.id);
+        assert!(path.exists(), "run.toml should exist at {path:?}");
+
+        let loaded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(loaded, run);
+        assert_eq!(loaded.scope, RunScope::AdHoc);
+        assert_eq!(loaded.status, RunStatus::Running);
+        assert_eq!(
+            loaded.inputs.get("initial_request"),
+            Some(&serde_json::Value::String("hello".to_owned()))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_symlink_is_created() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let link = store.run_dir(&run.id).join(WORKSPACE_LINK);
+        let meta = std::fs::symlink_metadata(&link).unwrap_or_else(|e| panic!("{e}"));
+        assert!(meta.file_type().is_symlink(), "workspace link missing");
+    }
+
+    #[test]
+    fn save_round_trips_run() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        let mut run = Run::new_ad_hoc(workspace);
+        run.session_count = 3;
+        store.save(&run).unwrap_or_else(|e| panic!("{e}"));
+        let loaded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(loaded.session_count, 3);
+    }
+
+    #[test]
+    fn list_returns_runs_newest_first() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+
+        let run1 = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        // Force a slightly later timestamp.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let run2 = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let listed = store.list().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(listed.len(), 2);
+        // Newest first.
+        assert_eq!(listed[0].id, run2.id);
+        assert_eq!(listed[1].id, run1.id);
+    }
+
+    #[test]
+    fn list_returns_empty_when_dir_missing() {
+        let (_tmp, store) = make_store();
+        let listed = store.list().unwrap_or_else(|e| panic!("{e}"));
+        assert!(listed.is_empty());
+    }
+
+    #[test]
+    fn latest_resumable_skips_terminal_runs() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+
+        let mut completed = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        completed.status = RunStatus::Completed;
+        store.save(&completed).unwrap_or_else(|e| panic!("{e}"));
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let running = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let resumable = store
+            .latest_resumable()
+            .unwrap_or_else(|e| panic!("{e}"))
+            .unwrap_or_else(|| panic!("expected a resumable run"));
+        assert_eq!(resumable.id, running.id);
+    }
+
+    #[test]
+    fn load_missing_returns_run_not_found() {
+        let (_tmp, store) = make_store();
+        let result = store.load(&RunId::from_string("deadbeef"));
+        assert!(matches!(
+            result,
+            Err(HarnessError::RunNotFound { ref run_id }) if run_id == "deadbeef"
+        ));
+    }
+}

--- a/crates/tmg-tui/Cargo.toml
+++ b/crates/tmg-tui/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 tmg-core = { workspace = true }
 tmg-llm = { workspace = true }
 tmg-agents = { workspace = true }
+tmg-harness = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 tokio = { workspace = true, features = ["signal", "sync"] }

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use tmg_agents::{AgentType, CustomAgentDef, SubagentManager, SubagentSummary, truncate_str};
 use tmg_core::{AgentLoop, CoreError, StreamSink, format_context_usage};
+use tmg_harness::RunSummary;
 use tmg_llm::Role;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -171,6 +172,9 @@ pub struct App {
 
     /// Optional path for structured event logging (JSON Lines).
     event_log_path: Option<PathBuf>,
+
+    /// The currently active run, used for header display.
+    current_run: Option<RunSummary>,
 }
 
 impl App {
@@ -205,7 +209,18 @@ impl App {
             pending_compact: false,
             thinking: false,
             event_log_path: event_log,
+            current_run: None,
         }
+    }
+
+    /// Set the active run for header display.
+    pub fn set_current_run(&mut self, run: RunSummary) {
+        self.current_run = Some(run);
+    }
+
+    /// Return the active run, if any.
+    pub fn current_run(&self) -> Option<&RunSummary> {
+        self.current_run.as_ref()
     }
 
     /// Set the subagent manager for status display.
@@ -608,9 +623,10 @@ impl App {
 
         // Open the event log writer if configured (append mode so all
         // turns accumulate in a single file).
-        let event_log_writer = self.event_log_path.as_deref().and_then(|path| {
-            tmg_core::EventLogWriter::open_append(path).ok()
-        });
+        let event_log_writer = self
+            .event_log_path
+            .as_deref()
+            .and_then(|path| tmg_core::EventLogWriter::open_append(path).ok());
 
         let join = tokio::spawn(async move {
             let channel_sink = ChannelStreamSink { tx: tx.clone() };

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -178,9 +178,7 @@ fn handle_key(app: &mut App, key: KeyEvent, cancel: &CancellationToken) {
         }
         // Shift+Enter or Alt+Enter: insert newline.
         // (Alt+Enter is the fallback for terminals without Kitty keyboard protocol.)
-        (KeyCode::Enter, m)
-            if m.contains(KeyModifiers::SHIFT) || m.contains(KeyModifiers::ALT) =>
-        {
+        (KeyCode::Enter, m) if m.contains(KeyModifiers::SHIFT) || m.contains(KeyModifiers::ALT) => {
             app.insert_newline();
         }
         // Enter alone: submit input and start turn.

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -15,12 +15,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crossterm::event::{
-    DisableMouseCapture, EnableMouseCapture,
-    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+    PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
 use tmg_agents::{CustomAgentDef, SubagentManager};
 use tmg_core::AgentLoop;
+use tmg_harness::RunSummary;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
@@ -40,6 +41,7 @@ use tokio_util::sync::CancellationToken;
 /// * `subagent_manager` - Optional shared subagent manager for status display.
 /// * `custom_agents` - Custom agent definitions for `/agents` list display.
 /// * `event_log` - Optional path to write structured event log (JSON Lines).
+/// * `current_run` - Optional active run summary for header display.
 ///
 /// # Errors
 ///
@@ -57,6 +59,7 @@ pub async fn run(
     subagent_manager: Option<Arc<Mutex<SubagentManager>>>,
     custom_agents: Vec<CustomAgentDef>,
     event_log: Option<PathBuf>,
+    current_run: Option<RunSummary>,
 ) -> Result<(), TuiError> {
     let mut terminal = ratatui::init();
 
@@ -96,6 +99,10 @@ pub async fn run(
 
     if !custom_agents.is_empty() {
         app.set_custom_agents(custom_agents);
+    }
+
+    if let Some(run) = current_run {
+        app.set_current_run(run);
     }
 
     let result = event::run_event_loop(&mut terminal, &mut app, cancel).await;

--- a/crates/tmg-tui/src/ui.rs
+++ b/crates/tmg-tui/src/ui.rs
@@ -37,24 +37,28 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
 }
 
-/// Draw the header bar: model name, context usage, and subagent count.
+/// Draw the header bar: model name, context usage, optional run id,
+/// and subagent count.
 fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
     let running_count = app.running_subagent_count();
+    let has_run = app.current_run().is_some();
+    let has_agents = running_count > 0;
 
-    let constraints = if running_count > 0 {
-        vec![
-            Constraint::Percentage(35),
-            Constraint::Percentage(35),
-            Constraint::Percentage(30),
-        ]
-    } else {
-        vec![Constraint::Percentage(50), Constraint::Percentage(50)]
-    };
+    // Build constraints dynamically: Model, Context are always present;
+    // Run is added when a run is active; Agents when subagents are running.
+    let mut constraints: Vec<Constraint> = Vec::with_capacity(4);
+    let total_panes: u16 = 2 + u16::from(has_run) + u16::from(has_agents);
+    let pane_pct: u16 = 100 / total_panes;
+    for _ in 0..total_panes {
+        constraints.push(Constraint::Percentage(pane_pct));
+    }
 
     let header_layout = Layout::default()
         .direction(Direction::Horizontal)
         .constraints(constraints)
         .split(area);
+
+    let mut idx = 0usize;
 
     let model_block = Block::default().borders(Borders::ALL).title(" Model ");
     let model_text = Paragraph::new(Line::from(vec![Span::styled(
@@ -64,7 +68,8 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
             .add_modifier(Modifier::BOLD),
     )]))
     .block(model_block);
-    frame.render_widget(model_text, header_layout[0]);
+    frame.render_widget(model_text, header_layout[idx]);
+    idx += 1;
 
     let context_block = Block::default().borders(Borders::ALL).title(" Context ");
     let context_text = Paragraph::new(Line::from(vec![Span::styled(
@@ -72,9 +77,27 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
         Style::default().fg(Color::Yellow),
     )]))
     .block(context_block);
-    frame.render_widget(context_text, header_layout[1]);
+    frame.render_widget(context_text, header_layout[idx]);
+    idx += 1;
 
-    if running_count > 0 {
+    if let Some(run) = app.current_run() {
+        let run_block = Block::default().borders(Borders::ALL).title(" Run ");
+        let run_text = Paragraph::new(Line::from(vec![
+            Span::styled(
+                run.short_id(),
+                Style::default()
+                    .fg(Color::Magenta)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" "),
+            Span::styled(run.scope_label, Style::default().fg(Color::DarkGray)),
+        ]))
+        .block(run_block);
+        frame.render_widget(run_text, header_layout[idx]);
+        idx += 1;
+    }
+
+    if has_agents {
         let agents_block = Block::default().borders(Borders::ALL).title(" Agents ");
         let agents_text = Paragraph::new(Line::from(vec![Span::styled(
             format!("{running_count} running"),
@@ -83,7 +106,7 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
                 .add_modifier(Modifier::BOLD),
         )]))
         .block(agents_block);
-        frame.render_widget(agents_text, header_layout[2]);
+        frame.render_widget(agents_text, header_layout[idx]);
     }
 }
 

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -21,6 +21,7 @@ tokio-util = { workspace = true }
 toml = { workspace = true }
 tmg-agents = { workspace = true }
 tmg-core = { workspace = true }
+tmg-harness = { workspace = true }
 tmg-llm = { workspace = true }
 tmg-sandbox = { workspace = true }
 tmg-skills = { workspace = true }

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -115,6 +115,40 @@ impl PartialSkillsConfig {
     }
 }
 
+/// Partial harness config used for deserialization from TOML.
+///
+/// All fields are `Option` so we can distinguish "not set" from
+/// "explicitly set to the default value", matching the
+/// [`PartialLlmConfig`] convention.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PartialHarnessConfig {
+    pub runs_dir: Option<PathBuf>,
+    pub auto_resume_on_start: Option<bool>,
+}
+
+impl PartialHarnessConfig {
+    /// Merge `other` into `self`. `Some` fields in `other` take precedence.
+    fn merge_from(&mut self, other: &Self) {
+        if other.runs_dir.is_some() {
+            self.runs_dir.clone_from(&other.runs_dir);
+        }
+        if other.auto_resume_on_start.is_some() {
+            self.auto_resume_on_start = other.auto_resume_on_start;
+        }
+    }
+
+    /// Convert to final `HarnessConfig`, filling in defaults for unset
+    /// fields.
+    fn into_final(self) -> HarnessConfig {
+        HarnessConfig {
+            runs_dir: self.runs_dir.unwrap_or_else(default_runs_dir),
+            auto_resume_on_start: self
+                .auto_resume_on_start
+                .unwrap_or(default_auto_resume_on_start()),
+        }
+    }
+}
+
 /// Partial top-level config used for deserialization and merging.
 ///
 /// Deserialized from TOML, merged across sources, then converted to
@@ -129,6 +163,8 @@ struct PartialTsumugiConfig {
     pub tui: TuiConfig,
     #[serde(default)]
     pub skills: PartialSkillsConfig,
+    #[serde(default)]
+    pub harness: PartialHarnessConfig,
 }
 
 impl PartialTsumugiConfig {
@@ -139,6 +175,7 @@ impl PartialTsumugiConfig {
         self.sandbox.merge_from(&other.sandbox);
         self.tui.merge_from(&other.tui);
         self.skills.merge_from(&other.skills);
+        self.harness.merge_from(&other.harness);
     }
 
     /// Apply environment variable overrides (`TMG_*` prefix).
@@ -207,6 +244,17 @@ impl PartialTsumugiConfig {
             })?;
             self.sandbox.timeout_secs = Some(n);
         }
+        if let Some(v) = env_fn("TMG_HARNESS_RUNS_DIR") {
+            self.harness.runs_dir = Some(PathBuf::from(v));
+        }
+        if let Some(v) = env_fn("TMG_HARNESS_AUTO_RESUME_ON_START") {
+            let parsed = parse_bool(&v).map_err(|()| ConfigError::InvalidValue {
+                field: "TMG_HARNESS_AUTO_RESUME_ON_START".to_owned(),
+                value: v,
+                reason: "must be one of: true, false, 1, 0".to_owned(),
+            })?;
+            self.harness.auto_resume_on_start = Some(parsed);
+        }
         Ok(())
     }
 
@@ -217,7 +265,17 @@ impl PartialTsumugiConfig {
             sandbox: self.sandbox,
             tui: self.tui,
             skills: self.skills.into_final(),
+            harness: self.harness.into_final(),
         }
+    }
+}
+
+/// Parse a `bool` from a string, accepting common truthy/falsy spellings.
+fn parse_bool(value: &str) -> Result<bool, ()> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Ok(true),
+        "false" | "0" | "no" | "off" => Ok(false),
+        _ => Err(()),
     }
 }
 
@@ -312,6 +370,34 @@ pub struct TuiConfig {
     pub show_token_usage: Option<bool>,
 }
 
+/// Harness settings from `[harness]` section.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HarnessConfig {
+    /// Directory where run state is persisted (relative to cwd).
+    pub runs_dir: PathBuf,
+
+    /// Whether to automatically resume the most recent unfinished run on
+    /// startup, instead of creating a new ad-hoc run.
+    pub auto_resume_on_start: bool,
+}
+
+fn default_runs_dir() -> PathBuf {
+    PathBuf::from(".tsumugi").join("runs")
+}
+
+const fn default_auto_resume_on_start() -> bool {
+    true
+}
+
+impl Default for HarnessConfig {
+    fn default() -> Self {
+        Self {
+            runs_dir: default_runs_dir(),
+            auto_resume_on_start: default_auto_resume_on_start(),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Top-level config (final, validated)
 // ---------------------------------------------------------------------------
@@ -334,6 +420,10 @@ pub struct TsumugiConfig {
     /// Skill discovery settings.
     #[serde(default)]
     pub skills: tmg_skills::SkillsConfig,
+
+    /// Harness settings (run persistence and resume policy).
+    #[serde(default)]
+    pub harness: HarnessConfig,
 }
 
 // ---------------------------------------------------------------------------
@@ -867,5 +957,82 @@ compat_claude = false
         let config = TsumugiConfig::default();
         assert_eq!(config.llm.tool_calling, ToolCallingMode::Auto);
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn harness_defaults() {
+        let config = TsumugiConfig::default();
+        assert_eq!(config.harness.runs_dir, default_runs_dir());
+        assert!(config.harness.auto_resume_on_start);
+    }
+
+    #[test]
+    fn harness_section_round_trip() {
+        let toml_str = r#"
+[harness]
+runs_dir = "/tmp/tsumugi-runs"
+auto_resume_on_start = false
+"#;
+        let partial: PartialTsumugiConfig =
+            toml::from_str(toml_str).unwrap_or_else(|e| panic!("{e}"));
+        let config = partial.into_final();
+        assert_eq!(config.harness.runs_dir, PathBuf::from("/tmp/tsumugi-runs"));
+        assert!(!config.harness.auto_resume_on_start);
+    }
+
+    #[test]
+    fn harness_section_merge_overrides() {
+        let mut base = PartialTsumugiConfig::default();
+        base.harness.runs_dir = Some(PathBuf::from(".tsumugi/runs"));
+        base.harness.auto_resume_on_start = Some(true);
+
+        let mut overlay = PartialTsumugiConfig::default();
+        overlay.harness.auto_resume_on_start = Some(false);
+        // runs_dir stays None: should not override.
+
+        base.merge_from(&overlay);
+        let final_config = base.into_final();
+
+        assert_eq!(
+            final_config.harness.runs_dir,
+            PathBuf::from(".tsumugi/runs")
+        );
+        assert!(!final_config.harness.auto_resume_on_start);
+    }
+
+    #[test]
+    fn harness_env_overrides_apply() {
+        let mut config = PartialTsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            match key {
+                "TMG_HARNESS_RUNS_DIR" => Some("/var/tsumugi".to_owned()),
+                "TMG_HARNESS_AUTO_RESUME_ON_START" => Some("false".to_owned()),
+                _ => None,
+            }
+        };
+        config
+            .apply_env_overrides(&env_fn)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let final_config = config.into_final();
+        assert_eq!(final_config.harness.runs_dir, PathBuf::from("/var/tsumugi"));
+        assert!(!final_config.harness.auto_resume_on_start);
+    }
+
+    #[test]
+    fn harness_env_override_invalid_bool_returns_error() {
+        let mut config = PartialTsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            if key == "TMG_HARNESS_AUTO_RESUME_ON_START" {
+                Some("maybe".to_owned())
+            } else {
+                None
+            }
+        };
+        let result = config.apply_env_overrides(&env_fn);
+        assert!(matches!(
+            result,
+            Err(ConfigError::InvalidValue { ref field, .. })
+                if field == "TMG_HARNESS_AUTO_RESUME_ON_START"
+        ));
     }
 }

--- a/tmg-cli/src/harness_init.rs
+++ b/tmg-cli/src/harness_init.rs
@@ -22,9 +22,14 @@ use crate::config::HarnessConfig;
 /// Behaviour:
 ///
 /// - When `harness.auto_resume_on_start` is `true`, ask the store for
-///   the most recent resumable run. If one exists, load it and return.
-/// - Otherwise (no resumable run, or auto-resume disabled), create a
-///   new ad-hoc run rooted at `workspace_path`.
+///   the most recent resumable run **whose `workspace_path` matches**
+///   the current `workspace_path`. If one exists, load it and return.
+/// - Otherwise (no matching resumable run, or auto-resume disabled),
+///   create a new ad-hoc run rooted at `workspace_path`.
+///
+/// Filtering by `workspace_path` prevents resuming a run that belongs
+/// to a different project when several projects share the same
+/// configured `runs_dir`.
 ///
 /// In both cases the run's `last_session_at` and `session_count` are
 /// updated and persisted via the [`RunRunner`](tmg_harness::RunRunner)
@@ -34,10 +39,10 @@ pub fn resolve_startup_run(
     store: &Arc<RunStore>,
     workspace_path: std::path::PathBuf,
 ) -> Result<Run, HarnessError> {
-    if harness.auto_resume_on_start {
-        if let Some(summary) = store.latest_resumable()? {
-            return store.load(&summary.id);
-        }
+    if harness.auto_resume_on_start
+        && let Some(summary) = store.latest_resumable(Some(&workspace_path))?
+    {
+        return store.load(&summary.id);
     }
     store.create_ad_hoc(workspace_path, None)
 }
@@ -143,5 +148,89 @@ mod tests {
         let listed = store.list().unwrap_or_else(|e| panic!("{e}"));
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, resolved.id);
+    }
+
+    #[test]
+    fn auto_resume_skips_runs_for_other_workspace() {
+        let (tmp, store) = make_store();
+        let workspace_a = tmp.path().join("workspace-a");
+        let workspace_b = tmp.path().join("workspace-b");
+        std::fs::create_dir_all(&workspace_a).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::create_dir_all(&workspace_b).unwrap_or_else(|e| panic!("{e}"));
+
+        // Seed a resumable run for workspace_a.
+        let run_a = store
+            .create_ad_hoc(workspace_a.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let cfg = HarnessConfig {
+            runs_dir: store.runs_dir().to_path_buf(),
+            auto_resume_on_start: true,
+        };
+
+        // Starting in workspace_b should NOT resume run_a; instead a
+        // fresh ad-hoc run should be created with workspace_path = b.
+        let resolved = resolve_startup_run(&cfg, &store, workspace_b.clone())
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        assert_ne!(resolved.id, run_a.id, "must not resume across workspaces");
+        assert_eq!(resolved.workspace_path, workspace_b);
+
+        // Both runs should exist now.
+        let listed = store.list().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(listed.len(), 2);
+    }
+
+    /// Integration-style test exercising the resume flow end-to-end:
+    /// `resolve_startup_run` -> `RunRunner::new` -> `begin_session`,
+    /// across two simulated launches in the same workspace.
+    #[test]
+    fn resume_flow_increments_session_count_on_second_launch() {
+        use tmg_harness::{RunRunner, SessionEndTrigger};
+
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+
+        let cfg = HarnessConfig {
+            runs_dir: store.runs_dir().to_path_buf(),
+            auto_resume_on_start: true,
+        };
+
+        // First launch: create a fresh run, begin and end one session,
+        // capture the assigned RunId.
+        let first_run =
+            resolve_startup_run(&cfg, &store, workspace.clone()).unwrap_or_else(|e| panic!("{e}"));
+        let first_id = first_run.id.clone();
+        let mut runner_one = RunRunner::new(first_run, Arc::clone(&store));
+        let handle_one = runner_one.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(runner_one.run().session_count, 1);
+        runner_one
+            .end_session(handle_one, SessionEndTrigger::Completed)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        // Second launch: resume the same run (same workspace, status
+        // is still Running so it should be picked up by
+        // latest_resumable).
+        let second_run =
+            resolve_startup_run(&cfg, &store, workspace.clone()).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            second_run.id, first_id,
+            "second launch should resume the same RunId"
+        );
+        assert_eq!(
+            second_run.session_count, 1,
+            "session_count from prior launch must be persisted"
+        );
+
+        let mut runner_two = RunRunner::new(second_run, Arc::clone(&store));
+        let handle_two = runner_two.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(handle_two.index, 2);
+        assert_eq!(
+            runner_two.run().session_count,
+            2,
+            "session_count must increment to 2 on resume"
+        );
+        assert_eq!(runner_two.run().id, first_id);
     }
 }

--- a/tmg-cli/src/harness_init.rs
+++ b/tmg-cli/src/harness_init.rs
@@ -1,0 +1,147 @@
+//! Startup integration with the [`tmg_harness`] crate.
+//!
+//! Encapsulates the run-resolution logic that runs at the start of
+//! [`run_tui`](crate::run_tui): given a [`HarnessConfig`] and a
+//! workspace path, return a [`Run`] that the CLI can hand to the
+//! [`RunRunner`]. The function resumes the most recent unfinished run
+//! when configured to and falls back to creating a fresh ad-hoc run
+//! otherwise.
+//!
+//! Keeping this separate from `main.rs` makes the policy unit-testable
+//! without spinning up an `AgentLoop` or a TUI.
+
+use std::sync::Arc;
+
+use tmg_harness::{HarnessError, Run, RunStore};
+
+use crate::config::HarnessConfig;
+
+/// Resolve the active [`Run`] at startup, persisting any state changes
+/// through the supplied [`RunStore`].
+///
+/// Behaviour:
+///
+/// - When `harness.auto_resume_on_start` is `true`, ask the store for
+///   the most recent resumable run. If one exists, load it and return.
+/// - Otherwise (no resumable run, or auto-resume disabled), create a
+///   new ad-hoc run rooted at `workspace_path`.
+///
+/// In both cases the run's `last_session_at` and `session_count` are
+/// updated and persisted via the [`RunRunner`](tmg_harness::RunRunner)
+/// elsewhere; this function only handles the load-vs-create choice.
+pub fn resolve_startup_run(
+    harness: &HarnessConfig,
+    store: &Arc<RunStore>,
+    workspace_path: std::path::PathBuf,
+) -> Result<Run, HarnessError> {
+    if harness.auto_resume_on_start {
+        if let Some(summary) = store.latest_resumable()? {
+            return store.load(&summary.id);
+        }
+    }
+    store.create_ad_hoc(workspace_path, None)
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use tmg_harness::{RunStatus, RunStore};
+
+    fn make_store() -> (tempfile::TempDir, Arc<RunStore>) {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let store = Arc::new(RunStore::new(tmp.path().join("runs")));
+        (tmp, store)
+    }
+
+    #[test]
+    fn auto_resume_true_with_existing_run_resumes_it() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+
+        // Seed an existing run that is still in Running status.
+        let seeded = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let cfg = HarnessConfig {
+            runs_dir: store.runs_dir().to_path_buf(),
+            auto_resume_on_start: true,
+        };
+        let resolved =
+            resolve_startup_run(&cfg, &store, workspace.clone()).unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(resolved.id, seeded.id, "should resume the existing run");
+    }
+
+    #[test]
+    fn auto_resume_false_creates_new_run_even_when_run_exists() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+
+        let seeded = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let cfg = HarnessConfig {
+            runs_dir: store.runs_dir().to_path_buf(),
+            auto_resume_on_start: false,
+        };
+        let resolved =
+            resolve_startup_run(&cfg, &store, workspace.clone()).unwrap_or_else(|e| panic!("{e}"));
+
+        assert_ne!(
+            resolved.id, seeded.id,
+            "should create a new run instead of resuming"
+        );
+        // Both runs should exist now.
+        let listed = store.list().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(listed.len(), 2);
+    }
+
+    #[test]
+    fn auto_resume_true_skips_terminal_runs() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+
+        let mut completed = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        completed.status = RunStatus::Completed;
+        store.save(&completed).unwrap_or_else(|e| panic!("{e}"));
+
+        let cfg = HarnessConfig {
+            runs_dir: store.runs_dir().to_path_buf(),
+            auto_resume_on_start: true,
+        };
+        let resolved =
+            resolve_startup_run(&cfg, &store, workspace.clone()).unwrap_or_else(|e| panic!("{e}"));
+
+        assert_ne!(
+            resolved.id, completed.id,
+            "should not resume a Completed run"
+        );
+    }
+
+    #[test]
+    fn auto_resume_true_creates_run_when_none_exist() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+
+        let cfg = HarnessConfig {
+            runs_dir: store.runs_dir().to_path_buf(),
+            auto_resume_on_start: true,
+        };
+        let resolved =
+            resolve_startup_run(&cfg, &store, workspace.clone()).unwrap_or_else(|e| panic!("{e}"));
+
+        // The run should be persisted and listed.
+        let listed = store.list().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, resolved.id);
+    }
+}

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -247,8 +247,14 @@ fn run_tui(
         });
 
         let cwd = std::env::current_dir()?;
-        // Use cwd as project root for now (could be improved with git root detection).
-        let project_root = cwd.clone();
+        // Canonicalise so the persisted `workspace_path` and the
+        // `workspace` symlink target are absolute and stable across
+        // shells that may have entered via a symlinked path. Falls
+        // back to the raw cwd if canonicalisation fails (e.g. on
+        // unusual filesystems).
+        let canonical_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+        // Use canonical cwd as project root for now (could be improved with git root detection).
+        let project_root = canonical_cwd.clone();
 
         // Resolve `runs_dir`: relative paths are interpreted against cwd
         // so the on-disk layout matches `.tsumugi/runs/<run-id>` for the
@@ -256,10 +262,10 @@ fn run_tui(
         let runs_dir = if harness_config.runs_dir.is_absolute() {
             harness_config.runs_dir.clone()
         } else {
-            cwd.join(&harness_config.runs_dir)
+            canonical_cwd.join(&harness_config.runs_dir)
         };
         let store = Arc::new(RunStore::new(runs_dir));
-        let run = harness_init::resolve_startup_run(harness_config, &store, cwd.clone())
+        let run = harness_init::resolve_startup_run(harness_config, &store, canonical_cwd.clone())
             .context("resolving startup run")?;
         let mut runner = RunRunner::new(run, Arc::clone(&store));
         let session_handle = runner
@@ -294,7 +300,7 @@ fn run_tui(
             registry,
             cancel.clone(),
             &project_root,
-            &cwd,
+            &canonical_cwd,
             context_config,
             tool_calling_mode,
         )?;
@@ -305,7 +311,7 @@ fn run_tui(
             model,
             tui_cancel,
             project_root,
-            cwd,
+            canonical_cwd,
             Some(subagent_manager),
             custom_agent_defs,
             event_log,
@@ -315,10 +321,12 @@ fn run_tui(
 
         // Close the harness session before propagating the TUI result so
         // that `last_session_at` / `session_count` are persisted even on
-        // error or cancellation paths.
-        let trigger = if tui_result.is_err() {
+        // error or cancellation paths. Capture the underlying error
+        // message in the `Errored` trigger so post-mortem inspection of
+        // the run sees the real failure rather than a generic string.
+        let trigger = if let Err(ref e) = tui_result {
             SessionEndTrigger::Errored {
-                message: "TUI returned an error".to_owned(),
+                message: format!("TUI returned an error: {e:#}"),
             }
         } else if cancel.is_cancelled() {
             SessionEndTrigger::UserCancelled

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -3,13 +3,15 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
+use tmg_harness::{RunRunner, RunStore, RunSummary, SessionEndTrigger};
 use tmg_llm::ToolCallingMode;
 use tokio::sync::Mutex;
 
 mod config;
 mod error;
+mod harness_init;
 
-use config::TsumugiConfig;
+use config::{HarnessConfig, TsumugiConfig};
 
 /// tsumugi - a local-LLM-powered coding agent
 #[derive(Parser, Debug)]
@@ -121,6 +123,7 @@ fn main() -> anyhow::Result<()> {
             context_config,
             config.llm.tool_calling,
             cli.event_log,
+            &config.harness,
         )?;
     }
 
@@ -210,12 +213,23 @@ fn run_prompt(
 /// and input area. The TUI handles multi-turn conversations with
 /// streaming LLM responses. Includes subagent support via
 /// `spawn_agent` tool, with custom agent definitions from TOML.
+///
+/// Initialises a [`RunStore`] and resolves the active [`Run`] following
+/// the policy described in [`harness_init::resolve_startup_run`]: when
+/// `harness.auto_resume_on_start` is `true` and a resumable run exists,
+/// the most recent one is loaded; otherwise a fresh ad-hoc run is
+/// created. The run is wrapped in a [`RunRunner`] which begins one
+/// session that lives for the duration of the TUI; the session is ended
+/// with a normal-completion trigger when the TUI returns and aborted
+/// with `UserCancelled` if the cancellation token fired or the TUI
+/// returned an error.
 fn run_tui(
     endpoint: &str,
     model: &str,
     context_config: tmg_core::ContextConfig,
     tool_calling_mode: tmg_core::ToolCallingMode,
     event_log: Option<PathBuf>,
+    harness_config: &HarnessConfig,
 ) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
@@ -235,6 +249,23 @@ fn run_tui(
         let cwd = std::env::current_dir()?;
         // Use cwd as project root for now (could be improved with git root detection).
         let project_root = cwd.clone();
+
+        // Resolve `runs_dir`: relative paths are interpreted against cwd
+        // so the on-disk layout matches `.tsumugi/runs/<run-id>` for the
+        // current project.
+        let runs_dir = if harness_config.runs_dir.is_absolute() {
+            harness_config.runs_dir.clone()
+        } else {
+            cwd.join(&harness_config.runs_dir)
+        };
+        let store = Arc::new(RunStore::new(runs_dir));
+        let run = harness_init::resolve_startup_run(harness_config, &store, cwd.clone())
+            .context("resolving startup run")?;
+        let mut runner = RunRunner::new(run, Arc::clone(&store));
+        let session_handle = runner
+            .begin_session()
+            .context("beginning harness session")?;
+        let run_summary: RunSummary = runner.summary();
 
         // Discover custom agent definitions.
         let custom_agent_metas = tmg_agents::discover_custom_agents(&project_root)
@@ -268,18 +299,49 @@ fn run_tui(
             tool_calling_mode,
         )?;
 
-        tmg_tui::run(
+        let tui_cancel = cancel.clone();
+        let tui_result = tmg_tui::run(
             agent,
             model,
-            cancel,
+            tui_cancel,
             project_root,
             cwd,
             Some(subagent_manager),
             custom_agent_defs,
             event_log,
+            Some(run_summary),
         )
-        .await?;
+        .await;
 
+        // Close the harness session before propagating the TUI result so
+        // that `last_session_at` / `session_count` are persisted even on
+        // error or cancellation paths.
+        let trigger = if tui_result.is_err() {
+            SessionEndTrigger::Errored {
+                message: "TUI returned an error".to_owned(),
+            }
+        } else if cancel.is_cancelled() {
+            SessionEndTrigger::UserCancelled
+        } else {
+            SessionEndTrigger::Completed
+        };
+        if let Err(e) = runner.end_session(session_handle, trigger) {
+            // Persisting on shutdown is best-effort; surface as a
+            // warning rather than masking the original TUI result.
+            eprintln_warning(&format!("failed to persist run state on shutdown: {e}"));
+        }
+
+        tui_result?;
         Ok::<(), anyhow::Error>(())
     })
+}
+
+/// Print a warning to stderr without violating the workspace
+/// `print_stderr` lint.
+#[expect(
+    clippy::print_stderr,
+    reason = "best-effort shutdown warning; surfaced to operator without disturbing the TUI exit code"
+)]
+fn eprintln_warning(message: &str) {
+    eprintln!("[tmg] warning: {message}");
 }


### PR DESCRIPTION
## Summary

Introduces the unified Run model from SPEC §9 as the new `tmg-harness` crate and wires the TUI startup sequence through it.

- New `crates/tmg-harness/` with `Run` / `RunId` / `RunScope` / `RunStatus` / `Session` / `SessionEndTrigger` data types per SPEC §9.5, plus a `RunStore` (`create_ad_hoc` / `load` / `list` / `save`) and a minimal `RunRunner` (`new`, `run`, `begin_session`, `end_session`).
- `RunStore::create_ad_hoc` writes `.tsumugi/runs/<run-id>/run.toml` and a best-effort `workspace` symlink to the project root on first creation.
- `tmg-cli` gains a `[harness]` config section (`runs_dir`, `auto_resume_on_start`) following the existing `PartialLlmConfig` merge pattern, plus matching `TMG_HARNESS_RUNS_DIR` / `TMG_HARNESS_AUTO_RESUME_ON_START` env overrides.
- `run_tui` now resolves the startup run via `harness_init::resolve_startup_run` (auto-resume the latest `Running`/`Paused`/`Exhausted` run, or create a new ad-hoc run), wraps it in a `RunRunner`, calls `begin_session` to bump `session_count` / `last_session_at`, and `end_session(...)` on exit so state is persisted on completion, cancellation, and error paths alike.
- TUI `App` carries `current_run: Option<RunSummary>`; the header shows a new `Run` pane with the 8-char short id and the scope label, alongside the existing Model / Context / Agents panes.
- Workspace dependencies gain `chrono` and `uuid`; the `tmg-harness` crate is added to `[workspace.members]` and the workspace dependency table.

## Crates touched

- `crates/tmg-harness/` (new)
- `crates/tmg-tui/` (App.current_run, header pane, plumbing)
- `tmg-cli/` ([harness] config, harness_init module, run_tui integration)
- root `Cargo.toml` / `Cargo.lock`

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (all suites green; `tmg-harness` adds 19 unit tests, `tmg-cli` adds harness config tests + `harness_init` resume/false-resume/skip-terminal/none-existing scenarios)
- [ ] `cargo deny check` — `cargo-deny` is not installed in the local environment; this should be re-run in CI. New external deps are `chrono` (MIT/Apache-2.0) and `uuid` (Apache-2.0/MIT), both already on the existing license allowlist.

### Runtime Verification

- LLM server: available (`http://localhost:8080`)
- One-shot mode: PASS
  - `tmg --prompt "Say hello briefly" --event-log /tmp/tmg-verify-oneshot.jsonl` returns a streaming reply; event log has 1230 entries with normal `done` event and no `is_error: true`.
- TUI mode: PASS
  - First launch in an empty project creates `.tsumugi/runs/<id>/` with `run.toml` (`session_count = 1`, `state = "running"`, `kind = "ad_hoc"`) and a `workspace` symlink.
  - Second launch with default config (`auto_resume_on_start = true`) reuses the same run id and bumps `session_count` to 2, `last_session_at` updated.
  - Third launch with project-local `[harness] auto_resume_on_start = false` creates a new run id alongside the existing one, confirming the flag's semantics end-to-end.

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)