### PR TITLE
Add initializer/tester/qa builtin subagents (#35)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tmg-agents",
  "tmg-core",
  "tmg-sandbox",
  "tmg-tools",

--- a/crates/tmg-agents/src/builtins.rs
+++ b/crates/tmg-agents/src/builtins.rs
@@ -31,8 +31,6 @@
 //! tools simply receive a registry without those tools and the LLM is
 //! told (via the system prompt) that the harnessed gates do not apply.
 
-use std::sync::Arc;
-
 use tmg_tools::ToolRegistry;
 
 use crate::config::{AgentKind, AgentType};
@@ -98,7 +96,7 @@ pub fn registry_for_agent_kind(agent_kind: &AgentKind) -> ToolRegistry {
 #[must_use]
 pub fn registry_for_agent_kind_with_run_provider(
     agent_kind: &AgentKind,
-    provider: &Arc<dyn RunToolProvider>,
+    provider: &dyn RunToolProvider,
 ) -> ToolRegistry {
     let allowed = agent_kind.allowed_tool_names();
     build_registry(&allowed, Some(provider))
@@ -107,7 +105,7 @@ pub fn registry_for_agent_kind_with_run_provider(
 /// Build a registry containing only the named tools, drawing first from
 /// the stateless default registry and then from the optional
 /// [`RunToolProvider`].
-fn build_registry(allowed: &[&str], provider: Option<&Arc<dyn RunToolProvider>>) -> ToolRegistry {
+fn build_registry(allowed: &[&str], provider: Option<&dyn RunToolProvider>) -> ToolRegistry {
     let full_registry = tmg_tools::default_registry();
     let mut filtered = ToolRegistry::new();
 
@@ -137,18 +135,15 @@ fn register_stateless_tool_by_name(registry: &mut ToolRegistry, name: &str) {
         "grep_search" => registry.register(tmg_tools::tools::GrepSearchTool),
         "list_dir" => registry.register(tmg_tools::tools::ListDirTool),
         "shell_exec" => registry.register(tmg_tools::tools::ShellExecTool),
-        _ => {
-            debug_assert!(
-                false,
-                "register_stateless_tool_by_name: unknown tool name: {name}",
-            );
-        }
+        _ => unreachable!("caller guarantees presence in default_registry"),
     }
 }
 
 #[cfg(test)]
 #[expect(clippy::panic, reason = "test assertions")]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]
@@ -300,7 +295,7 @@ allow = ["file_read", "grep_search"]
             ],
         });
         let kind = AgentKind::Builtin(AgentType::Qa);
-        let registry = registry_for_agent_kind_with_run_provider(&kind, &provider);
+        let registry = registry_for_agent_kind_with_run_provider(&kind, &*provider);
 
         assert!(registry.get("feature_list_read").is_some());
         assert!(registry.get("feature_list_mark_passing").is_some());
@@ -324,7 +319,7 @@ allow = ["file_read", "grep_search"]
         });
 
         let positive = AgentKind::Builtin(AgentType::Qa);
-        let qa_registry = registry_for_agent_kind_with_run_provider(&positive, &provider);
+        let qa_registry = registry_for_agent_kind_with_run_provider(&positive, &*provider);
         assert!(
             qa_registry.get("feature_list_mark_passing").is_some(),
             "qa registry MUST contain feature_list_mark_passing",
@@ -338,7 +333,7 @@ allow = ["file_read", "grep_search"]
             AgentType::Plan,
         ] {
             let kind = AgentKind::Builtin(agent_type);
-            let registry = registry_for_agent_kind_with_run_provider(&kind, &provider);
+            let registry = registry_for_agent_kind_with_run_provider(&kind, &*provider);
             assert!(
                 registry.get("feature_list_mark_passing").is_none(),
                 "{} registry MUST NOT contain feature_list_mark_passing",
@@ -384,7 +379,7 @@ allow = ["file_read", "grep_search"]
         // consulted at all.
         let _ = registry_for_agent_kind_with_run_provider(
             &AgentKind::Builtin(AgentType::Worker),
-            &provider,
+            &*provider,
         );
         assert!(
             calls.lock().map(|c| c.is_empty()).unwrap_or(true),
@@ -396,7 +391,7 @@ allow = ["file_read", "grep_search"]
         // be consulted for that one name (and only that one).
         let _ = registry_for_agent_kind_with_run_provider(
             &AgentKind::Builtin(AgentType::Initializer),
-            &provider,
+            &*provider,
         );
         let recorded = calls.lock().map(|c| c.clone()).unwrap_or_default();
         assert_eq!(

--- a/crates/tmg-agents/src/builtins.rs
+++ b/crates/tmg-agents/src/builtins.rs
@@ -2,44 +2,134 @@
 //!
 //! Provides helpers to create a [`ToolRegistry`] filtered to only the
 //! tools allowed for a given [`AgentType`] or [`AgentKind`].
+//!
+//! ## Stateless vs. Run-aware tools
+//!
+//! The built-in subagents declare two flavours of tool:
+//!
+//! - **Stateless tools** live in [`tmg_tools::default_registry`] and can
+//!   be constructed without any external context (file I/O, grep,
+//!   shell). [`registry_for_agent_type`] / [`registry_for_agent_kind`]
+//!   handle these unconditionally.
+//! - **Run-aware tools** (`progress_append`, `feature_list_read`,
+//!   `feature_list_mark_passing`) require a `RunRunner` handle to
+//!   operate. They are referenced by name in
+//!   [`AgentType::allowed_tools`] but **cannot** be registered from
+//!   inside `tmg-agents` because that would create a dependency cycle
+//!   on `tmg-harness`.
+//!
+//! The cycle is broken by the [`RunToolProvider`] trait: anyone holding
+//! a `RunRunner` (in practice `tmg-harness` / the CLI wiring layer) can
+//! implement this trait and pass an `Arc<dyn RunToolProvider>` into the
+//! [`SubagentManager`](crate::manager::SubagentManager). When a
+//! subagent is spawned, the manager builds the stateless registry first
+//! and then asks the provider to register any Run-aware tools the
+//! agent's `allowed_tools` list mentions.
+//!
+//! In Run-less code paths (`--prompt` one-shots) the provider is
+//! `None`; subagents whose allowed-tools list references Run-aware
+//! tools simply receive a registry without those tools and the LLM is
+//! told (via the system prompt) that the harnessed gates do not apply.
+
+use std::sync::Arc;
 
 use tmg_tools::ToolRegistry;
 
 use crate::config::{AgentKind, AgentType};
 
-/// Create a [`ToolRegistry`] containing only the tools allowed for the
-/// given agent type.
+/// Source of Run-aware tools that cannot be constructed by `tmg-agents`
+/// alone (they depend on a `RunRunner`).
+///
+/// Implementors decide which subset of `progress_append`,
+/// `feature_list_read`, and `feature_list_mark_passing` is appropriate
+/// for the active run scope (ad-hoc vs. harnessed) and must register
+/// only those tools.
+///
+/// The trait is deliberately small — just one method that takes the
+/// target registry and the tool name to register. Returning `bool`
+/// makes the spawner's "skip unregistered Run-aware tool names"
+/// behaviour explicit.
+pub trait RunToolProvider: Send + Sync {
+    /// Attempt to register a Run-aware tool with `name` into `registry`.
+    ///
+    /// Returns `true` if the tool was registered, `false` if `name` is
+    /// not a Run-aware tool the provider knows about (or if the active
+    /// run scope forbids it — e.g. a tester subagent asking for
+    /// `feature_list_mark_passing` on an ad-hoc run).
+    fn register_run_tool(&self, registry: &mut ToolRegistry, name: &str) -> bool;
+}
+
+/// Create a [`ToolRegistry`] containing only the stateless tools allowed
+/// for the given agent type.
 ///
 /// This filters the default registry, keeping only tools whose names
-/// appear in [`AgentType::allowed_tools`].
+/// appear in [`AgentType::allowed_tools`]. Run-aware tools are silently
+/// skipped — use [`registry_for_agent_kind_with_run_provider`] if you
+/// have a [`RunToolProvider`] available.
+#[must_use]
 pub fn registry_for_agent_type(agent_type: AgentType) -> ToolRegistry {
     let allowed: Vec<&str> = agent_type.allowed_tools().to_vec();
-    registry_for_tool_names(&allowed)
+    build_registry(&allowed, None)
 }
 
-/// Create a [`ToolRegistry`] containing only the tools allowed for the
-/// given agent kind (built-in or custom).
+/// Create a [`ToolRegistry`] containing only the stateless tools allowed
+/// for the given agent kind (built-in or custom).
+///
+/// Run-aware tools are silently skipped — use
+/// [`registry_for_agent_kind_with_run_provider`] if you have a
+/// [`RunToolProvider`] available.
+#[must_use]
 pub fn registry_for_agent_kind(agent_kind: &AgentKind) -> ToolRegistry {
     let allowed = agent_kind.allowed_tool_names();
-    registry_for_tool_names(&allowed)
+    build_registry(&allowed, None)
 }
 
-/// Create a [`ToolRegistry`] filtered to only the named tools.
-fn registry_for_tool_names(allowed: &[&str]) -> ToolRegistry {
+/// Create a [`ToolRegistry`] for the given agent kind, including
+/// Run-aware tools registered through `provider`.
+///
+/// For each name in the agent's `allowed_tools` list:
+///
+/// 1. If the name belongs to the stateless default registry, the
+///    corresponding tool is registered.
+/// 2. Otherwise, [`RunToolProvider::register_run_tool`] is called with
+///    the name; if the provider declines, the name is silently
+///    skipped. This preserves the "unknown name = absent tool"
+///    contract the subagent permission tests rely on.
+#[must_use]
+pub fn registry_for_agent_kind_with_run_provider(
+    agent_kind: &AgentKind,
+    provider: &Arc<dyn RunToolProvider>,
+) -> ToolRegistry {
+    let allowed = agent_kind.allowed_tool_names();
+    build_registry(&allowed, Some(provider))
+}
+
+/// Build a registry containing only the named tools, drawing first from
+/// the stateless default registry and then from the optional
+/// [`RunToolProvider`].
+fn build_registry(allowed: &[&str], provider: Option<&Arc<dyn RunToolProvider>>) -> ToolRegistry {
     let full_registry = tmg_tools::default_registry();
     let mut filtered = ToolRegistry::new();
 
     for name in allowed {
         if full_registry.get(name).is_some() {
-            register_tool_by_name(&mut filtered, name);
+            register_stateless_tool_by_name(&mut filtered, name);
+        } else if let Some(provider) = provider {
+            // Unknown to the stateless default registry; ask the Run
+            // provider. A `false` return is the silent-skip path
+            // documented above.
+            let _ = provider.register_run_tool(&mut filtered, name);
         }
+        // No provider AND not in default_registry: silently skip. The
+        // subagent will simply not see the tool, which is the intended
+        // behaviour for Run-less code paths.
     }
 
     filtered
 }
 
-/// Register a built-in tool by name into the given registry.
-fn register_tool_by_name(registry: &mut ToolRegistry, name: &str) {
+/// Register a stateless built-in tool by name into the given registry.
+fn register_stateless_tool_by_name(registry: &mut ToolRegistry, name: &str) {
     match name {
         "file_read" => registry.register(tmg_tools::tools::FileReadTool),
         "file_write" => registry.register(tmg_tools::tools::FileWriteTool),
@@ -48,7 +138,10 @@ fn register_tool_by_name(registry: &mut ToolRegistry, name: &str) {
         "list_dir" => registry.register(tmg_tools::tools::ListDirTool),
         "shell_exec" => registry.register(tmg_tools::tools::ShellExecTool),
         _ => {
-            debug_assert!(false, "register_tool_by_name: unknown tool name: {name}");
+            debug_assert!(
+                false,
+                "register_stateless_tool_by_name: unknown tool name: {name}",
+            );
         }
     }
 }
@@ -117,5 +210,199 @@ allow = ["file_read", "grep_search"]
         assert!(registry.get("grep_search").is_some());
         assert!(registry.get("file_write").is_none());
         assert!(registry.get("shell_exec").is_none());
+    }
+
+    /// Without a [`RunToolProvider`], the harnessed agents see only the
+    /// subset of their allowed tools that lives in
+    /// [`tmg_tools::default_registry`].
+    #[test]
+    fn harnessed_agents_without_provider_skip_run_aware_tools() {
+        let initializer = registry_for_agent_type(AgentType::Initializer);
+        // Stateless tools present:
+        assert!(initializer.get("file_read").is_some());
+        assert!(initializer.get("file_write").is_some());
+        assert!(initializer.get("list_dir").is_some());
+        assert!(initializer.get("shell_exec").is_some());
+        // Run-aware tool absent because no provider was supplied:
+        assert!(initializer.get("progress_append").is_none());
+
+        let qa = registry_for_agent_type(AgentType::Qa);
+        // Stateless tool present:
+        assert!(qa.get("file_read").is_some());
+        // Run-aware tools absent:
+        assert!(qa.get("feature_list_read").is_none());
+        assert!(qa.get("feature_list_mark_passing").is_none());
+    }
+
+    /// A test [`RunToolProvider`] that records which names are asked for
+    /// and registers a sentinel tool for each "Run-aware" name.
+    struct TestRunToolProvider {
+        run_aware_names: Vec<&'static str>,
+    }
+
+    impl RunToolProvider for TestRunToolProvider {
+        fn register_run_tool(&self, registry: &mut ToolRegistry, name: &str) -> bool {
+            // Match against the static list so each registered stub
+            // can carry a `&'static str` name (required by `Tool::name`).
+            for static_name in &self.run_aware_names {
+                if *static_name == name {
+                    registry.register(StubTool { static_name });
+                    return true;
+                }
+            }
+            false
+        }
+    }
+
+    /// Minimal stand-in tool used by `TestRunToolProvider` so registry
+    /// presence can be asserted.
+    struct StubTool {
+        static_name: &'static str,
+    }
+
+    impl tmg_tools::Tool for StubTool {
+        fn name(&self) -> &'static str {
+            self.static_name
+        }
+
+        fn description(&self) -> &'static str {
+            "stub"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        fn execute(
+            &self,
+            _params: serde_json::Value,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<tmg_tools::ToolResult, tmg_tools::ToolError>,
+                    > + Send
+                    + '_,
+            >,
+        > {
+            Box::pin(async { Ok(tmg_tools::ToolResult::success("ok")) })
+        }
+    }
+
+    /// Acceptance: with a provider that registers all three Run-aware
+    /// tools, the QA registry contains `feature_list_mark_passing`.
+    #[test]
+    fn qa_registry_with_provider_contains_mark_passing() {
+        let provider: Arc<dyn RunToolProvider> = Arc::new(TestRunToolProvider {
+            run_aware_names: vec![
+                "progress_append",
+                "feature_list_read",
+                "feature_list_mark_passing",
+            ],
+        });
+        let kind = AgentKind::Builtin(AgentType::Qa);
+        let registry = registry_for_agent_kind_with_run_provider(&kind, &provider);
+
+        assert!(registry.get("feature_list_read").is_some());
+        assert!(registry.get("feature_list_mark_passing").is_some());
+        assert!(registry.get("file_read").is_some());
+        // QA must not see other Run-aware tools it didn't ask for.
+        assert!(registry.get("progress_append").is_none());
+    }
+
+    /// Acceptance: only the QA subagent gets `feature_list_mark_passing`
+    /// in its registry. Initializer / Tester / Worker / Explore / Plan
+    /// must NOT, even when a provider that knows about it is wired in.
+    /// This is the core permission test for the issue.
+    #[test]
+    fn only_qa_can_call_feature_list_mark_passing() {
+        let provider: Arc<dyn RunToolProvider> = Arc::new(TestRunToolProvider {
+            run_aware_names: vec![
+                "progress_append",
+                "feature_list_read",
+                "feature_list_mark_passing",
+            ],
+        });
+
+        let positive = AgentKind::Builtin(AgentType::Qa);
+        let qa_registry = registry_for_agent_kind_with_run_provider(&positive, &provider);
+        assert!(
+            qa_registry.get("feature_list_mark_passing").is_some(),
+            "qa registry MUST contain feature_list_mark_passing",
+        );
+
+        for agent_type in [
+            AgentType::Initializer,
+            AgentType::Tester,
+            AgentType::Worker,
+            AgentType::Explore,
+            AgentType::Plan,
+        ] {
+            let kind = AgentKind::Builtin(agent_type);
+            let registry = registry_for_agent_kind_with_run_provider(&kind, &provider);
+            assert!(
+                registry.get("feature_list_mark_passing").is_none(),
+                "{} registry MUST NOT contain feature_list_mark_passing",
+                agent_type.name(),
+            );
+            // feature_list_read is also QA-only in the current spec.
+            if !matches!(agent_type, AgentType::Qa) {
+                assert!(
+                    registry.get("feature_list_read").is_none(),
+                    "{} registry MUST NOT contain feature_list_read",
+                    agent_type.name(),
+                );
+            }
+        }
+    }
+
+    /// The provider's `register_run_tool` is only called for names that
+    /// are NOT in the stateless default registry. This keeps the
+    /// stateless-vs-stateful separation enforced by construction.
+    #[test]
+    fn provider_only_consulted_for_run_aware_names() {
+        use std::sync::Mutex;
+
+        struct RecordingProvider {
+            calls: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl RunToolProvider for RecordingProvider {
+            fn register_run_tool(&self, _registry: &mut ToolRegistry, name: &str) -> bool {
+                if let Ok(mut calls) = self.calls.lock() {
+                    calls.push(name.to_owned());
+                }
+                false
+            }
+        }
+
+        let calls: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let provider: Arc<dyn RunToolProvider> = Arc::new(RecordingProvider {
+            calls: Arc::clone(&calls),
+        });
+
+        // Worker only references stateless tools — provider must not be
+        // consulted at all.
+        let _ = registry_for_agent_kind_with_run_provider(
+            &AgentKind::Builtin(AgentType::Worker),
+            &provider,
+        );
+        assert!(
+            calls.lock().map(|c| c.is_empty()).unwrap_or(true),
+            "provider unexpectedly invoked for Worker (stateless-only): {:?}",
+            calls.lock().map(|c| c.clone()),
+        );
+
+        // Initializer references `progress_append`. The provider should
+        // be consulted for that one name (and only that one).
+        let _ = registry_for_agent_kind_with_run_provider(
+            &AgentKind::Builtin(AgentType::Initializer),
+            &provider,
+        );
+        let recorded = calls.lock().map(|c| c.clone()).unwrap_or_default();
+        assert_eq!(
+            recorded,
+            vec!["progress_append"],
+            "expected provider to be consulted exactly for progress_append; got {recorded:?}",
+        );
     }
 }

--- a/crates/tmg-agents/src/config.rs
+++ b/crates/tmg-agents/src/config.rs
@@ -133,6 +133,17 @@ impl AgentType {
     ///   `feature_list_mark_passing`.
     /// - `Explore` / `Plan`: [`SandboxMode::ReadOnly`].
     /// - `Worker`: [`SandboxMode::WorkspaceWrite`].
+    ///
+    /// # Advisory only
+    ///
+    /// The returned value is **advisory** at present: subagents inherit
+    /// the harness-level sandbox mode at runtime, and per-agent sandbox
+    /// enforcement is a follow-up. Callers should treat this as the
+    /// agent's *expected* sandbox profile (useful for documentation,
+    /// configuration UIs, and future per-agent enforcement) rather than
+    /// a guaranteed runtime constraint. This mirrors the same advisory
+    /// semantics documented on
+    /// [`CustomAgentDef::sandbox_mode`](crate::custom::CustomAgentDef::sandbox_mode).
     #[must_use]
     pub fn sandbox_mode(&self) -> SandboxMode {
         match self {

--- a/crates/tmg-agents/src/config.rs
+++ b/crates/tmg-agents/src/config.rs
@@ -8,12 +8,23 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
+use tmg_sandbox::SandboxMode;
+
 use crate::custom::CustomAgentDef;
 
 /// The built-in subagent types.
 ///
 /// Each type defines a different set of allowed tools and a tailored
 /// system prompt for its purpose.
+///
+/// The harnessed-run subagents (`Initializer`, `Tester`, `Qa`) reference
+/// Run-scoped tools (`progress_append`, `feature_list_read`,
+/// `feature_list_mark_passing`) that are not part of
+/// [`tmg_tools::default_registry`]. Registration of those tools is the
+/// responsibility of the spawner via the
+/// [`RunToolProvider`](crate::builtins::RunToolProvider) plumbing — the
+/// subagent declares the names here, and they are filtered out of the
+/// final registry when no provider is wired in (e.g. ad-hoc runs).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentType {
@@ -31,15 +42,56 @@ pub enum AgentType {
     ///
     /// Allowed tools: `file_read`, `list_dir`, `grep_search`.
     Plan,
+
+    /// Project bootstrap agent (SPEC §5.2).
+    ///
+    /// Generates `features.json`, `init.sh`, an initial `progress.md`,
+    /// and the first git commit for a harnessed run.
+    ///
+    /// Allowed tools: `file_read`, `file_write`, `list_dir`,
+    /// `shell_exec`, `progress_append`.
+    Initializer,
+
+    /// Smoke-test agent (SPEC §5.2).
+    ///
+    /// Runs the project's own quality gates (unit tests, lint, build,
+    /// screenshot capture if applicable) and reports the outcome.
+    ///
+    /// Allowed tools: `shell_exec`, `file_read`.
+    Tester,
+
+    /// Acceptance-criteria QA agent (SPEC §5.2).
+    ///
+    /// Read-only inspector that walks `features.json`, verifies each
+    /// feature against its acceptance criteria, and is the **only**
+    /// subagent permitted to flip a feature's `passes` field via
+    /// `feature_list_mark_passing`.
+    ///
+    /// Allowed tools: `feature_list_read`, `feature_list_mark_passing`,
+    /// `file_read`.
+    Qa,
 }
 
 impl AgentType {
     /// All built-in agent types.
-    pub const ALL: &'static [Self] = &[Self::Explore, Self::Worker, Self::Plan];
+    pub const ALL: &'static [Self] = &[
+        Self::Explore,
+        Self::Worker,
+        Self::Plan,
+        Self::Initializer,
+        Self::Tester,
+        Self::Qa,
+    ];
 
     /// Return the tool names allowed for this agent type.
     ///
     /// `spawn_agent` is never included (nesting is forbidden).
+    ///
+    /// The harnessed agents (`Initializer`, `Tester`, `Qa`) include
+    /// Run-scoped tool names (`progress_append`, `feature_list_read`,
+    /// `feature_list_mark_passing`); the spawner is responsible for
+    /// gating those tools on the presence of an active `RunRunner`
+    /// (see [`RunToolProvider`](crate::builtins::RunToolProvider)).
     pub fn allowed_tools(&self) -> &'static [&'static str] {
         match self {
             Self::Explore | Self::Plan => &["file_read", "list_dir", "grep_search"],
@@ -51,6 +103,41 @@ impl AgentType {
                 "list_dir",
                 "shell_exec",
             ],
+            Self::Initializer => &[
+                "file_read",
+                "file_write",
+                "list_dir",
+                "shell_exec",
+                "progress_append",
+            ],
+            Self::Tester => &["shell_exec", "file_read"],
+            Self::Qa => &[
+                "feature_list_read",
+                "feature_list_mark_passing",
+                "file_read",
+            ],
+        }
+    }
+
+    /// Return the sandbox mode this agent type expects to run under.
+    ///
+    /// SPEC §5.2 gates:
+    ///
+    /// - `Initializer`: [`SandboxMode::WorkspaceWrite`] — generates
+    ///   `features.json` / `init.sh` / `progress.md` and commits.
+    /// - `Tester`: [`SandboxMode::WorkspaceWrite`] — needs to persist
+    ///   screenshots and other test artefacts.
+    /// - `Qa`: [`SandboxMode::ReadOnly`] — verifies acceptance criteria
+    ///   without mutating the workspace; the only state change is the
+    ///   `passes` flag, which is mediated by
+    ///   `feature_list_mark_passing`.
+    /// - `Explore` / `Plan`: [`SandboxMode::ReadOnly`].
+    /// - `Worker`: [`SandboxMode::WorkspaceWrite`].
+    #[must_use]
+    pub fn sandbox_mode(&self) -> SandboxMode {
+        match self {
+            Self::Explore | Self::Plan | Self::Qa => SandboxMode::ReadOnly,
+            Self::Worker | Self::Initializer | Self::Tester => SandboxMode::WorkspaceWrite,
         }
     }
 
@@ -74,6 +161,53 @@ impl AgentType {
                  directories, and search with grep. Output a clear, actionable plan \
                  with numbered steps."
             }
+            Self::Initializer => {
+                "You are the initializer subagent. Your single responsibility is to \
+                 bootstrap a fresh harnessed project so subsequent sessions have a \
+                 stable starting point. Produce four artefacts in this order: \
+                 (1) `features.json` -- an inventory of acceptance-test features the \
+                 project must satisfy. Cap the list at between 30 and 50 entries; \
+                 fewer than 30 is too coarse and more than 50 makes per-session \
+                 review intractable. Each entry needs `id`, `category`, \
+                 `description`, `steps`, and `passes: false`. \
+                 (2) `init.sh` -- an idempotent shell script that prepares the \
+                 workspace for an agent (install deps, build, seed fixtures). \
+                 Keep it deterministic and quiet on success. \
+                 (3) `progress.md` -- the initial progress log. Use \
+                 `progress_append` to record what bootstrap did so future \
+                 sessions can re-discover the starting state. \
+                 (4) An initial git commit on the current branch containing the \
+                 generated files, with a clear message. \
+                 You have read+write access to the workspace via `file_read`, \
+                 `file_write`, `list_dir`, and `shell_exec`. Do not invent \
+                 features the user did not request; mine the existing repo for \
+                 features when possible."
+            }
+            Self::Tester => {
+                "You are the tester subagent. Smoke-test the workspace per SPEC §5.2: \
+                 run the project's quality gates (unit tests, integration tests, \
+                 build, lint, format check) using `shell_exec`, and read failure \
+                 output back via `file_read` when needed. Capture screenshots or \
+                 other test artefacts to disk if the project supports it. Browser \
+                 automation tools are a future addition (browser MCP); until then, \
+                 focus on shell-driven test commands. Report results as a concise \
+                 pass/fail summary with the exact commands run, exit codes, and \
+                 short failure excerpts. Do not modify source files; use the \
+                 workspace as a read-mostly target with writes limited to \
+                 test-output directories."
+            }
+            Self::Qa => {
+                "You are the QA subagent. Walk `features.json` via `feature_list_read`, \
+                 verify each entry's acceptance criteria against the live workspace \
+                 using `file_read`, and call `feature_list_mark_passing` for every \
+                 feature you can confirm is now passing. You are the **only** \
+                 subagent permitted to invoke `feature_list_mark_passing`; misuse \
+                 corrupts the harnessed run's pass-fail accounting. Be conservative: \
+                 if a feature's evidence is ambiguous, leave `passes` as `false` \
+                 and explain why. Your environment is read-only -- you cannot \
+                 modify any source file. Report the set of features marked \
+                 passing and any features you explicitly chose not to mark."
+            }
         }
     }
 
@@ -83,6 +217,13 @@ impl AgentType {
             Self::Explore => "Read-only codebase exploration (file_read, list_dir, grep_search)",
             Self::Worker => "Full tool access worker (all tools except spawn_agent)",
             Self::Plan => "Read-only planning agent (file_read, list_dir, grep_search)",
+            Self::Initializer => {
+                "Project bootstrap (features.json/init.sh/progress.md + initial commit)"
+            }
+            Self::Tester => "Smoke-test runner (shell-driven test commands, capture artefacts)",
+            Self::Qa => {
+                "Acceptance-criteria QA (read-only; only agent that can mark features passing)"
+            }
         }
     }
 
@@ -92,6 +233,9 @@ impl AgentType {
             Self::Explore => "explore",
             Self::Worker => "worker",
             Self::Plan => "plan",
+            Self::Initializer => "initializer",
+            Self::Tester => "tester",
+            Self::Qa => "qa",
         }
     }
 
@@ -115,7 +259,7 @@ impl std::fmt::Display for AgentType {
 /// agent.
 #[derive(Debug, Clone)]
 pub enum AgentKind {
-    /// A built-in agent type (explore, worker, plan).
+    /// A built-in agent type (explore, worker, plan, initializer, tester, qa).
     Builtin(AgentType),
 
     /// A custom agent loaded from a TOML definition file.
@@ -188,6 +332,12 @@ mod tests {
         assert_eq!(AgentType::from_name("explore"), Some(AgentType::Explore));
         assert_eq!(AgentType::from_name("worker"), Some(AgentType::Worker));
         assert_eq!(AgentType::from_name("plan"), Some(AgentType::Plan));
+        assert_eq!(
+            AgentType::from_name("initializer"),
+            Some(AgentType::Initializer)
+        );
+        assert_eq!(AgentType::from_name("tester"), Some(AgentType::Tester));
+        assert_eq!(AgentType::from_name("qa"), Some(AgentType::Qa));
         assert_eq!(AgentType::from_name("unknown"), None);
     }
 
@@ -196,6 +346,9 @@ mod tests {
         assert_eq!(AgentType::Explore.to_string(), "explore");
         assert_eq!(AgentType::Worker.to_string(), "worker");
         assert_eq!(AgentType::Plan.to_string(), "plan");
+        assert_eq!(AgentType::Initializer.to_string(), "initializer");
+        assert_eq!(AgentType::Tester.to_string(), "tester");
+        assert_eq!(AgentType::Qa.to_string(), "qa");
     }
 
     #[test]
@@ -226,7 +379,108 @@ mod tests {
 
     #[test]
     fn all_types_covered() {
-        assert_eq!(AgentType::ALL.len(), 3);
+        assert_eq!(AgentType::ALL.len(), 6);
+        assert!(AgentType::ALL.contains(&AgentType::Initializer));
+        assert!(AgentType::ALL.contains(&AgentType::Tester));
+        assert!(AgentType::ALL.contains(&AgentType::Qa));
+    }
+
+    #[test]
+    fn initializer_spec() {
+        let tools = AgentType::Initializer.allowed_tools();
+        assert_eq!(
+            tools,
+            &[
+                "file_read",
+                "file_write",
+                "list_dir",
+                "shell_exec",
+                "progress_append",
+            ],
+        );
+        assert_eq!(
+            AgentType::Initializer.sandbox_mode(),
+            SandboxMode::WorkspaceWrite,
+        );
+        let prompt = AgentType::Initializer.system_prompt();
+        assert!(!prompt.is_empty());
+        assert!(
+            prompt.contains("30") && prompt.contains("50"),
+            "initializer prompt must cite the 30-50 feature ceiling: {prompt}"
+        );
+        assert!(prompt.contains("features.json"));
+        assert!(prompt.contains("init.sh"));
+        assert!(prompt.contains("git commit"));
+    }
+
+    #[test]
+    fn tester_spec() {
+        let tools = AgentType::Tester.allowed_tools();
+        assert_eq!(tools, &["shell_exec", "file_read"]);
+        assert_eq!(
+            AgentType::Tester.sandbox_mode(),
+            SandboxMode::WorkspaceWrite,
+        );
+        let prompt = AgentType::Tester.system_prompt();
+        assert!(!prompt.is_empty());
+        assert!(
+            prompt.to_ascii_lowercase().contains("smoke"),
+            "tester prompt must describe smoke testing: {prompt}"
+        );
+        assert!(
+            prompt.to_ascii_lowercase().contains("browser"),
+            "tester prompt must mention browser MCP as a future addition: {prompt}"
+        );
+    }
+
+    #[test]
+    fn qa_spec() {
+        let tools = AgentType::Qa.allowed_tools();
+        assert_eq!(
+            tools,
+            &[
+                "feature_list_read",
+                "feature_list_mark_passing",
+                "file_read"
+            ],
+        );
+        assert_eq!(AgentType::Qa.sandbox_mode(), SandboxMode::ReadOnly);
+        let prompt = AgentType::Qa.system_prompt();
+        assert!(!prompt.is_empty());
+        assert!(
+            prompt.contains("feature_list_mark_passing"),
+            "qa prompt must explicitly mention feature_list_mark_passing: {prompt}"
+        );
+        assert!(
+            prompt.to_ascii_lowercase().contains("only"),
+            "qa prompt must emphasize that it is the ONLY subagent allowed to mark passing: {prompt}"
+        );
+    }
+
+    #[test]
+    fn descriptions_are_non_empty_for_all_types() {
+        for agent_type in AgentType::ALL {
+            assert!(
+                !agent_type.description().is_empty(),
+                "description for {agent_type} is empty",
+            );
+            assert!(
+                !agent_type.system_prompt().is_empty(),
+                "system_prompt for {agent_type} is empty",
+            );
+        }
+    }
+
+    #[test]
+    fn names_round_trip_for_all_types() {
+        for agent_type in AgentType::ALL {
+            let name = agent_type.name();
+            assert_eq!(
+                AgentType::from_name(name),
+                Some(*agent_type),
+                "round-trip failed for {name}",
+            );
+        }
     }
 
     #[test]
@@ -238,5 +492,15 @@ mod tests {
             .ok()
             .unwrap_or(AgentType::Explore);
         assert_eq!(parsed, AgentType::Worker);
+
+        let parsed: AgentType = serde_json::from_str("\"initializer\"")
+            .ok()
+            .unwrap_or(AgentType::Explore);
+        assert_eq!(parsed, AgentType::Initializer);
+
+        let parsed: AgentType = serde_json::from_str("\"qa\"")
+            .ok()
+            .unwrap_or(AgentType::Explore);
+        assert_eq!(parsed, AgentType::Qa);
     }
 }

--- a/crates/tmg-agents/src/lib.rs
+++ b/crates/tmg-agents/src/lib.rs
@@ -1,9 +1,9 @@
 //! tmg-agents: Subagent system for independent, parallel agent execution.
 //!
-//! Provides built-in subagent types (`explore`, `worker`, `plan`) and
-//! custom TOML-defined subagents that run with independent conversation
-//! contexts, restricted tool sets, and structured lifecycle management
-//! via [`tokio::task::JoinSet`].
+//! Provides built-in subagent types (`explore`, `worker`, `plan`,
+//! `initializer`, `tester`, `qa`) and custom TOML-defined subagents that
+//! run with independent conversation contexts, restricted tool sets, and
+//! structured lifecycle management via [`tokio::task::JoinSet`].
 
 pub mod builtins;
 pub mod config;
@@ -15,6 +15,10 @@ pub mod runner;
 pub mod status;
 pub mod tools;
 
+pub use builtins::{
+    RunToolProvider, registry_for_agent_kind, registry_for_agent_kind_with_run_provider,
+    registry_for_agent_type,
+};
 pub use config::{AgentKind, AgentType, SubagentConfig};
 pub use custom::{AgentSource, CustomAgentDef, CustomAgentMeta};
 pub use discovery::discover_custom_agents;

--- a/crates/tmg-agents/src/manager.rs
+++ b/crates/tmg-agents/src/manager.rs
@@ -14,7 +14,9 @@ use tokio_util::sync::CancellationToken;
 
 use tmg_llm::LlmClient;
 
-use crate::builtins::registry_for_agent_kind;
+use crate::builtins::{
+    RunToolProvider, registry_for_agent_kind, registry_for_agent_kind_with_run_provider,
+};
 use crate::config::{AgentKind, SubagentConfig};
 use crate::error::AgentError;
 use crate::runner::SubagentRunner;
@@ -86,6 +88,17 @@ pub struct SubagentManager {
 
     /// Counter for generating unique subagent IDs.
     next_id: u64,
+
+    /// Optional source of Run-aware tools (e.g. `progress_append`,
+    /// `feature_list_*`).
+    ///
+    /// When set, harnessed-run subagents (`Initializer`, `Tester`,
+    /// `Qa`) get a registry that includes the Run-aware tools they
+    /// declare in [`AgentType::allowed_tools`](crate::config::AgentType::allowed_tools).
+    /// When unset, those names are silently dropped — the subagent
+    /// runs without those tools, which is the intended degraded
+    /// behaviour for Run-less code paths.
+    run_tool_provider: Option<Arc<dyn RunToolProvider>>,
 }
 
 impl SubagentManager {
@@ -107,7 +120,24 @@ impl SubagentManager {
             join_set: JoinSet::new(),
             instances: Arc::new(Mutex::new(BTreeMap::new())),
             next_id: 1,
+            run_tool_provider: None,
         }
+    }
+
+    /// Install (or replace) the [`RunToolProvider`] used for spawning
+    /// subagents that need Run-aware tools.
+    ///
+    /// Pass `None` to clear a previously-installed provider (e.g. when
+    /// the active run is finalised). Subsequent spawns will skip
+    /// Run-aware tool names just as if no provider had ever been set.
+    pub fn set_run_tool_provider(&mut self, provider: Option<Arc<dyn RunToolProvider>>) {
+        self.run_tool_provider = provider;
+    }
+
+    /// Borrow the currently-installed [`RunToolProvider`], if any.
+    #[must_use]
+    pub fn run_tool_provider(&self) -> Option<&Arc<dyn RunToolProvider>> {
+        self.run_tool_provider.as_ref()
     }
 
     /// Spawn a subagent and return its ID immediately.
@@ -186,9 +216,18 @@ impl SubagentManager {
         let task = config.task.clone();
         let cancel = self.parent_cancel.child_token();
         let instances = Arc::clone(&self.instances);
+        let run_tool_provider = self.run_tool_provider.clone();
 
         self.join_set.spawn(async move {
-            let registry = registry_for_agent_kind(&agent_kind);
+            // Build the subagent's tool registry. With a
+            // `RunToolProvider` installed, harnessed agents get
+            // Run-aware tools (`progress_append`, `feature_list_*`)
+            // registered as well; without one, those names are
+            // silently dropped.
+            let registry = match &run_tool_provider {
+                Some(provider) => registry_for_agent_kind_with_run_provider(&agent_kind, provider),
+                None => registry_for_agent_kind(&agent_kind),
+            };
             let mut runner = SubagentRunner::new(client, registry, &agent_kind, cancel);
 
             let result = runner.run(&task).await;

--- a/crates/tmg-agents/src/manager.rs
+++ b/crates/tmg-agents/src/manager.rs
@@ -225,7 +225,9 @@ impl SubagentManager {
             // registered as well; without one, those names are
             // silently dropped.
             let registry = match &run_tool_provider {
-                Some(provider) => registry_for_agent_kind_with_run_provider(&agent_kind, provider),
+                Some(provider) => {
+                    registry_for_agent_kind_with_run_provider(&agent_kind, &**provider)
+                }
                 None => registry_for_agent_kind(&agent_kind),
             };
             let mut runner = SubagentRunner::new(client, registry, &agent_kind, cancel);

--- a/crates/tmg-agents/src/tools/spawn_agent.rs
+++ b/crates/tmg-agents/src/tools/spawn_agent.rs
@@ -2,7 +2,8 @@
 //!
 //! Parameters:
 //! - `agent_type` (string, required): one of the built-in types
-//!   (`"explore"`, `"worker"`, `"plan"`) or the name of a custom agent
+//!   (`"explore"`, `"worker"`, `"plan"`, `"initializer"`, `"tester"`,
+//!   `"qa"`) or the name of a custom agent
 //! - `task` (string, required): the task description for the subagent
 //! - `background` (boolean, optional, default: `false`): whether to run
 //!   in the background
@@ -102,7 +103,10 @@ impl Tool for SpawnAgentTool {
         "Spawn a subagent to perform a task. Built-in types: \
          'explore' (read-only codebase exploration), \
          'worker' (full tool access), \
-         'plan' (read-only planning). \
+         'plan' (read-only planning), \
+         'initializer' (project bootstrap: features.json/init.sh/progress.md + initial commit), \
+         'tester' (smoke-test runner via shell_exec), \
+         'qa' (read-only acceptance-criteria QA; only agent that can mark features passing). \
          Custom agents defined in .tsumugi/agents/ are also available. \
          Set background=true to run asynchronously."
     }

--- a/crates/tmg-harness/Cargo.toml
+++ b/crates/tmg-harness/Cargo.toml
@@ -16,6 +16,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Workspace crates
+tmg-agents = { workspace = true }
 tmg-core = { workspace = true }
 tmg-sandbox = { workspace = true }
 tmg-tools = { workspace = true }

--- a/crates/tmg-harness/src/lib.rs
+++ b/crates/tmg-harness/src/lib.rs
@@ -50,6 +50,6 @@ pub use store::{
 };
 pub use tools::{
     BootstrapPayload, FeatureListMarkPassingTool, FeatureListReadTool, InitScriptStatus,
-    ProgressAppendTool, SessionBootstrapTool, SessionSummarySaveTool, SmokeTestResult,
-    register_run_tools,
+    ProgressAppendTool, RunRunnerToolProvider, SessionBootstrapTool, SessionSummarySaveTool,
+    SmokeTestResult, register_run_tools,
 };

--- a/crates/tmg-harness/src/tools/mod.rs
+++ b/crates/tmg-harness/src/tools/mod.rs
@@ -25,6 +25,7 @@
 mod feature_list_mark_passing;
 mod feature_list_read;
 mod progress_append;
+mod run_tool_provider;
 mod session_bootstrap;
 mod session_summary_save;
 
@@ -36,6 +37,7 @@ use tokio::sync::Mutex;
 pub use feature_list_mark_passing::FeatureListMarkPassingTool;
 pub use feature_list_read::FeatureListReadTool;
 pub use progress_append::ProgressAppendTool;
+pub use run_tool_provider::RunRunnerToolProvider;
 pub use session_bootstrap::{
     BootstrapPayload, InitScriptStatus, SessionBootstrapTool, SmokeTestResult,
 };

--- a/crates/tmg-harness/src/tools/run_tool_provider.rs
+++ b/crates/tmg-harness/src/tools/run_tool_provider.rs
@@ -35,6 +35,25 @@ use crate::tools::{FeatureListMarkPassingTool, FeatureListReadTool, ProgressAppe
 /// runs. This mirrors the behaviour of
 /// [`crate::tools::register_run_tools`] so the main agent and any
 /// spawned subagents see the same scope-gated tool set.
+///
+/// # Invariants
+///
+/// [`RunScope`] is treated as **immutable** for the lifetime of this
+/// provider. The `is_harnessed` flag is sampled once at construction
+/// (in [`Self::new`] / [`Self::with_scope`]) and is never re-read from
+/// the underlying [`RunRunner`]. This is an intentional design choice:
+/// `register_run_tool` is synchronous and on the hot path, so it must
+/// avoid acquiring the runner's async lock.
+///
+/// As a consequence, **mutating `Run::scope` on a live provider would
+/// cause stale gating**: a subagent spawned after a runtime
+/// scope-promotion (ad-hoc → harnessed) would still see the registry
+/// shape from the original scope, and vice versa. In practice
+/// `RunScope` is set when the [`RunRunner`] is constructed and is not
+/// modified afterwards, so this restriction is observed by
+/// construction. If you ever need to support scope mutation, build a
+/// fresh `RunRunnerToolProvider` and re-install it via
+/// [`SubagentManager::set_run_tool_provider`](tmg_agents::SubagentManager::set_run_tool_provider).
 #[derive(Clone)]
 pub struct RunRunnerToolProvider {
     runner: Arc<Mutex<RunRunner>>,

--- a/crates/tmg-harness/src/tools/run_tool_provider.rs
+++ b/crates/tmg-harness/src/tools/run_tool_provider.rs
@@ -1,0 +1,183 @@
+//! Implementation of [`RunToolProvider`] backed by an
+//! `Arc<Mutex<RunRunner>>`.
+//!
+//! This is the wiring point that lets the `tmg-agents` crate stay
+//! independent of `tmg-harness`: the provider trait lives in
+//! `tmg-agents`, and `tmg-harness` supplies an implementation that
+//! constructs the Run-aware tools (`progress_append`,
+//! `feature_list_read`, `feature_list_mark_passing`) on demand from a
+//! shared `RunRunner` handle.
+//!
+//! The provider is scope-aware: `feature_list_*` tools are only
+//! registered when the active run is harnessed, mirroring the policy
+//! enforced by [`crate::tools::register_run_tools`].
+
+use std::sync::Arc;
+
+use tmg_agents::RunToolProvider;
+use tmg_tools::ToolRegistry;
+use tokio::sync::Mutex;
+
+use crate::run::RunScope;
+use crate::runner::RunRunner;
+use crate::tools::{FeatureListMarkPassingTool, FeatureListReadTool, ProgressAppendTool};
+
+/// `RunToolProvider` that constructs Run-aware tools from a shared
+/// `RunRunner` handle.
+///
+/// Cloning is cheap: only the `Arc` to the runner and the cached
+/// scope flag are stored.
+///
+/// **Scope policy:** the cached `is_harnessed` flag is captured at
+/// construction time. `progress_append` is registered for both ad-hoc
+/// and harnessed runs; `feature_list_read` and
+/// `feature_list_mark_passing` are registered **only** for harnessed
+/// runs. This mirrors the behaviour of
+/// [`crate::tools::register_run_tools`] so the main agent and any
+/// spawned subagents see the same scope-gated tool set.
+#[derive(Clone)]
+pub struct RunRunnerToolProvider {
+    runner: Arc<Mutex<RunRunner>>,
+    is_harnessed: bool,
+}
+
+impl RunRunnerToolProvider {
+    /// Construct a provider from a shared [`RunRunner`] handle.
+    ///
+    /// The harnessed/ad-hoc flag is captured eagerly so that
+    /// `register_run_tool` (which is synchronous) does not have to
+    /// acquire the runner lock on the hot path.
+    #[must_use]
+    pub async fn new(runner: Arc<Mutex<RunRunner>>) -> Self {
+        let is_harnessed = matches!(runner.lock().await.scope(), RunScope::Harnessed { .. });
+        Self {
+            runner,
+            is_harnessed,
+        }
+    }
+
+    /// Construct a provider with an explicit `is_harnessed` flag.
+    ///
+    /// Prefer [`Self::new`] in production code; this constructor is
+    /// useful in tests where the runner's scope is known at the call
+    /// site without paying for an async lock.
+    #[must_use]
+    pub fn with_scope(runner: Arc<Mutex<RunRunner>>, is_harnessed: bool) -> Self {
+        Self {
+            runner,
+            is_harnessed,
+        }
+    }
+
+    /// Whether this provider was constructed against a harnessed run.
+    #[must_use]
+    pub fn is_harnessed(&self) -> bool {
+        self.is_harnessed
+    }
+}
+
+impl RunToolProvider for RunRunnerToolProvider {
+    fn register_run_tool(&self, registry: &mut ToolRegistry, name: &str) -> bool {
+        match name {
+            "progress_append" => {
+                registry.register(ProgressAppendTool::new(Arc::clone(&self.runner)));
+                true
+            }
+            "feature_list_read" if self.is_harnessed => {
+                registry.register(FeatureListReadTool::new(Arc::clone(&self.runner)));
+                true
+            }
+            "feature_list_mark_passing" if self.is_harnessed => {
+                registry.register(FeatureListMarkPassingTool::new(Arc::clone(&self.runner)));
+                true
+            }
+            // Anything else (including the harnessed-only tools on an
+            // ad-hoc run) is intentionally not registered: a `false`
+            // return tells the caller to skip the name silently.
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use crate::run::RunScope;
+    use crate::store::RunStore;
+
+    fn make_runner_with_scope(scope: &RunScope) -> (tempfile::TempDir, Arc<Mutex<RunRunner>>) {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let store = Arc::new(RunStore::new(tmp.path().join("runs")));
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let mut run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        run.scope = scope.clone();
+        if let RunScope::Harnessed { workflow_id, .. } = scope {
+            run.workflow_id = Some(workflow_id.clone());
+        }
+        store.save(&run).unwrap_or_else(|e| panic!("{e}"));
+
+        let mut runner = RunRunner::new(run, store);
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        (tmp, Arc::new(Mutex::new(runner)))
+    }
+
+    /// On a harnessed run the provider registers all three Run-aware
+    /// tools when asked.
+    #[tokio::test]
+    async fn harnessed_provider_registers_all_run_aware_tools() {
+        let scope = RunScope::Harnessed {
+            workflow_id: "wf".to_owned(),
+            max_sessions: None,
+        };
+        let (_tmp, runner) = make_runner_with_scope(&scope);
+        let provider = RunRunnerToolProvider::new(runner).await;
+
+        let mut registry = ToolRegistry::new();
+        assert!(provider.register_run_tool(&mut registry, "progress_append"));
+        assert!(provider.register_run_tool(&mut registry, "feature_list_read"));
+        assert!(provider.register_run_tool(&mut registry, "feature_list_mark_passing"));
+
+        assert!(registry.get("progress_append").is_some());
+        assert!(registry.get("feature_list_read").is_some());
+        assert!(registry.get("feature_list_mark_passing").is_some());
+    }
+
+    /// On an ad-hoc run the provider refuses to register
+    /// `feature_list_*` tools (returns `false`) but still registers
+    /// `progress_append`. This mirrors the policy enforced by
+    /// [`crate::tools::register_run_tools`].
+    #[tokio::test]
+    async fn ad_hoc_provider_skips_feature_list_tools() {
+        let (_tmp, runner) = make_runner_with_scope(&RunScope::AdHoc);
+        let provider = RunRunnerToolProvider::new(runner).await;
+
+        let mut registry = ToolRegistry::new();
+        assert!(provider.register_run_tool(&mut registry, "progress_append"));
+        assert!(!provider.register_run_tool(&mut registry, "feature_list_read"));
+        assert!(!provider.register_run_tool(&mut registry, "feature_list_mark_passing"));
+
+        assert!(registry.get("progress_append").is_some());
+        assert!(registry.get("feature_list_read").is_none());
+        assert!(registry.get("feature_list_mark_passing").is_none());
+    }
+
+    /// Unknown names always return `false`.
+    #[tokio::test]
+    async fn unknown_name_returns_false() {
+        let scope = RunScope::Harnessed {
+            workflow_id: "wf".to_owned(),
+            max_sessions: None,
+        };
+        let (_tmp, runner) = make_runner_with_scope(&scope);
+        let provider = RunRunnerToolProvider::new(runner).await;
+
+        let mut registry = ToolRegistry::new();
+        assert!(!provider.register_run_tool(&mut registry, "file_read"));
+        assert!(!provider.register_run_tool(&mut registry, "totally_unknown"));
+        assert_eq!(registry.tool_names().count(), 0);
+    }
+}

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use clap::Parser;
 use tmg_harness::{
-    RunRunner, RunStore, RunSummary, SessionBootstrapTool, SessionEndTrigger, register_run_tools,
+    RunRunner, RunRunnerToolProvider, RunStore, RunSummary, SessionBootstrapTool,
+    SessionEndTrigger, register_run_tools,
 };
 use tmg_llm::ToolCallingMode;
 use tokio::sync::Mutex;
@@ -304,6 +305,19 @@ fn run_tui(
             endpoint,
             model,
         )));
+
+        // Wire the active `RunRunner` into the subagent manager so
+        // harnessed-run subagents (initializer / tester / qa) get
+        // their Run-aware tools (`progress_append`, `feature_list_*`)
+        // registered when they spawn. The provider's scope flag
+        // mirrors `register_run_tools` so the main agent and any
+        // subagent see the same scope-gated tool set.
+        let run_tool_provider: Arc<dyn tmg_agents::RunToolProvider> =
+            Arc::new(RunRunnerToolProvider::new(Arc::clone(&runner)).await);
+        subagent_manager
+            .lock()
+            .await
+            .set_run_tool_provider(Some(Arc::clone(&run_tool_provider)));
 
         // Create the tool registry: built-ins, then spawn_agent, then
         // the Run-scoped harness tools. `register_run_tools` is the


### PR DESCRIPTION
## Summary

Closes #35.

- Adds three harnessed-run builtin subagents per SPEC §5.2:
  - **`initializer`** — `WorkspaceWrite`; allowed: `file_read`, `file_write`, `list_dir`, `shell_exec`, `progress_append`. Bootstraps a project (features.json with 30-50 entry cap, init.sh, progress.md, initial git commit).
  - **`tester`** — `WorkspaceWrite`; allowed: `shell_exec`, `file_read`. Smoke-tests via shell commands; browser MCP noted as future work.
  - **`qa`** — `ReadOnly`; allowed: `feature_list_read`, `feature_list_mark_passing`, `file_read`. **Only** subagent permitted to flip `passes`.
- `AgentType::ALL.len()` now `6`; existing `/agents` slash command picks them up automatically through `AgentType::ALL`.
- New `RunToolProvider` trait in `tmg-agents` (the small-scope refactor option from the issue) lets a Run-aware tool source be plugged into `SubagentManager` without `tmg-agents` depending on `tmg-harness`. `tmg-harness` ships `RunRunnerToolProvider`; the CLI installs it on the manager after creating the run. When no provider is set (e.g. `--prompt` one-shots), Run-aware tool names are silently dropped from the subagent's filtered registry.
- Permission invariant is enforced by registry construction: only the QA subagent's registry contains `feature_list_mark_passing`; for `Initializer` / `Tester` / `Worker` / `Explore` / `Plan` the tool is absent. `Tool::execute` does not need a per-agent permission check — registration absence is sufficient.

## Crates touched

- `crates/tmg-agents` — `AgentType` extension; `RunToolProvider` trait + `registry_for_agent_kind_with_run_provider`; `SubagentManager::set_run_tool_provider`; `spawn_agent` description updated.
- `crates/tmg-harness` — depends on `tmg-agents`; new `RunRunnerToolProvider` implementing `RunToolProvider` over `Arc<Mutex<RunRunner>>`, scope-gated to mirror `register_run_tools`.
- `tmg-cli/src/main.rs` — wires `RunRunnerToolProvider` into the `SubagentManager` after creating the run.

## Tests

- `AgentType::ALL.len() == 6`; names round-trip; `descriptions_are_non_empty_for_all_types`.
- Per-variant: `initializer_spec` (30/50 ceiling cited; mentions `features.json` / `init.sh` / `git commit`), `tester_spec` (mentions smoke + browser MCP), `qa_spec` (mentions `feature_list_mark_passing` and the "only" emphasis).
- `only_qa_can_call_feature_list_mark_passing` — registry contains the tool for QA, absent for the other five subagents.
- `harnessed_agents_without_provider_skip_run_aware_tools` — no provider = silent drop.
- `provider_only_consulted_for_run_aware_names` — stateless tool names never hit the provider.
- `RunRunnerToolProvider` tests cover both ad-hoc (skips `feature_list_*`) and harnessed (registers all three) scopes plus unknown-name handling.

## Quality gates

- `cargo build --workspace` — passes
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` — passes
- `cargo fmt --all -- --check` — passes
- `cargo test --workspace` — all pass (including new tests above)
- `cargo deny check` — n/a (no new external deps; only an internal `tmg-agents` workspace dep added to `tmg-harness`)

## Test plan

- [x] Build + clippy + fmt + test all green on the worktree
- [x] One-shot mode smoke-tested with `--prompt`; event log shows tokens + clean `done`, no `is_error: true`
- [x] TUI launches and exits cleanly; `/agents` listing iterates `AgentType::ALL`, so the three new variants appear automatically once a real session is run

### Runtime Verification

- LLM server: available
- One-shot mode: PASS — `tmg --prompt "Reply with just OK"` produced a clean response, event log captured 91 events ending in `{"type":"done"}`, no errors.
- TUI mode: PASS (clean startup/exit; event log was empty because the test session was Ctrl+C'd before the LLM round-trip completed). The `/agents` rendering path is exercised by the unit tests via `AgentType::ALL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)