### PR TITLE
Add escalator subagent and per-agent endpoint overrides (#36)

### DIFF
--- a/crates/tmg-agents/src/config.rs
+++ b/crates/tmg-agents/src/config.rs
@@ -70,6 +70,21 @@ pub enum AgentType {
     /// Allowed tools: `feature_list_read`, `feature_list_mark_passing`,
     /// `file_read`.
     Qa,
+
+    /// Scope-escalation evaluator (SPEC §5.2 / §9.3).
+    ///
+    /// Read-only judge that decides whether the current task should be
+    /// promoted from an ad-hoc run to a fully harnessed run. Receives a
+    /// snapshot of the user request plus a brief workspace recon and
+    /// returns a strict JSON verdict
+    /// (`{ "escalate": bool, "reason": string, "estimated_features": int? }`).
+    ///
+    /// Allowed tools: `file_read`, `list_dir`. The escalator never
+    /// mutates the workspace and is intended to run on a lightweight,
+    /// dedicated endpoint (configurable via `[harness.escalator]`) so
+    /// the cost of the gating decision stays small relative to the run
+    /// itself; see [`crate::escalator`] for the verdict parser.
+    Escalator,
 }
 
 impl AgentType {
@@ -81,6 +96,7 @@ impl AgentType {
         Self::Initializer,
         Self::Tester,
         Self::Qa,
+        Self::Escalator,
     ];
 
     /// Return the tool names allowed for this agent type.
@@ -116,6 +132,7 @@ impl AgentType {
                 "feature_list_mark_passing",
                 "file_read",
             ],
+            Self::Escalator => &["file_read", "list_dir"],
         }
     }
 
@@ -133,6 +150,8 @@ impl AgentType {
     ///   `feature_list_mark_passing`.
     /// - `Explore` / `Plan`: [`SandboxMode::ReadOnly`].
     /// - `Worker`: [`SandboxMode::WorkspaceWrite`].
+    /// - `Escalator`: [`SandboxMode::ReadOnly`] — the escalator only
+    ///   inspects the workspace to estimate scope and never mutates it.
     ///
     /// # Advisory only
     ///
@@ -147,12 +166,16 @@ impl AgentType {
     #[must_use]
     pub fn sandbox_mode(&self) -> SandboxMode {
         match self {
-            Self::Explore | Self::Plan | Self::Qa => SandboxMode::ReadOnly,
+            Self::Explore | Self::Plan | Self::Qa | Self::Escalator => SandboxMode::ReadOnly,
             Self::Worker | Self::Initializer | Self::Tester => SandboxMode::WorkspaceWrite,
         }
     }
 
     /// Return the system prompt for this agent type.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "linear per-variant prompt match; splitting would scatter SPEC text across helpers"
+    )]
     pub fn system_prompt(&self) -> &'static str {
         match self {
             Self::Explore => {
@@ -219,6 +242,47 @@ impl AgentType {
                  modify any source file. Report the set of features marked \
                  passing and any features you explicitly chose not to mark."
             }
+            Self::Escalator => {
+                "You are the escalator subagent (SPEC §5.2 / §9.3). Your single \
+                 responsibility is to decide whether the user's current request \
+                 should be promoted from an ad-hoc run to a fully harnessed run. \
+                 You have read-only access to the workspace via `file_read` and \
+                 `list_dir`; do not attempt any other action. \
+                 \
+                 Evaluate the request against this rubric: \
+                 (1) breadth -- does it span multiple subsystems, modules, or \
+                 several distinct features? \
+                 (2) duration -- will it plausibly require multiple sessions \
+                 (more than a single sitting) to complete? \
+                 (3) verification surface -- does it need a stable acceptance \
+                 list (features.json) and recurring smoke tests, or is a \
+                 single-shot fix enough? \
+                 \
+                 If at least two of those signals point to harnessed scope, \
+                 escalate. Otherwise, decline. Be conservative: when in doubt, \
+                 do NOT escalate -- harnessed runs are expensive and the user \
+                 can always re-issue the request with explicit harnessing. \
+                 \
+                 You MUST output a single JSON object and nothing else. The \
+                 schema is strict: \
+                 \
+                 { \"escalate\": <bool>, \"reason\": <string>, \
+                 \"estimated_features\": <int> } \
+                 \
+                 Rules: \
+                 - `escalate` is required and must be `true` or `false`. \
+                 - `reason` is required and must be a concise one- or two- \
+                   sentence justification (no markdown, no newlines inside). \
+                 - `estimated_features` is OPTIONAL. Include it only when \
+                   `escalate` is `true` and you can give a defensible \
+                   integer estimate of how many entries `features.json` will \
+                   eventually need (target 30-50 per the initializer spec). \
+                   If you cannot estimate, OMIT the field entirely -- do not \
+                   send `null`, `0`, or a string. \
+                 - Output JSON only. No prose before or after, no code fences, \
+                   no comments, no extra fields. The harness rejects any \
+                   response that does not parse as exactly this schema."
+            }
         }
     }
 
@@ -235,6 +299,9 @@ impl AgentType {
             Self::Qa => {
                 "Acceptance-criteria QA (read-only; only agent that can mark features passing)"
             }
+            Self::Escalator => {
+                "Scope-escalation evaluator (read-only; emits strict JSON verdict for harnessing)"
+            }
         }
     }
 
@@ -247,6 +314,7 @@ impl AgentType {
             Self::Initializer => "initializer",
             Self::Tester => "tester",
             Self::Qa => "qa",
+            Self::Escalator => "escalator",
         }
     }
 
@@ -349,6 +417,10 @@ mod tests {
         );
         assert_eq!(AgentType::from_name("tester"), Some(AgentType::Tester));
         assert_eq!(AgentType::from_name("qa"), Some(AgentType::Qa));
+        assert_eq!(
+            AgentType::from_name("escalator"),
+            Some(AgentType::Escalator)
+        );
         assert_eq!(AgentType::from_name("unknown"), None);
     }
 
@@ -360,6 +432,7 @@ mod tests {
         assert_eq!(AgentType::Initializer.to_string(), "initializer");
         assert_eq!(AgentType::Tester.to_string(), "tester");
         assert_eq!(AgentType::Qa.to_string(), "qa");
+        assert_eq!(AgentType::Escalator.to_string(), "escalator");
     }
 
     #[test]
@@ -390,10 +463,32 @@ mod tests {
 
     #[test]
     fn all_types_covered() {
-        assert_eq!(AgentType::ALL.len(), 6);
+        assert_eq!(AgentType::ALL.len(), 7);
         assert!(AgentType::ALL.contains(&AgentType::Initializer));
         assert!(AgentType::ALL.contains(&AgentType::Tester));
         assert!(AgentType::ALL.contains(&AgentType::Qa));
+        assert!(AgentType::ALL.contains(&AgentType::Escalator));
+    }
+
+    #[test]
+    fn escalator_spec() {
+        let tools = AgentType::Escalator.allowed_tools();
+        assert_eq!(tools, &["file_read", "list_dir"]);
+        assert_eq!(AgentType::Escalator.sandbox_mode(), SandboxMode::ReadOnly);
+        let prompt = AgentType::Escalator.system_prompt();
+        assert!(!prompt.is_empty());
+        assert!(
+            prompt.contains("escalate"),
+            "escalator prompt must mention the escalate verdict field: {prompt}"
+        );
+        assert!(
+            prompt.contains("estimated_features"),
+            "escalator prompt must describe the optional estimated_features field: {prompt}"
+        );
+        assert!(
+            prompt.contains("JSON"),
+            "escalator prompt must call out strict JSON output: {prompt}"
+        );
     }
 
     #[test]
@@ -513,5 +608,10 @@ mod tests {
             .ok()
             .unwrap_or(AgentType::Explore);
         assert_eq!(parsed, AgentType::Qa);
+
+        let parsed: AgentType = serde_json::from_str("\"escalator\"")
+            .ok()
+            .unwrap_or(AgentType::Explore);
+        assert_eq!(parsed, AgentType::Escalator);
     }
 }

--- a/crates/tmg-agents/src/config.rs
+++ b/crates/tmg-agents/src/config.rs
@@ -326,6 +326,31 @@ impl AgentType {
         let quoted = format!("\"{name}\"");
         serde_json::from_str(&quoted).ok()
     }
+
+    /// Whether this agent type may be spawned directly by the LLM via
+    /// the `spawn_agent` tool.
+    ///
+    /// Returns `false` for agents whose lifecycle is owned by the
+    /// harness rather than the model. Currently the only such agent is
+    /// [`AgentType::Escalator`]: the escalator is invoked by the
+    /// harness during scope evaluation and must never be reachable from
+    /// an LLM `spawn_agent` call, otherwise the model could trigger
+    /// recursive escalation decisions or bypass the harness gating.
+    ///
+    /// Used by `spawn_agent` to filter [`AgentType::ALL`] when building
+    /// the JSON-Schema `enum` and the human-readable error list.
+    #[must_use]
+    pub fn is_user_spawnable(&self) -> bool {
+        match self {
+            Self::Explore
+            | Self::Worker
+            | Self::Plan
+            | Self::Initializer
+            | Self::Tester
+            | Self::Qa => true,
+            Self::Escalator => false,
+        }
+    }
 }
 
 impl std::fmt::Display for AgentType {
@@ -338,7 +363,7 @@ impl std::fmt::Display for AgentType {
 /// agent.
 #[derive(Debug, Clone)]
 pub enum AgentKind {
-    /// A built-in agent type (explore, worker, plan, initializer, tester, qa).
+    /// A built-in agent type (explore, worker, plan, initializer, tester, qa, escalator).
     Builtin(AgentType),
 
     /// A custom agent loaded from a TOML definition file.

--- a/crates/tmg-agents/src/error.rs
+++ b/crates/tmg-agents/src/error.rs
@@ -22,6 +22,13 @@ pub enum AgentError {
     #[error("subagent nesting is not allowed: spawn_agent cannot be called from a subagent")]
     NestingForbidden,
 
+    /// The escalator subagent was requested but disabled by operator
+    /// configuration (`[harness.escalator] disable = true`, SPEC §9.10).
+    /// The auto-promotion gate (issue #37) treats this as "do not
+    /// escalate" rather than as a hard error.
+    #[error("escalator disabled")]
+    EscalatorDisabled,
+
     /// The subagent was cancelled via `CancellationToken`.
     #[error("subagent cancelled")]
     Cancelled,

--- a/crates/tmg-agents/src/escalator.rs
+++ b/crates/tmg-agents/src/escalator.rs
@@ -13,9 +13,10 @@
 //! ```
 //!
 //! `estimated_features` is OPTIONAL and is only meaningful when
-//! `escalate` is `true`; emitting it as `null`, `0`, or a string is
-//! rejected so that downstream automation does not have to guess what
-//! the model meant.
+//! `escalate` is `true`; emitting it as `null`, `0`, a float, or a
+//! string is rejected so that downstream automation does not have to
+//! guess what the model meant. If there are no features to estimate,
+//! emit `escalate: false` and omit the field entirely.
 //!
 //! [`parse_verdict`] is the only sanctioned entry point for accepting
 //! escalator output. It uses `#[serde(deny_unknown_fields)]` and an
@@ -23,19 +24,24 @@
 //! surfaced loudly rather than silently routed to the wrong control
 //! flow.
 
-use serde::de::Deserializer;
+use serde::de::{Deserializer, Error as DeError, Unexpected};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// Deserialize `estimated_features` as a strict non-negative integer
-/// when present, rejecting explicit `null` (the system prompt forbids
-/// it -- see [`crate::config::AgentType::Escalator::system_prompt`]).
+/// Deserialize `estimated_features` as a strict positive integer when
+/// present, rejecting explicit `null`, `0`, floats, and strings (the
+/// system prompt forbids those -- see
+/// [`crate::config::AgentType::Escalator::system_prompt`]).
 ///
 /// Used in combination with `#[serde(default)]` on the field so that
 /// "field omitted" still maps to `None`. Without this helper, serde's
 /// default `Option<u32>` adapter would silently accept `null` and
 /// `None` interchangeably, masking model bugs that emit `null`
 /// instead of omitting the key entirely.
+///
+/// `0` is rejected explicitly: a zero estimate is meaningless for the
+/// escalator's purpose. If there are no features to estimate, the
+/// model should emit `escalate: false` and omit the field.
 fn deserialize_estimated_features<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
 where
     D: Deserializer<'de>,
@@ -43,7 +49,15 @@ where
     // Deserialize as a plain `u32`. If serde encounters `null` it will
     // raise an `invalid type: null` error, which is exactly what we
     // want -- it gets surfaced as `ParseError::Json` to the caller.
+    // Floats (e.g. `3.0`, `3.5`) are rejected by `u32` deserialization
+    // because `serde_json` keeps `f64` and `u64` as distinct types.
     let value = u32::deserialize(deserializer)?;
+    if value == 0 {
+        return Err(D::Error::invalid_value(
+            Unexpected::Unsigned(0),
+            &"a positive integer (omit the field instead of sending 0)",
+        ));
+    }
     Ok(Some(value))
 }
 
@@ -112,8 +126,9 @@ pub enum ParseError {
 /// Strict rules:
 ///
 /// - Required fields: `escalate` (bool) and `reason` (string).
-/// - Optional field: `estimated_features` (non-negative integer, fits
-///   in `u32`).
+/// - Optional field: `estimated_features` (strictly positive integer
+///   that fits in `u32`; `0`, floats, strings, and `null` are
+///   rejected — omit the field instead).
 /// - Unknown fields are rejected by `#[serde(deny_unknown_fields)]`.
 /// - Trailing non-whitespace input is rejected via [`ParseError::TrailingInput`].
 ///
@@ -129,23 +144,26 @@ pub fn parse_verdict(json: &str) -> Result<EscalatorVerdict, ParseError> {
     // "reason":"x"} garbage` because the default parser stops at the
     // closing brace.
     let mut stream = serde_json::Deserializer::from_str(json).into_iter::<EscalatorVerdict>();
-    let verdict = stream.next().ok_or_else(|| {
-        // Synthesize a Json error so the caller does not need to
-        // distinguish "empty input" from "malformed JSON" — both
-        // are genuine parse failures.
-        let synthetic = serde_json::from_str::<EscalatorVerdict>("")
-            .err()
-            .unwrap_or_else(|| {
-                // serde_json should always fail on empty input;
-                // keep a defensive fallback so the helper stays
-                // total.
-                serde_json::Error::io(std::io::Error::new(
-                    std::io::ErrorKind::UnexpectedEof,
-                    "empty escalator verdict",
-                ))
-            });
-        ParseError::Json(synthetic)
-    })??;
+    let verdict = match stream.next() {
+        Some(item) => item?,
+        None => {
+            // The streaming iterator yields `None` only when the input
+            // contains no JSON value at all (empty or whitespace-only).
+            // Re-run the parser on the original input so the caller
+            // sees a normal `serde_json::Error`. The work is bounded
+            // by the size of the (already-empty) slice, so this is
+            // both faster and clearer than fabricating an error by
+            // hand. `serde_json` is contractually required to fail on
+            // whitespace-only input; if it ever returned `Ok` here the
+            // streaming iterator would have yielded a value, so the
+            // `Ok` branch below short-circuits to `Ok(verdict)` and
+            // keeps the function total without an `unwrap`/`expect`.
+            return match serde_json::from_str::<EscalatorVerdict>(json) {
+                Ok(v) => Ok(v),
+                Err(e) => Err(ParseError::Json(e)),
+            };
+        }
+    };
 
     let consumed = stream.byte_offset();
     let remainder = json[consumed..].trim_start();
@@ -258,6 +276,51 @@ mod tests {
         }"#;
         let err = parse_verdict(json).expect_err("string estimate must fail");
         assert!(matches!(err, ParseError::Json(_)));
+    }
+
+    #[test]
+    fn rejects_estimated_features_as_zero() {
+        // A `0` estimate is meaningless for the escalator's purpose.
+        // Per the schema docs, when there is nothing to estimate the
+        // model must emit `escalate: false` and omit the field.
+        let json = r#"{
+            "escalate": true,
+            "reason": "no real features",
+            "estimated_features": 0
+        }"#;
+        let err = parse_verdict(json).expect_err("zero estimate must fail");
+        assert!(
+            matches!(err, ParseError::Json(_)),
+            "expected ParseError::Json, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_estimated_features_as_float() {
+        // Both clearly-fractional (3.5) and "would-fool-a-permissive-parser"
+        // (3.0) cases must fail. `serde_json` keeps `f64` and `u64` as
+        // distinct numeric types, so `u32::deserialize` rejects both.
+        let fractional = r#"{
+            "escalate": true,
+            "reason": "ok",
+            "estimated_features": 3.5
+        }"#;
+        let err = parse_verdict(fractional).expect_err("3.5 must fail");
+        assert!(
+            matches!(err, ParseError::Json(_)),
+            "fractional float must produce ParseError::Json, got {err:?}"
+        );
+
+        let whole = r#"{
+            "escalate": true,
+            "reason": "ok",
+            "estimated_features": 3.0
+        }"#;
+        let err = parse_verdict(whole).expect_err("3.0 must fail");
+        assert!(
+            matches!(err, ParseError::Json(_)),
+            "whole-number float must produce ParseError::Json, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/tmg-agents/src/escalator.rs
+++ b/crates/tmg-agents/src/escalator.rs
@@ -1,0 +1,307 @@
+//! Escalator subagent verdict types and JSON parsing.
+//!
+//! The escalator subagent (SPEC §5.2 / §9.3) produces a strict JSON
+//! verdict that decides whether the current task should be promoted
+//! from an ad-hoc run to a fully harnessed run. Its output schema is
+//!
+//! ```json
+//! {
+//!   "escalate": true,
+//!   "reason": "spans tmg-llm and tmg-tui; needs features.json",
+//!   "estimated_features": 36
+//! }
+//! ```
+//!
+//! `estimated_features` is OPTIONAL and is only meaningful when
+//! `escalate` is `true`; emitting it as `null`, `0`, or a string is
+//! rejected so that downstream automation does not have to guess what
+//! the model meant.
+//!
+//! [`parse_verdict`] is the only sanctioned entry point for accepting
+//! escalator output. It uses `#[serde(deny_unknown_fields)]` and an
+//! explicit "no trailing input" check so a malformed model response is
+//! surfaced loudly rather than silently routed to the wrong control
+//! flow.
+
+use serde::de::Deserializer;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Deserialize `estimated_features` as a strict non-negative integer
+/// when present, rejecting explicit `null` (the system prompt forbids
+/// it -- see [`crate::config::AgentType::Escalator::system_prompt`]).
+///
+/// Used in combination with `#[serde(default)]` on the field so that
+/// "field omitted" still maps to `None`. Without this helper, serde's
+/// default `Option<u32>` adapter would silently accept `null` and
+/// `None` interchangeably, masking model bugs that emit `null`
+/// instead of omitting the key entirely.
+fn deserialize_estimated_features<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Deserialize as a plain `u32`. If serde encounters `null` it will
+    // raise an `invalid type: null` error, which is exactly what we
+    // want -- it gets surfaced as `ParseError::Json` to the caller.
+    let value = u32::deserialize(deserializer)?;
+    Ok(Some(value))
+}
+
+/// Strict verdict emitted by the escalator subagent.
+///
+/// Constructed exclusively via [`parse_verdict`]; the struct itself is
+/// `pub` so downstream automation can inspect the fields, but the
+/// public constructor surface goes through the parser to keep the
+/// validation rules in one place.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EscalatorVerdict {
+    /// `true` when the escalator recommends promoting the request to a
+    /// harnessed run; `false` to keep the ad-hoc scope.
+    pub escalate: bool,
+
+    /// Concise human-readable justification (one or two sentences,
+    /// no newlines) explaining the decision.
+    pub reason: String,
+
+    /// Optional integer estimate of how many entries `features.json`
+    /// will eventually need (target 30-50 per the initializer spec).
+    ///
+    /// Omitted entirely when the escalator cannot estimate or when
+    /// `escalate` is `false`. Encoded as `Option<u32>` and skipped on
+    /// serialization so the round-trip preserves the "field omitted"
+    /// vs. "field present with zero" distinction the schema requires.
+    ///
+    /// `deserialize_with` rejects explicit `null`; only "field
+    /// omitted" maps to `None`. Strings, floats, and negative numbers
+    /// are also rejected.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_estimated_features"
+    )]
+    pub estimated_features: Option<u32>,
+}
+
+/// Errors produced when parsing an escalator response.
+///
+/// Distinct variants make it easier for callers (and tests) to assert
+/// on the failure mode without string-matching.
+#[derive(Debug, Error)]
+pub enum ParseError {
+    /// The input was not valid JSON, was missing a required field, or
+    /// contained an unknown / mistyped field. Wraps the underlying
+    /// `serde_json` error for diagnostics.
+    #[error("invalid escalator verdict JSON: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The JSON parsed cleanly but extra non-whitespace input followed
+    /// the verdict object. The escalator system prompt forbids this
+    /// (no prose, no code fences, no trailing text), and silently
+    /// dropping the trailing bytes risks masking a malformed response.
+    #[error("trailing input after escalator verdict: {trailing:?}")]
+    TrailingInput {
+        /// The bytes that followed the parsed JSON object, lossily
+        /// converted to a UTF-8 string for error display.
+        trailing: String,
+    },
+}
+
+/// Parse a JSON string into an [`EscalatorVerdict`].
+///
+/// Strict rules:
+///
+/// - Required fields: `escalate` (bool) and `reason` (string).
+/// - Optional field: `estimated_features` (non-negative integer, fits
+///   in `u32`).
+/// - Unknown fields are rejected by `#[serde(deny_unknown_fields)]`.
+/// - Trailing non-whitespace input is rejected via [`ParseError::TrailingInput`].
+///
+/// # Errors
+///
+/// Returns [`ParseError::Json`] for malformed input or schema
+/// violations, and [`ParseError::TrailingInput`] when valid JSON is
+/// followed by extra content.
+pub fn parse_verdict(json: &str) -> Result<EscalatorVerdict, ParseError> {
+    // Use a streaming deserializer so we can detect trailing
+    // non-whitespace input without re-scanning the source. Calling
+    // `serde_json::from_str` would silently accept `{"escalate":true,
+    // "reason":"x"} garbage` because the default parser stops at the
+    // closing brace.
+    let mut stream = serde_json::Deserializer::from_str(json).into_iter::<EscalatorVerdict>();
+    let verdict = stream.next().ok_or_else(|| {
+        // Synthesize a Json error so the caller does not need to
+        // distinguish "empty input" from "malformed JSON" — both
+        // are genuine parse failures.
+        let synthetic = serde_json::from_str::<EscalatorVerdict>("")
+            .err()
+            .unwrap_or_else(|| {
+                // serde_json should always fail on empty input;
+                // keep a defensive fallback so the helper stays
+                // total.
+                serde_json::Error::io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "empty escalator verdict",
+                ))
+            });
+        ParseError::Json(synthetic)
+    })??;
+
+    let consumed = stream.byte_offset();
+    let remainder = json[consumed..].trim_start();
+    if !remainder.is_empty() {
+        return Err(ParseError::TrailingInput {
+            trailing: remainder.to_owned(),
+        });
+    }
+
+    Ok(verdict)
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions")]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_escalate_true_with_features() {
+        let json = r#"{
+            "escalate": true,
+            "reason": "spans tmg-llm and tmg-tui; needs features.json",
+            "estimated_features": 36
+        }"#;
+        let v = parse_verdict(json).unwrap_or_else(|e| panic!("{e}"));
+        assert!(v.escalate);
+        assert_eq!(v.reason, "spans tmg-llm and tmg-tui; needs features.json");
+        assert_eq!(v.estimated_features, Some(36));
+    }
+
+    #[test]
+    fn parses_escalate_false_without_features() {
+        let json = r#"{
+            "escalate": false,
+            "reason": "single-file fix; no features needed"
+        }"#;
+        let v = parse_verdict(json).unwrap_or_else(|e| panic!("{e}"));
+        assert!(!v.escalate);
+        assert_eq!(v.reason, "single-file fix; no features needed");
+        assert_eq!(v.estimated_features, None);
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let json = r#"{ "escalate": true, "reason": "missing brace" "#;
+        let err = parse_verdict(json).expect_err("malformed JSON must fail");
+        assert!(
+            matches!(err, ParseError::Json(_)),
+            "expected ParseError::Json, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        // SPEC §9.3 -- the schema is closed.
+        let json = r#"{
+            "escalate": true,
+            "reason": "ok",
+            "estimated_features": 5,
+            "confidence": 0.9
+        }"#;
+        let err = parse_verdict(json).expect_err("unknown field must fail");
+        assert!(
+            matches!(err, ParseError::Json(_)),
+            "expected ParseError::Json, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("confidence") || msg.contains("unknown field"),
+            "error must identify the unknown field; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_required_field_escalate() {
+        let json = r#"{ "reason": "no escalate key" }"#;
+        let err = parse_verdict(json).expect_err("missing escalate must fail");
+        assert!(matches!(err, ParseError::Json(_)));
+    }
+
+    #[test]
+    fn rejects_missing_required_field_reason() {
+        let json = r#"{ "escalate": true }"#;
+        let err = parse_verdict(json).expect_err("missing reason must fail");
+        assert!(matches!(err, ParseError::Json(_)));
+    }
+
+    #[test]
+    fn rejects_estimated_features_as_null() {
+        // The system prompt forbids `null`; we want a parse failure
+        // rather than silently treating null as "omitted", since that
+        // would let a sloppy model send `{"estimated_features": null}`
+        // in place of an actual estimate.
+        let json = r#"{
+            "escalate": true,
+            "reason": "ok",
+            "estimated_features": null
+        }"#;
+        let err = parse_verdict(json).expect_err("null estimate must fail");
+        assert!(matches!(err, ParseError::Json(_)));
+    }
+
+    #[test]
+    fn rejects_estimated_features_as_string() {
+        let json = r#"{
+            "escalate": true,
+            "reason": "ok",
+            "estimated_features": "many"
+        }"#;
+        let err = parse_verdict(json).expect_err("string estimate must fail");
+        assert!(matches!(err, ParseError::Json(_)));
+    }
+
+    #[test]
+    fn rejects_trailing_input() {
+        let json = r#"{ "escalate": false, "reason": "x" } trailing prose"#;
+        let err = parse_verdict(json).expect_err("trailing input must fail");
+        assert!(
+            matches!(err, ParseError::TrailingInput { .. }),
+            "expected ParseError::TrailingInput, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        let err = parse_verdict("").expect_err("empty input must fail");
+        assert!(matches!(err, ParseError::Json(_)));
+    }
+
+    #[test]
+    fn round_trip_omits_estimated_features_when_none() {
+        let v = EscalatorVerdict {
+            escalate: false,
+            reason: "no need".to_owned(),
+            estimated_features: None,
+        };
+        let s = serde_json::to_string(&v).unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            !s.contains("estimated_features"),
+            "field must be skipped when None, got: {s}"
+        );
+        let parsed = parse_verdict(&s).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(parsed, v);
+    }
+
+    #[test]
+    fn round_trip_includes_estimated_features_when_some() {
+        let v = EscalatorVerdict {
+            escalate: true,
+            reason: "spans crates".to_owned(),
+            estimated_features: Some(42),
+        };
+        let s = serde_json::to_string(&v).unwrap_or_else(|e| panic!("{e}"));
+        assert!(s.contains("\"estimated_features\":42"));
+        let parsed = parse_verdict(&s).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(parsed, v);
+    }
+}

--- a/crates/tmg-agents/src/lib.rs
+++ b/crates/tmg-agents/src/lib.rs
@@ -1,15 +1,17 @@
 //! tmg-agents: Subagent system for independent, parallel agent execution.
 //!
 //! Provides built-in subagent types (`explore`, `worker`, `plan`,
-//! `initializer`, `tester`, `qa`) and custom TOML-defined subagents that
-//! run with independent conversation contexts, restricted tool sets, and
-//! structured lifecycle management via [`tokio::task::JoinSet`].
+//! `initializer`, `tester`, `qa`, `escalator`) and custom TOML-defined
+//! subagents that run with independent conversation contexts,
+//! restricted tool sets, and structured lifecycle management via
+//! [`tokio::task::JoinSet`].
 
 pub mod builtins;
 pub mod config;
 pub mod custom;
 pub mod discovery;
 pub mod error;
+pub mod escalator;
 pub mod manager;
 pub mod runner;
 pub mod status;
@@ -23,7 +25,8 @@ pub use config::{AgentKind, AgentType, SubagentConfig};
 pub use custom::{AgentSource, CustomAgentDef, CustomAgentMeta};
 pub use discovery::discover_custom_agents;
 pub use error::AgentError;
-pub use manager::{SubagentId, SubagentManager, SubagentSummary};
+pub use escalator::{EscalatorVerdict, ParseError as EscalatorParseError, parse_verdict};
+pub use manager::{EscalatorOverrides, SubagentId, SubagentManager, SubagentSummary};
 pub use runner::SubagentRunner;
 pub use status::{SubagentStatus, truncate_str};
 pub use tools::SpawnAgentTool;

--- a/crates/tmg-agents/src/manager.rs
+++ b/crates/tmg-agents/src/manager.rs
@@ -3,6 +3,28 @@
 //! The [`SubagentManager`] tracks all subagent instances, spawns them
 //! as tokio tasks in a [`JoinSet`], and provides methods to query
 //! status and collect results.
+//!
+//! ## Endpoint / model resolution
+//!
+//! Each spawn picks an `(endpoint, model)` pair using the precedence
+//! rules in [`SubagentManager::resolve_endpoint`]:
+//!
+//! - [`AgentKind::Custom`]: a non-empty `endpoint` / `model` on the
+//!   custom-agent definition wins; missing fields fall back to the
+//!   manager defaults.
+//! - [`AgentKind::Builtin`] of [`AgentType::Escalator`]: non-empty
+//!   values from [`EscalatorOverrides`] win; missing fields fall back
+//!   to the manager defaults so the escalator can transparently share
+//!   the main endpoint until a dedicated lightweight model is
+//!   configured.
+//! - All other built-in agents always run on the manager defaults.
+//!
+//! TODO(SPEC §10.1 `[llm.subagent_pool]`): when load-balanced subagent
+//! endpoints land, the round-robin pool MUST NOT route the escalator;
+//! the escalator owns its dedicated endpoint so its cost stays
+//! predictable (SPEC §9.10). Keep that wiring out of
+//! `resolve_endpoint` for the escalator branch even after the pool
+//! exists.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -17,10 +39,51 @@ use tmg_llm::LlmClient;
 use crate::builtins::{
     RunToolProvider, registry_for_agent_kind, registry_for_agent_kind_with_run_provider,
 };
-use crate::config::{AgentKind, SubagentConfig};
+use crate::config::{AgentKind, AgentType, SubagentConfig};
 use crate::error::AgentError;
 use crate::runner::SubagentRunner;
 use crate::status::SubagentStatus;
+
+/// Optional overrides for the escalator subagent's `(endpoint, model)`
+/// pair plus an explicit disable switch (SPEC §9.10 / §10.1
+/// `[harness.escalator]`).
+///
+/// Empty / `None` fields fall back to the manager's main endpoint and
+/// model so a partially-configured TOML still produces a working
+/// escalator. The `disabled` flag is enforced inside
+/// [`SubagentManager::spawn_inner`]: a disabled escalator request
+/// produces [`AgentError::EscalatorDisabled`] before any LLM client
+/// is constructed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EscalatorOverrides {
+    /// Optional override endpoint URL. `None` (or `Some("")` after the
+    /// caller normalises empty strings) means "inherit the main
+    /// endpoint".
+    pub endpoint: Option<String>,
+
+    /// Optional override model name. `None` means "inherit the main
+    /// model".
+    pub model: Option<String>,
+
+    /// When `true`, requests for the escalator are rejected with
+    /// [`AgentError::EscalatorDisabled`].
+    pub disabled: bool,
+}
+
+impl EscalatorOverrides {
+    /// Construct overrides from raw config values, treating empty
+    /// strings as `None` so an unset `[harness.escalator]` field
+    /// (`endpoint = ""`) inherits the main endpoint.
+    #[must_use]
+    pub fn from_strings(endpoint: String, model: String, disabled: bool) -> Self {
+        let normalize = |s: String| if s.is_empty() { None } else { Some(s) };
+        Self {
+            endpoint: normalize(endpoint),
+            model: normalize(model),
+            disabled,
+        }
+    }
+}
 
 /// A unique identifier for a subagent instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -99,6 +162,12 @@ pub struct SubagentManager {
     /// runs without those tools, which is the intended degraded
     /// behaviour for Run-less code paths.
     run_tool_provider: Option<Arc<dyn RunToolProvider>>,
+
+    /// Optional overrides for the escalator's endpoint / model and
+    /// the operator's disable switch. Defaults to "no overrides, not
+    /// disabled" so manager construction stays a single positional
+    /// call until a `[harness.escalator]` section is present.
+    escalator_overrides: EscalatorOverrides,
 }
 
 impl SubagentManager {
@@ -106,6 +175,9 @@ impl SubagentManager {
     ///
     /// The `default_endpoint` and `default_model` are used when a custom
     /// agent does not specify its own endpoint/model overrides.
+    /// The escalator overrides default to "no overrides, not disabled";
+    /// install them with [`Self::with_escalator_overrides`] when a
+    /// `[harness.escalator]` section is configured.
     pub fn new(
         client: LlmClient,
         parent_cancel: CancellationToken,
@@ -121,7 +193,42 @@ impl SubagentManager {
             instances: Arc::new(Mutex::new(BTreeMap::new())),
             next_id: 1,
             run_tool_provider: None,
+            escalator_overrides: EscalatorOverrides::default(),
         }
+    }
+
+    /// Install (or replace) the [`EscalatorOverrides`] used when
+    /// spawning the escalator subagent.
+    ///
+    /// Builder-style consuming method so the call site reads:
+    ///
+    /// ```ignore
+    /// let manager = SubagentManager::new(client, cancel, ep, model)
+    ///     .with_escalator_overrides(EscalatorOverrides::from_strings(
+    ///         cfg.endpoint.clone(),
+    ///         cfg.model.clone(),
+    ///         cfg.disable,
+    ///     ));
+    /// ```
+    #[must_use]
+    pub fn with_escalator_overrides(mut self, overrides: EscalatorOverrides) -> Self {
+        self.escalator_overrides = overrides;
+        self
+    }
+
+    /// Replace the [`EscalatorOverrides`] in-place.
+    ///
+    /// Useful when the manager already lives behind an `Arc<Mutex<_>>`
+    /// and the escalator config changes after construction (e.g. a
+    /// future config-reload path).
+    pub fn set_escalator_overrides(&mut self, overrides: EscalatorOverrides) {
+        self.escalator_overrides = overrides;
+    }
+
+    /// Borrow the currently-installed escalator overrides.
+    #[must_use]
+    pub fn escalator_overrides(&self) -> &EscalatorOverrides {
+        &self.escalator_overrides
     }
 
     /// Install (or replace) the [`RunToolProvider`] used for spawning
@@ -138,6 +245,56 @@ impl SubagentManager {
     #[must_use]
     pub fn run_tool_provider(&self) -> Option<&Arc<dyn RunToolProvider>> {
         self.run_tool_provider.as_ref()
+    }
+
+    /// Resolve the `(endpoint, model)` pair for a given [`AgentKind`].
+    ///
+    /// Precedence rules (see the module-level docs for context):
+    ///
+    /// - [`AgentKind::Custom`]: a non-empty `endpoint` / `model` on
+    ///   the custom-agent definition wins; missing fields fall back
+    ///   to the manager defaults.
+    /// - [`AgentKind::Builtin`] of [`AgentType::Escalator`]: non-empty
+    ///   values from [`EscalatorOverrides`] win; missing fields fall
+    ///   back to the manager defaults.
+    /// - All other built-in agents always run on the manager defaults.
+    ///
+    /// Exposed so the spawn path (and the dedicated test
+    /// [`Self::resolved_endpoint_for_kind`]) share a single source of
+    /// truth for the precedence rules.
+    fn resolve_endpoint(&self, kind: &AgentKind) -> (String, String) {
+        match kind {
+            AgentKind::Custom(def) => {
+                let endpoint = def.endpoint().unwrap_or(&self.default_endpoint).to_owned();
+                let model = def.model().unwrap_or(&self.default_model).to_owned();
+                (endpoint, model)
+            }
+            AgentKind::Builtin(AgentType::Escalator) => {
+                let endpoint = self
+                    .escalator_overrides
+                    .endpoint
+                    .clone()
+                    .unwrap_or_else(|| self.default_endpoint.clone());
+                let model = self
+                    .escalator_overrides
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| self.default_model.clone());
+                (endpoint, model)
+            }
+            AgentKind::Builtin(_) => (self.default_endpoint.clone(), self.default_model.clone()),
+        }
+    }
+
+    /// Test/inspection helper that returns the `(endpoint, model)`
+    /// pair a hypothetical spawn of `kind` would receive.
+    ///
+    /// Bypasses LLM-client construction so test code (and future
+    /// diagnostics commands) can verify the precedence rules without
+    /// a live llama-server.
+    #[must_use]
+    pub fn resolved_endpoint_for_kind(&self, kind: &AgentKind) -> (String, String) {
+        self.resolve_endpoint(kind)
     }
 
     /// Spawn a subagent and return its ID immediately.
@@ -179,6 +336,16 @@ impl SubagentManager {
         config: SubagentConfig,
         notify: Option<oneshot::Sender<Result<String, AgentError>>>,
     ) -> Result<SubagentId, AgentError> {
+        // Reject disabled-escalator requests up front, before
+        // allocating an ID or constructing an LLM client. SPEC §9.10
+        // expects the auto-promotion path to treat this as "do not
+        // escalate" rather than as a generic LLM/tool failure.
+        if matches!(config.agent_kind, AgentKind::Builtin(AgentType::Escalator))
+            && self.escalator_overrides.disabled
+        {
+            return Err(AgentError::EscalatorDisabled);
+        }
+
         let id = SubagentId(self.next_id);
         self.next_id += 1;
 
@@ -197,20 +364,21 @@ impl SubagentManager {
             instances.insert(id, instance);
         }
 
-        // For custom agents with a specific endpoint/model, create a
-        // dedicated LlmClient. Otherwise, use the shared client.
-        let client = if let AgentKind::Custom(ref def) = config.agent_kind {
-            if def.endpoint().is_some() || def.model().is_some() {
-                let endpoint = def.endpoint().unwrap_or(&self.default_endpoint);
-                let model = def.model().unwrap_or(&self.default_model);
-                let llm_config = tmg_llm::LlmClientConfig::new(endpoint, model);
-                tmg_llm::LlmClient::new(llm_config).map_err(AgentError::Llm)?
-            } else {
+        // Resolve the endpoint / model with the centralised precedence
+        // rules (see `resolve_endpoint`). When the resolved pair
+        // matches the manager defaults we keep the shared `self.client`
+        // to avoid constructing a redundant `LlmClient`; otherwise we
+        // spin up a dedicated client. This reuse keeps the common
+        // built-in path allocation-free while still letting custom
+        // agents and the escalator land on a different endpoint.
+        let (resolved_endpoint, resolved_model) = self.resolve_endpoint(&config.agent_kind);
+        let client =
+            if resolved_endpoint == self.default_endpoint && resolved_model == self.default_model {
                 self.client.clone()
-            }
-        } else {
-            self.client.clone()
-        };
+            } else {
+                let llm_config = tmg_llm::LlmClientConfig::new(&resolved_endpoint, &resolved_model);
+                tmg_llm::LlmClient::new(llm_config).map_err(AgentError::Llm)?
+            };
 
         let agent_kind = config.agent_kind.clone();
         let task = config.task.clone();
@@ -349,6 +517,7 @@ impl SubagentManager {
 
 #[cfg(test)]
 #[expect(clippy::panic, reason = "test assertions")]
+#[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
     use crate::config::AgentType;
@@ -434,6 +603,224 @@ mod tests {
         let summaries = manager.summaries().await;
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].agent_name, "explore");
+
+        cancel.cancel();
+        manager.shutdown().await;
+    }
+
+    /// Helper that builds a default-configured manager for endpoint
+    /// resolution tests. Returns `None` when `LlmClient::new` fails so
+    /// the test can early-exit gracefully (mirrors the pattern used by
+    /// the spawn tests above).
+    fn make_manager_for_resolution_tests() -> Option<SubagentManager> {
+        let config = tmg_llm::LlmClientConfig::new("http://main:8080", "main-model");
+        let client = tmg_llm::LlmClient::new(config).ok()?;
+        Some(SubagentManager::new(
+            client,
+            CancellationToken::new(),
+            "http://main:8080",
+            "main-model",
+        ))
+    }
+
+    #[test]
+    fn escalator_overrides_from_strings_treats_empty_as_none() {
+        let overrides = EscalatorOverrides::from_strings(String::new(), String::new(), false);
+        assert_eq!(overrides.endpoint, None);
+        assert_eq!(overrides.model, None);
+        assert!(!overrides.disabled);
+
+        let overrides = EscalatorOverrides::from_strings(
+            "http://escalator.invalid".to_owned(),
+            "tiny".to_owned(),
+            true,
+        );
+        assert_eq!(
+            overrides.endpoint.as_deref(),
+            Some("http://escalator.invalid"),
+        );
+        assert_eq!(overrides.model.as_deref(), Some("tiny"));
+        assert!(overrides.disabled);
+    }
+
+    #[test]
+    fn resolved_endpoint_for_builtin_uses_main_defaults() {
+        let Some(manager) = make_manager_for_resolution_tests() else {
+            return;
+        };
+        for kind in [
+            AgentKind::Builtin(AgentType::Explore),
+            AgentKind::Builtin(AgentType::Worker),
+            AgentKind::Builtin(AgentType::Plan),
+            AgentKind::Builtin(AgentType::Initializer),
+            AgentKind::Builtin(AgentType::Tester),
+            AgentKind::Builtin(AgentType::Qa),
+        ] {
+            let (ep, model) = manager.resolved_endpoint_for_kind(&kind);
+            assert_eq!(ep, "http://main:8080", "wrong endpoint for {}", kind.name());
+            assert_eq!(model, "main-model", "wrong model for {}", kind.name());
+        }
+    }
+
+    /// Acceptance criterion (issue #36): the escalator endpoint
+    /// override must actually be used at spawn time, not silently
+    /// dropped. We verify this via the public
+    /// [`SubagentManager::resolved_endpoint_for_kind`] helper rather
+    /// than a mock `LlmClient` so the test stays unit-scoped.
+    #[test]
+    fn resolved_endpoint_for_escalator_uses_overrides() {
+        let Some(manager) = make_manager_for_resolution_tests() else {
+            return;
+        };
+        let manager = manager.with_escalator_overrides(EscalatorOverrides::from_strings(
+            "http://escalator.invalid".to_owned(),
+            "lite".to_owned(),
+            false,
+        ));
+
+        let (ep, model) =
+            manager.resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Escalator));
+        assert_eq!(ep, "http://escalator.invalid");
+        assert_eq!(model, "lite");
+
+        // Other built-ins must keep using the main endpoint even when
+        // escalator overrides are installed.
+        let (ep, model) =
+            manager.resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Explore));
+        assert_eq!(ep, "http://main:8080");
+        assert_eq!(model, "main-model");
+    }
+
+    /// Regression: an empty `[harness.escalator] endpoint = ""` must
+    /// fall back to the main endpoint instead of trying to talk to a
+    /// blank URL.
+    #[test]
+    fn resolved_endpoint_for_escalator_falls_back_to_main_when_empty() {
+        let Some(manager) = make_manager_for_resolution_tests() else {
+            return;
+        };
+        let manager = manager.with_escalator_overrides(EscalatorOverrides::from_strings(
+            String::new(),
+            String::new(),
+            false,
+        ));
+
+        let (ep, model) =
+            manager.resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Escalator));
+        assert_eq!(ep, "http://main:8080");
+        assert_eq!(model, "main-model");
+    }
+
+    /// Partial overrides: only `endpoint` set, `model` empty -> the
+    /// model inherits the main config while the endpoint is honoured.
+    #[test]
+    fn resolved_endpoint_for_escalator_mixes_override_and_default() {
+        let Some(manager) = make_manager_for_resolution_tests() else {
+            return;
+        };
+        let manager = manager.with_escalator_overrides(EscalatorOverrides::from_strings(
+            "http://escalator.invalid".to_owned(),
+            String::new(),
+            false,
+        ));
+
+        let (ep, model) =
+            manager.resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Escalator));
+        assert_eq!(ep, "http://escalator.invalid");
+        assert_eq!(model, "main-model");
+    }
+
+    #[test]
+    fn resolved_endpoint_for_custom_uses_def_overrides() {
+        let Some(manager) = make_manager_for_resolution_tests() else {
+            return;
+        };
+
+        let toml = r#"
+name = "reviewer"
+description = "test"
+instructions = "do things"
+endpoint = "http://custom:7777"
+model = "custom-model"
+
+[tools]
+allow = ["file_read"]
+"#;
+        let def = crate::custom::CustomAgentDef::from_toml(toml, "test.toml")
+            .unwrap_or_else(|e| panic!("{e}"));
+        let kind = AgentKind::Custom(Arc::new(def));
+        let (ep, model) = manager.resolved_endpoint_for_kind(&kind);
+        assert_eq!(ep, "http://custom:7777");
+        assert_eq!(model, "custom-model");
+    }
+
+    #[tokio::test]
+    async fn escalator_disabled_rejects_spawn() {
+        let config = tmg_llm::LlmClientConfig::new("http://main:8080", "main-model");
+        let Ok(client) = tmg_llm::LlmClient::new(config) else {
+            return;
+        };
+        let cancel = CancellationToken::new();
+        let mut manager =
+            SubagentManager::new(client, cancel.clone(), "http://main:8080", "main-model")
+                .with_escalator_overrides(EscalatorOverrides::from_strings(
+                    String::new(),
+                    String::new(),
+                    true,
+                ));
+
+        let cfg = SubagentConfig {
+            agent_kind: AgentKind::Builtin(AgentType::Escalator),
+            task: "should be rejected".to_owned(),
+            background: true,
+        };
+        let err = manager
+            .spawn(cfg)
+            .await
+            .expect_err("disabled escalator must reject spawn");
+        assert!(
+            matches!(err, AgentError::EscalatorDisabled),
+            "expected AgentError::EscalatorDisabled, got {err:?}"
+        );
+
+        // Other builtins must still be spawnable when only the
+        // escalator is disabled.
+        let cfg_explore = SubagentConfig {
+            agent_kind: AgentKind::Builtin(AgentType::Explore),
+            task: "explore should still spawn".to_owned(),
+            background: true,
+        };
+        manager
+            .spawn(cfg_explore)
+            .await
+            .unwrap_or_else(|e| panic!("non-escalator spawn must still succeed: {e}"));
+
+        cancel.cancel();
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn escalator_not_disabled_by_default() {
+        let config = tmg_llm::LlmClientConfig::new("http://main:8080", "main-model");
+        let Ok(client) = tmg_llm::LlmClient::new(config) else {
+            return;
+        };
+        let cancel = CancellationToken::new();
+        let mut manager =
+            SubagentManager::new(client, cancel.clone(), "http://main:8080", "main-model");
+
+        let cfg = SubagentConfig {
+            agent_kind: AgentKind::Builtin(AgentType::Escalator),
+            task: "default escalator should spawn".to_owned(),
+            background: true,
+        };
+        // The actual LLM call will fail because no server is running,
+        // but the spawn-side gating must succeed.
+        let result = manager.spawn(cfg).await;
+        assert!(
+            result.is_ok(),
+            "default config should permit escalator spawn; got {result:?}",
+        );
 
         cancel.cancel();
         manager.shutdown().await;

--- a/crates/tmg-agents/src/tools/spawn_agent.rs
+++ b/crates/tmg-agents/src/tools/spawn_agent.rs
@@ -1,9 +1,12 @@
 //! The `spawn_agent` tool: spawns a subagent from the main agent loop.
 //!
 //! Parameters:
-//! - `agent_type` (string, required): one of the built-in types
-//!   (`"explore"`, `"worker"`, `"plan"`, `"initializer"`, `"tester"`,
-//!   `"qa"`) or the name of a custom agent
+//! - `agent_type` (string, required): one of the user-spawnable
+//!   built-in types (`"explore"`, `"worker"`, `"plan"`,
+//!   `"initializer"`, `"tester"`, `"qa"`) or the name of a custom
+//!   agent. The `"escalator"` type is harness-orchestrated only and is
+//!   intentionally excluded from this tool's schema (see
+//!   [`AgentType::is_user_spawnable`]).
 //! - `task` (string, required): the task description for the subagent
 //! - `background` (boolean, optional, default: `false`): whether to run
 //!   in the background
@@ -69,12 +72,17 @@ impl SpawnAgentTool {
 
     /// Resolve an `agent_type` string to an `AgentKind`.
     ///
-    /// First checks built-in types, then falls back to custom agents.
-    /// Uses `Arc::clone` for custom agents to avoid copying the entire
-    /// definition on each resolution.
+    /// First checks built-in types (excluding harness-orchestrated ones
+    /// such as `escalator`; see [`AgentType::is_user_spawnable`]), then
+    /// falls back to custom agents. Uses `Arc::clone` for custom agents
+    /// to avoid copying the entire definition on each resolution.
     fn resolve_agent_kind(&self, name: &str) -> Option<AgentKind> {
-        // Try built-in first.
-        if let Some(builtin) = AgentType::from_name(name) {
+        // Try built-in first, but only the user-spawnable subset --
+        // harness-only agents (e.g. `escalator`) must not be reachable
+        // through `spawn_agent`.
+        if let Some(builtin) = AgentType::from_name(name)
+            && builtin.is_user_spawnable()
+        {
             return Some(AgentKind::Builtin(builtin));
         }
 
@@ -84,9 +92,19 @@ impl SpawnAgentTool {
             .map(|def| AgentKind::Custom(Arc::clone(def)))
     }
 
-    /// Return all available agent type names for error messages.
+    /// Return the agent type names this tool is allowed to spawn.
+    ///
+    /// Used both for the JSON-Schema `enum` and for the
+    /// "valid types" hint inside `unknown agent_type` error messages.
+    /// Filters [`AgentType::ALL`] through
+    /// [`AgentType::is_user_spawnable`] so harness-only agents
+    /// (currently `escalator`) never appear.
     fn available_agent_names(&self) -> Vec<String> {
-        let mut names: Vec<String> = AgentType::ALL.iter().map(|t| t.name().to_owned()).collect();
+        let mut names: Vec<String> = AgentType::ALL
+            .iter()
+            .filter(|t| t.is_user_spawnable())
+            .map(|t| t.name().to_owned())
+            .collect();
         let mut custom_names: Vec<String> = self.custom_agents.keys().cloned().collect();
         custom_names.sort();
         names.extend(custom_names);
@@ -107,6 +125,8 @@ impl Tool for SpawnAgentTool {
          'initializer' (project bootstrap: features.json/init.sh/progress.md + initial commit), \
          'tester' (smoke-test runner via shell_exec), \
          'qa' (read-only acceptance-criteria QA; only agent that can mark features passing). \
+         The 'escalator' built-in is harness-orchestrated only and \
+         cannot be spawned through this tool. \
          Custom agents defined in .tsumugi/agents/ are also available. \
          Set background=true to run asynchronously."
     }
@@ -221,5 +241,92 @@ impl Tool for SpawnAgentTool {
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions")]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use tokio_util::sync::CancellationToken;
+
+    use crate::manager::SubagentManager;
+
+    /// Build a `SpawnAgentTool` with no custom agents over a manager
+    /// that points at a deliberately-unreachable endpoint. The schema
+    /// and resolution paths exercised in these tests never actually
+    /// dispatch an HTTP request, so the unreachable endpoint is fine.
+    fn make_tool() -> Option<SpawnAgentTool> {
+        let cfg = tmg_llm::LlmClientConfig::new("http://127.0.0.1:1", "test-model");
+        let client = tmg_llm::LlmClient::new(cfg).ok()?;
+        let manager = SubagentManager::new(
+            client,
+            CancellationToken::new(),
+            "http://127.0.0.1:1",
+            "test-model",
+        );
+        Some(SpawnAgentTool::new(Arc::new(Mutex::new(manager))))
+    }
+
+    #[test]
+    fn schema_enum_excludes_escalator() {
+        let Some(tool) = make_tool() else {
+            // LlmClient construction failed for environmental reasons;
+            // the schema does not depend on the client at runtime, but
+            // the constructor does. Skip rather than fail spuriously.
+            return;
+        };
+        let schema = tool.parameters_schema();
+        let enum_values = schema
+            .pointer("/properties/agent_type/enum")
+            .and_then(serde_json::Value::as_array)
+            .expect("agent_type enum must exist");
+        let names: Vec<&str> = enum_values
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect();
+        assert!(
+            !names.contains(&"escalator"),
+            "schema enum must not advertise 'escalator' as a spawnable agent: {names:?}"
+        );
+        // Sanity-check that the user-spawnable built-ins are still there.
+        for expected in ["explore", "worker", "plan", "initializer", "tester", "qa"] {
+            assert!(
+                names.contains(&expected),
+                "schema enum must advertise '{expected}': {names:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_escalator_at_runtime() {
+        let Some(tool) = make_tool() else {
+            return;
+        };
+        let params = serde_json::json!({
+            "agent_type": "escalator",
+            "task": "should be rejected before any spawn",
+        });
+        let err = tool
+            .execute(params)
+            .await
+            .expect_err("escalator must be rejected by spawn_agent");
+        match err {
+            ToolError::InvalidParams { message } => {
+                assert!(
+                    message.contains("unknown agent_type") && message.contains("escalator"),
+                    "error must call out the rejected agent_type: {message}"
+                );
+                // Ensure the suggested-types list does not mention
+                // 'escalator' either.
+                let suggested = message.split("Valid types:").nth(1).map_or("", str::trim);
+                assert!(
+                    !suggested.contains("escalator"),
+                    "error suggestions must not include 'escalator': {message}"
+                );
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
     }
 }

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -144,6 +144,68 @@ struct PartialHarnessConfig {
     /// [`load_config`] runs rather than only when the harness tries to
     /// schedule a session.
     pub default_session_timeout: Option<String>,
+    /// `[harness.escalator]` overrides for the scope-escalation
+    /// subagent (SPEC §10.1 / §9.10 / issue #36).
+    #[serde(default)]
+    pub escalator: PartialEscalatorConfig,
+}
+
+/// Partial `[harness.escalator]` config used for deserialization from
+/// TOML.
+///
+/// All three fields are optional; missing values (or empty strings on
+/// `endpoint` / `model`) mean "inherit from the main `[llm]` section"
+/// when the value is later handed to
+/// [`tmg_agents::EscalatorOverrides::from_strings`].
+///
+/// Mirrors the `deny_unknown_fields` policy of [`PartialHarnessConfig`]
+/// so a typo in `[harness.escalator]` is rejected at load time.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PartialEscalatorConfig {
+    /// Override endpoint URL for escalator spawns. Empty string or
+    /// absent means "inherit `[llm] endpoint`".
+    pub endpoint: Option<String>,
+
+    /// Override model name for escalator spawns. Empty string or
+    /// absent means "inherit `[llm] model`".
+    pub model: Option<String>,
+
+    /// When `true`, the harness rejects requests for the escalator
+    /// subagent (SPEC §9.10 cost management). The auto-promotion gate
+    /// (issue #37) treats a disabled escalator as "do not escalate".
+    pub disable: Option<bool>,
+}
+
+impl PartialEscalatorConfig {
+    /// Merge `other` into `self`. `Some(_)` fields in `other` win,
+    /// mirroring the rest of the partial-config merge story. Empty
+    /// strings are preserved so the same TOML round-trips cleanly;
+    /// the empty-string-as-inherit convention is resolved exactly
+    /// once when the partial is converted to the final
+    /// [`EscalatorConfig`] by the consumer.
+    fn merge_from(&mut self, other: &Self) {
+        if other.endpoint.is_some() {
+            self.endpoint.clone_from(&other.endpoint);
+        }
+        if other.model.is_some() {
+            self.model.clone_from(&other.model);
+        }
+        if other.disable.is_some() {
+            self.disable = other.disable;
+        }
+    }
+
+    /// Resolve into the final [`EscalatorConfig`]. No validation is
+    /// required here -- empty strings are valid (they simply mean
+    /// "inherit") and the disable flag is a plain bool.
+    fn into_final(self) -> EscalatorConfig {
+        EscalatorConfig {
+            endpoint: self.endpoint.unwrap_or_default(),
+            model: self.model.unwrap_or_default(),
+            disable: self.disable.unwrap_or(false),
+        }
+    }
 }
 
 impl PartialHarnessConfig {
@@ -168,6 +230,7 @@ impl PartialHarnessConfig {
             self.default_session_timeout
                 .clone_from(&other.default_session_timeout);
         }
+        self.escalator.merge_from(&other.escalator);
     }
 
     /// Convert to final `HarnessConfig`, filling in defaults for unset
@@ -228,6 +291,7 @@ impl PartialHarnessConfig {
             smoke_test_every_n_sessions,
             default_max_sessions,
             default_session_timeout,
+            escalator: self.escalator.into_final(),
         })
     }
 }
@@ -409,6 +473,20 @@ impl PartialTsumugiConfig {
             }
             self.harness.default_session_timeout = Some(v);
         }
+        if let Some(v) = env_fn("TMG_HARNESS_ESCALATOR_ENDPOINT") {
+            self.harness.escalator.endpoint = Some(v);
+        }
+        if let Some(v) = env_fn("TMG_HARNESS_ESCALATOR_MODEL") {
+            self.harness.escalator.model = Some(v);
+        }
+        if let Some(v) = env_fn("TMG_HARNESS_ESCALATOR_DISABLE") {
+            let parsed = parse_bool(&v).map_err(|()| ConfigError::InvalidValue {
+                field: "TMG_HARNESS_ESCALATOR_DISABLE".to_owned(),
+                value: v,
+                reason: "must be one of: true, false, 1, 0".to_owned(),
+            })?;
+            self.harness.escalator.disable = Some(parsed);
+        }
         Ok(())
     }
 
@@ -524,6 +602,31 @@ pub struct TuiConfig {
     pub show_token_usage: Option<bool>,
 }
 
+/// `[harness.escalator]` settings (SPEC §10.1 / §9.10 / issue #36).
+///
+/// Empty `endpoint` / `model` mean "inherit the main `[llm]`
+/// endpoint / model" when handed to
+/// [`tmg_agents::EscalatorOverrides::from_strings`]. The struct itself
+/// keeps the raw strings so a TOML round-trip preserves the operator's
+/// exact configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct EscalatorConfig {
+    /// Override endpoint for escalator spawns. Empty string means
+    /// "inherit `[llm] endpoint`".
+    #[serde(default)]
+    pub endpoint: String,
+
+    /// Override model for escalator spawns. Empty string means
+    /// "inherit `[llm] model`".
+    #[serde(default)]
+    pub model: String,
+
+    /// When `true`, escalator spawns are rejected with
+    /// `AgentError::EscalatorDisabled`.
+    #[serde(default)]
+    pub disable: bool,
+}
+
 /// Harness settings from `[harness]` section.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HarnessConfig {
@@ -562,6 +665,11 @@ pub struct HarnessConfig {
     /// `tsumugi.toml` as a humantime string (e.g. `"30m"`, `"1h30m"`).
     #[serde(with = "humantime_serde")]
     pub default_session_timeout: std::time::Duration,
+
+    /// `[harness.escalator]` overrides for the scope-escalation
+    /// subagent.
+    #[serde(default)]
+    pub escalator: EscalatorConfig,
 }
 
 fn default_runs_dir() -> PathBuf {
@@ -597,6 +705,7 @@ impl Default for HarnessConfig {
             smoke_test_every_n_sessions: default_smoke_test_every_n_sessions(),
             default_max_sessions: default_default_max_sessions(),
             default_session_timeout: default_session_timeout(),
+            escalator: EscalatorConfig::default(),
         }
     }
 }
@@ -1493,5 +1602,174 @@ smoke_test_evry_n_sessions = 3
             Err(ConfigError::InvalidValue { ref field, .. })
                 if field == "TMG_HARNESS_AUTO_RESUME_ON_START"
         ));
+    }
+
+    // ---- [harness.escalator] (issue #36) ---------------------------
+
+    #[test]
+    fn escalator_defaults_inherit_main() {
+        let config = TsumugiConfig::default();
+        assert_eq!(config.harness.escalator.endpoint, "");
+        assert_eq!(config.harness.escalator.model, "");
+        assert!(!config.harness.escalator.disable);
+    }
+
+    #[test]
+    fn escalator_round_trip_from_toml() {
+        let toml_str = r#"
+[harness.escalator]
+endpoint = "http://escalator.invalid"
+model = "tiny"
+disable = true
+"#;
+        let partial: PartialTsumugiConfig =
+            toml::from_str(toml_str).unwrap_or_else(|e| panic!("{e}"));
+        let final_config = partial.into_final().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            final_config.harness.escalator.endpoint,
+            "http://escalator.invalid",
+        );
+        assert_eq!(final_config.harness.escalator.model, "tiny");
+        assert!(final_config.harness.escalator.disable);
+    }
+
+    /// `endpoint = ""` is the documented "inherit main endpoint"
+    /// sentinel; loading must succeed and surface the empty string so
+    /// the spawn-side resolver can decide what to do.
+    #[test]
+    fn escalator_empty_endpoint_round_trips() {
+        let toml_str = r#"
+[harness.escalator]
+endpoint = ""
+model = ""
+disable = false
+"#;
+        let partial: PartialTsumugiConfig =
+            toml::from_str(toml_str).unwrap_or_else(|e| panic!("{e}"));
+        let final_config = partial.into_final().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(final_config.harness.escalator.endpoint, "");
+        assert_eq!(final_config.harness.escalator.model, "");
+        assert!(!final_config.harness.escalator.disable);
+    }
+
+    #[test]
+    fn escalator_partial_overrides() {
+        let toml_str = r#"
+[harness.escalator]
+endpoint = "http://escalator.invalid"
+"#;
+        let partial: PartialTsumugiConfig =
+            toml::from_str(toml_str).unwrap_or_else(|e| panic!("{e}"));
+        let final_config = partial.into_final().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            final_config.harness.escalator.endpoint,
+            "http://escalator.invalid",
+        );
+        assert_eq!(
+            final_config.harness.escalator.model, "",
+            "model not set in TOML must remain empty (inherit main)"
+        );
+        assert!(!final_config.harness.escalator.disable);
+    }
+
+    #[test]
+    fn escalator_unknown_field_rejected_at_load() {
+        // deny_unknown_fields parity with the rest of harness config.
+        let toml_str = r#"
+[harness.escalator]
+endpoint = "http://x"
+disabled = true
+"#;
+        let result: Result<PartialTsumugiConfig, _> = toml::from_str(toml_str);
+        assert!(
+            result.is_err(),
+            "expected deny_unknown_fields to reject `disabled` (typo for `disable`), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn escalator_env_overrides_apply() {
+        let mut config = PartialTsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            match key {
+                "TMG_HARNESS_ESCALATOR_ENDPOINT" => Some("http://env.escalator".to_owned()),
+                "TMG_HARNESS_ESCALATOR_MODEL" => Some("env-tiny".to_owned()),
+                "TMG_HARNESS_ESCALATOR_DISABLE" => Some("true".to_owned()),
+                _ => None,
+            }
+        };
+        config
+            .apply_env_overrides(&env_fn)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let final_config = config.into_final().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            final_config.harness.escalator.endpoint,
+            "http://env.escalator"
+        );
+        assert_eq!(final_config.harness.escalator.model, "env-tiny");
+        assert!(final_config.harness.escalator.disable);
+    }
+
+    #[test]
+    fn escalator_env_disable_invalid_returns_error() {
+        let mut config = PartialTsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            if key == "TMG_HARNESS_ESCALATOR_DISABLE" {
+                Some("maybe".to_owned())
+            } else {
+                None
+            }
+        };
+        let result = config.apply_env_overrides(&env_fn);
+        assert!(matches!(
+            result,
+            Err(ConfigError::InvalidValue { ref field, .. })
+                if field == "TMG_HARNESS_ESCALATOR_DISABLE"
+        ));
+    }
+
+    #[test]
+    fn escalator_env_overrides_win_over_toml() {
+        let toml_str = r#"
+[harness.escalator]
+endpoint = "http://from-toml"
+model = "toml-model"
+disable = false
+"#;
+        let mut partial: PartialTsumugiConfig =
+            toml::from_str(toml_str).unwrap_or_else(|e| panic!("{e}"));
+        let env_fn = |key: &str| -> Option<String> {
+            match key {
+                "TMG_HARNESS_ESCALATOR_ENDPOINT" => Some("http://from-env".to_owned()),
+                "TMG_HARNESS_ESCALATOR_DISABLE" => Some("true".to_owned()),
+                _ => None,
+            }
+        };
+        partial
+            .apply_env_overrides(&env_fn)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let final_config = partial.into_final().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(final_config.harness.escalator.endpoint, "http://from-env");
+        // model not env-overridden -> keeps the TOML value.
+        assert_eq!(final_config.harness.escalator.model, "toml-model");
+        assert!(final_config.harness.escalator.disable);
+    }
+
+    #[test]
+    fn escalator_partial_merge_overrides() {
+        let mut base = PartialTsumugiConfig::default();
+        base.harness.escalator.endpoint = Some("http://global".to_owned());
+        base.harness.escalator.model = Some("global-model".to_owned());
+
+        let mut overlay = PartialTsumugiConfig::default();
+        overlay.harness.escalator.endpoint = Some("http://project".to_owned());
+        overlay.harness.escalator.disable = Some(true);
+
+        base.merge_from(&overlay);
+        let final_config = base.into_final().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(final_config.harness.escalator.endpoint, "http://project");
+        // overlay did not set `model`; global wins.
+        assert_eq!(final_config.harness.escalator.model, "global-model");
+        assert!(final_config.harness.escalator.disable);
     }
 }

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -227,6 +227,10 @@ fn run_prompt(
 /// with a normal-completion trigger when the TUI returns and aborted
 /// with `UserCancelled` if the cancellation token fired or the TUI
 /// returned an error.
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear startup wiring (config -> store -> manager -> registry -> agent loop); splitting obscures the single-shot launch sequence"
+)]
 fn run_tui(
     endpoint: &str,
     model: &str,
@@ -298,13 +302,21 @@ fn run_tui(
         let custom_agent_defs: Vec<tmg_agents::CustomAgentDef> =
             custom_agent_metas.iter().map(|m| m.def().clone()).collect();
 
-        // Create the subagent manager.
-        let subagent_manager = Arc::new(Mutex::new(tmg_agents::SubagentManager::new(
-            client.clone(),
-            cancel.clone(),
-            endpoint,
-            model,
-        )));
+        // Create the subagent manager. The escalator's
+        // endpoint/model/disable knobs flow through
+        // [`tmg_agents::EscalatorOverrides`] so the resolver in
+        // `SubagentManager` is the single source of truth for
+        // precedence (see `crates/tmg-agents/src/manager.rs` module
+        // docs).
+        let escalator_overrides = tmg_agents::EscalatorOverrides::from_strings(
+            harness_config.escalator.endpoint.clone(),
+            harness_config.escalator.model.clone(),
+            harness_config.escalator.disable,
+        );
+        let subagent_manager = Arc::new(Mutex::new(
+            tmg_agents::SubagentManager::new(client.clone(), cancel.clone(), endpoint, model)
+                .with_escalator_overrides(escalator_overrides),
+        ));
 
         // Wire the active `RunRunner` into the subagent manager so
         // harnessed-run subagents (initializer / tester / qa) get


### PR DESCRIPTION
## Summary

- Adds the `Escalator` builtin subagent (SPEC §5.2 / §9.3) -- a
  read-only judge that emits a strict JSON verdict for promoting an
  ad-hoc request to a harnessed run.
- Refactors `SubagentManager` so the spawn path resolves
  `(endpoint, model)` through a single `resolve_endpoint` helper,
  letting the escalator (and existing custom agents) target a
  dedicated endpoint without poisoning the rest of the manager.
- Wires the new `[harness.escalator]` config section
  (`endpoint` / `model` / `disable` + matching `TMG_*` env overrides)
  through to `tmg_agents::EscalatorOverrides`.

Closes #36.

## Crates touched

- `tmg-agents`: new `escalator` module (`EscalatorVerdict` +
  `parse_verdict`), `EscalatorOverrides`, `AgentError::EscalatorDisabled`,
  `SubagentManager::with_escalator_overrides` /
  `resolved_endpoint_for_kind`. `AgentType::ALL` now contains 7
  variants so the TUI `/agents` listing picks `escalator` up
  automatically.
- `tmg-cli`: `[harness.escalator]` partial + final config types,
  env overrides (`TMG_HARNESS_ESCALATOR_ENDPOINT|MODEL|DISABLE`),
  `deny_unknown_fields` parity, and `run_tui` wiring that hands the
  resolved overrides to `SubagentManager`.

## Design notes

- **Strict verdict schema.** `parse_verdict` uses
  `serde(deny_unknown_fields)` plus a streaming deserializer that
  rejects trailing input. A custom `deserialize_with` on
  `estimated_features` refuses explicit `null` / strings / floats so
  the "field omitted" vs. "field present with bogus value"
  distinction stays sharp.
- **Inherit-main semantics.** Empty-string `endpoint` / `model` in
  `[harness.escalator]` are normalised to "inherit main" via
  `EscalatorOverrides::from_strings` so a partially-filled scaffold
  still produces a working escalator.
- **Disable gating happens before client construction.** Spawning
  `Builtin(Escalator)` while `disable = true` returns
  `AgentError::EscalatorDisabled` immediately, so the future
  auto-promotion gate (issue #37) can pattern-match on the variant
  without paying for an LLM round-trip.
- **LlmPool note.** A `TODO` comment in `manager.rs` documents that
  the future `[llm.subagent_pool]` round-robin (SPEC §10.1) must not
  route the escalator -- the escalator owns its dedicated endpoint
  to keep cost predictable per SPEC §9.10.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` -- 454 tests pass, including:
  - `escalator::tests::*` -- valid verdicts (with / without
    `estimated_features`), malformed JSON, unknown fields, missing
    required fields, `null` / string `estimated_features`,
    trailing input, round-trip preservation.
  - `manager::tests::resolved_endpoint_for_*` -- main defaults for
    other built-ins; escalator override honoured; empty fields fall
    back to main; partial overrides; custom-agent overrides.
  - `manager::tests::escalator_disabled_rejects_spawn` -- gating
    happens before client construction; non-escalator built-ins
    still spawn.
  - `tmg_cli::config::tests::escalator_*` -- TOML round-trip,
    inherit-main empty strings, partial overrides, env overrides
    win over TOML, `deny_unknown_fields` rejects typos
    (`disabled` vs `disable`), partial-config merge semantics.
- [x] Acceptance: spawning an `Escalator` with
  `escalator_endpoint = "http://escalator.invalid"` resolves to
  that endpoint via `SubagentManager::resolved_endpoint_for_kind`
  (covered by `resolved_endpoint_for_escalator_uses_overrides`).

### Runtime Verification

- LLM server: available
- One-shot mode (`--prompt` + `--event-log`): PASS
  - 48 token events, 0 errors, normal `done`. The one-shot path is
    streaming-only (no agent loop / tool execution), so it exercises
    the LLM round-trip rather than the escalator wiring directly;
    the escalator wiring is covered by unit tests.
- TUI mode: SKIP (expect-driven Enter submission did not produce a
  populated event log on this run; manual TUI smoke testing of the
  `/agents` listing -- which now includes `escalator` via
  `AgentType::ALL` -- is not gated by the escalator changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)