### PR TITLE
Add force-rotate, unified session-end, and session_log compaction (#38)

### DIFF
--- a/crates/tmg-harness/src/artifacts/mod.rs
+++ b/crates/tmg-harness/src/artifacts/mod.rs
@@ -22,4 +22,7 @@ pub mod session_log;
 pub use features::{Feature, FeatureList, Features, FeaturesSummary, FeaturesSummaryEntry};
 pub use init_script::{InitScript, InitScriptError, InitScriptOutput};
 pub use progress::ProgressLog;
-pub use session_log::{SessionLog, SessionLogEntry};
+pub use session_log::{
+    SUMMARY_AGGREGATE_FILENAME, SessionLog, SessionLogEntry, SessionSummaryAggregate,
+    SessionSummaryEntry,
+};

--- a/crates/tmg-harness/src/artifacts/session_log.rs
+++ b/crates/tmg-harness/src/artifacts/session_log.rs
@@ -20,8 +20,11 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
 use crate::error::HarnessError;
-use crate::session::Session;
+use crate::session::{Session, SessionEndTrigger};
 
 /// Persistent store for `session_NNN.json` records under one run.
 ///
@@ -131,6 +134,12 @@ impl SessionLog {
     /// from the highest index downwards.
     ///
     /// Returns `Ok(None)` when no session has set a hint yet.
+    ///
+    /// The scan also consults the compacted summary aggregate written
+    /// by [`compress_old_sessions`](Self::compress_old_sessions): when
+    /// the live `session_NNN.json` files do not carry a hint (e.g. all
+    /// recent sessions ended without explicitly setting one), the
+    /// aggregate is parsed and its newest non-empty hint is returned.
     pub fn last_hint(&self) -> Result<Option<String>, HarnessError> {
         let mut entries = self.list()?;
         entries.sort_by_key(|e| std::cmp::Reverse(e.index));
@@ -142,12 +151,231 @@ impl SessionLog {
                 return Ok(Some(hint));
             }
         }
+
+        // Fall back to the compacted aggregate: walk its entries
+        // newest-first so the most recent persisted hint wins.
+        let aggregate_path = self.summary_aggregate_path();
+        if !aggregate_path.exists() {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(&aggregate_path)
+            .map_err(|e| HarnessError::io(&aggregate_path, e))?;
+        let aggregate: SessionSummaryAggregate = serde_json::from_str(&raw)
+            .map_err(|e| HarnessError::session_deserialize(&aggregate_path, e))?;
+        for entry in aggregate.entries.iter().rev() {
+            if let Some(hint) = entry.next_session_hint.as_ref()
+                && !hint.trim().is_empty()
+            {
+                return Ok(Some(hint.clone()));
+            }
+        }
         Ok(None)
+    }
+
+    /// Compute the path of the compacted summary aggregate file.
+    ///
+    /// The filename is the constant
+    /// [`SUMMARY_AGGREGATE_FILENAME`](self::SUMMARY_AGGREGATE_FILENAME)
+    /// (`session_summaries.json`); the choice of a single fixed name
+    /// keeps merging across multiple compaction passes simple — every
+    /// new pass merges into the same file rather than producing one
+    /// `session_001-019.summary.json` per compaction.
+    #[must_use]
+    pub fn summary_aggregate_path(&self) -> PathBuf {
+        self.dir.join(SUMMARY_AGGREGATE_FILENAME)
+    }
+
+    /// Compact every session older than the most recent `keep_recent`
+    /// into a single [`SessionSummaryAggregate`] JSON file at
+    /// [`Self::summary_aggregate_path`], then delete the originals.
+    ///
+    /// **Mechanical-only:** this is purely text manipulation; no LLM
+    /// is consulted. Each compacted entry inherits the source
+    /// session's `summary`, `session_number`, `started_at`,
+    /// `ended_at`, `trigger`, and `next_session_hint` verbatim. SPEC
+    /// §9.11 leaves richer aggregations to a future issue.
+    ///
+    /// **Atomicity:** the aggregate is written via a `*.tmp` + rename
+    /// before any of the source `session_NNN.json` files are removed.
+    /// If the rename succeeds but a subsequent unlink fails, the
+    /// aggregate is consistent and the leftover live files merely
+    /// duplicate data; a re-run of `compress_old_sessions` cleans
+    /// them up.
+    ///
+    /// **Idempotency:** repeated calls re-merge the live files into
+    /// the existing aggregate; entries already in the aggregate are
+    /// preserved (we union by `session_number`, with the live file
+    /// winning on a duplicate so a hand-edited
+    /// `session_NNN.json` overrides a stale aggregate entry).
+    ///
+    /// `keep_recent == 0` compacts every available session.
+    /// `keep_recent` greater than the available session count is a
+    /// no-op.
+    ///
+    /// # Errors
+    ///
+    /// - [`HarnessError::Io`] for read/write failures of the source or
+    ///   aggregate files.
+    /// - [`HarnessError::SessionDeserialize`] when a live
+    ///   `session_NNN.json` cannot be parsed.
+    /// - [`HarnessError::SessionSerialize`] when the aggregate cannot
+    ///   be serialized.
+    pub fn compress_old_sessions(&self, keep_recent: usize) -> Result<(), HarnessError> {
+        let entries = self.list()?;
+        if entries.len() <= keep_recent {
+            return Ok(());
+        }
+        let cutoff = entries.len() - keep_recent;
+        let to_compact: Vec<&SessionLogEntry> = entries.iter().take(cutoff).collect();
+        if to_compact.is_empty() {
+            return Ok(());
+        }
+
+        // Load existing aggregate if present so a subsequent compaction
+        // pass merges into it rather than overwriting earlier entries.
+        let aggregate_path = self.summary_aggregate_path();
+        let mut aggregate = if aggregate_path.exists() {
+            let raw = fs::read_to_string(&aggregate_path)
+                .map_err(|e| HarnessError::io(&aggregate_path, e))?;
+            serde_json::from_str::<SessionSummaryAggregate>(&raw)
+                .map_err(|e| HarnessError::session_deserialize(&aggregate_path, e))?
+        } else {
+            SessionSummaryAggregate::default()
+        };
+
+        // Build the new entries first so an early failure leaves both
+        // the live files and the aggregate untouched.
+        let mut new_entries = Vec::with_capacity(to_compact.len());
+        for entry in &to_compact {
+            let session = self.load(entry.index)?.ok_or_else(|| HarnessError::Io {
+                path: entry.path.clone(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "session listed by SessionLog::list disappeared before load",
+                ),
+            })?;
+            new_entries.push(SessionSummaryEntry::from_session(&session));
+        }
+
+        // Merge: live entries overwrite any pre-existing aggregate
+        // entry for the same `session_number`, then we sort.
+        for incoming in new_entries {
+            if let Some(slot) = aggregate
+                .entries
+                .iter_mut()
+                .find(|e| e.session_number == incoming.session_number)
+            {
+                *slot = incoming;
+            } else {
+                aggregate.entries.push(incoming);
+            }
+        }
+        aggregate.entries.sort_by_key(|e| e.session_number);
+
+        // Atomic write of the aggregate BEFORE deleting any source.
+        fs::create_dir_all(&self.dir).map_err(|e| HarnessError::io(&self.dir, e))?;
+        let tmp_path = aggregate_path.with_extension("json.tmp");
+        let serialized = serde_json::to_string_pretty(&aggregate)
+            .map_err(|e| HarnessError::session_serialize(&aggregate_path, e))?;
+        if let Err(e) = fs::write(&tmp_path, serialized) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(HarnessError::io(&tmp_path, e));
+        }
+        if let Err(e) = fs::rename(&tmp_path, &aggregate_path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(HarnessError::io(&aggregate_path, e));
+        }
+
+        // Now safe to delete originals.
+        for entry in &to_compact {
+            if let Err(e) = fs::remove_file(&entry.path)
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::warn!(
+                    file = %entry.path.display(),
+                    %e,
+                    "failed to remove compacted session file; aggregate is durable",
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// On-disk filename for the compacted summary aggregate produced by
+/// [`SessionLog::compress_old_sessions`].
+pub const SUMMARY_AGGREGATE_FILENAME: &str = "session_summaries.json";
+
+/// Aggregate file written by
+/// [`SessionLog::compress_old_sessions`].
+///
+/// Each entry preserves the source session's identity
+/// (`session_number`, `started_at`, `ended_at`, `trigger`) plus the
+/// LLM-or-fallback `summary` text and the optional
+/// `next_session_hint`. The aggregate is a flat array sorted by
+/// `session_number` ascending.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SessionSummaryAggregate {
+    /// Compacted session entries, sorted by `session_number`
+    /// ascending.
+    #[serde(default)]
+    pub entries: Vec<SessionSummaryEntry>,
+}
+
+/// One compacted session entry inside a
+/// [`SessionSummaryAggregate`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionSummaryEntry {
+    /// Session sequence number within the parent run.
+    pub session_number: u32,
+
+    /// When the session started.
+    pub started_at: DateTime<Utc>,
+
+    /// When the session ended, if it did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<DateTime<Utc>>,
+
+    /// Why the session ended, if known.
+    #[serde(default, rename = "trigger", skip_serializing_if = "Option::is_none")]
+    pub end_trigger: Option<SessionEndTrigger>,
+
+    /// Free-form summary (`Session::summary`).
+    #[serde(default)]
+    pub summary: String,
+
+    /// Optional hint that the next session's bootstrap can consume.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_session_hint: Option<String>,
+}
+
+impl SessionSummaryEntry {
+    /// Build an entry from a [`Session`], copying the SPEC §9.11
+    /// fields verbatim.
+    #[must_use]
+    pub fn from_session(session: &Session) -> Self {
+        Self {
+            session_number: session.index,
+            started_at: session.started_at,
+            ended_at: session.ended_at,
+            end_trigger: session.end_trigger.clone(),
+            summary: session.summary.clone(),
+            next_session_hint: session.next_session_hint.clone(),
+        }
     }
 }
 
 /// Parse `session_NNN.json` -> `Some(NNN)`, otherwise `None`.
+///
+/// The compacted `session_summaries.json` aggregate produced by
+/// [`SessionLog::compress_old_sessions`] does not match this shape and
+/// is filtered out implicitly: its stem
+/// (`session_summaries`) does not start with `session_<digits>`.
 fn parse_session_filename(name: &str) -> Option<u32> {
+    if name == SUMMARY_AGGREGATE_FILENAME {
+        return None;
+    }
     let stem = name.strip_suffix(".json")?;
     let num = stem.strip_prefix("session_")?;
     num.parse::<u32>().ok()
@@ -253,5 +481,151 @@ mod tests {
         let (_tmp, log) = tmp_log();
         let hint = log.last_hint().unwrap_or_else(|e| panic!("{e}"));
         assert!(hint.is_none());
+    }
+
+    /// Acceptance: 25 sessions with `keep_recent = 20` aggregates
+    /// sessions 1..=5 into the summary file and leaves 6..=25 as
+    /// individual JSONs.
+    #[test]
+    fn compress_old_sessions_aggregates_oldest_keeps_recent() {
+        let (_tmp, log) = tmp_log();
+        for i in 1..=25_u32 {
+            let mut s = Session::begin(i);
+            s.summary = format!("summary {i}");
+            s.next_session_hint = Some(format!("hint {i}"));
+            s.end(SessionEndTrigger::Completed);
+            log.save(&s).unwrap_or_else(|e| panic!("{e}"));
+        }
+
+        log.compress_old_sessions(20)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        // Live files: 6..=25 remain.
+        let listed = log.list().unwrap_or_else(|e| panic!("{e}"));
+        let live_indices: Vec<u32> = listed.iter().map(|e| e.index).collect();
+        assert_eq!(live_indices, (6..=25).collect::<Vec<_>>());
+
+        // Sessions 1..=5 must be gone from disk.
+        for i in 1..=5_u32 {
+            assert!(
+                !log.session_path(i).exists(),
+                "session {i} should be compacted: {}",
+                log.session_path(i).display(),
+            );
+        }
+
+        // Aggregate file exists and carries the expected entries.
+        let aggregate_path = log.summary_aggregate_path();
+        assert!(aggregate_path.exists());
+        let raw = fs::read_to_string(&aggregate_path).unwrap_or_else(|e| panic!("{e}"));
+        let aggregate: SessionSummaryAggregate =
+            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("{e}"));
+        let aggregate_indices: Vec<u32> =
+            aggregate.entries.iter().map(|e| e.session_number).collect();
+        assert_eq!(aggregate_indices, vec![1, 2, 3, 4, 5]);
+        assert_eq!(aggregate.entries[0].summary, "summary 1");
+        assert_eq!(aggregate.entries[4].summary, "summary 5");
+        assert_eq!(
+            aggregate.entries[2].next_session_hint.as_deref(),
+            Some("hint 3"),
+        );
+    }
+
+    /// Compacting fewer-than-`keep_recent` sessions is a no-op.
+    #[test]
+    fn compress_old_sessions_no_op_when_below_keep_recent() {
+        let (_tmp, log) = tmp_log();
+        for i in 1..=5_u32 {
+            let mut s = Session::begin(i);
+            s.end(SessionEndTrigger::Completed);
+            log.save(&s).unwrap_or_else(|e| panic!("{e}"));
+        }
+        log.compress_old_sessions(20)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let listed = log.list().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(listed.len(), 5);
+        assert!(!log.summary_aggregate_path().exists());
+    }
+
+    /// Repeated compaction passes merge new entries into the existing
+    /// aggregate rather than overwriting it.
+    #[test]
+    fn compress_old_sessions_merges_into_existing_aggregate() {
+        let (_tmp, log) = tmp_log();
+        for i in 1..=10_u32 {
+            let mut s = Session::begin(i);
+            s.summary = format!("first {i}");
+            s.end(SessionEndTrigger::Completed);
+            log.save(&s).unwrap_or_else(|e| panic!("{e}"));
+        }
+        // First pass: keep 5 recent -> 1..=5 compacted.
+        log.compress_old_sessions(5)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        // Add more sessions and run another pass. Now we keep_recent=3
+        // out of the 5 surviving, so 6, 7 also get compacted.
+        for i in 11..=15_u32 {
+            let mut s = Session::begin(i);
+            s.summary = format!("second {i}");
+            s.end(SessionEndTrigger::Completed);
+            log.save(&s).unwrap_or_else(|e| panic!("{e}"));
+        }
+        // Now 10 live files (6..=15). keep_recent=3 -> 7 oldest get
+        // compacted, leaving 13..=15.
+        log.compress_old_sessions(3)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let listed = log.list().unwrap_or_else(|e| panic!("{e}"));
+        let live_indices: Vec<u32> = listed.iter().map(|e| e.index).collect();
+        assert_eq!(live_indices, vec![13, 14, 15]);
+
+        let raw =
+            fs::read_to_string(log.summary_aggregate_path()).unwrap_or_else(|e| panic!("{e}"));
+        let aggregate: SessionSummaryAggregate =
+            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("{e}"));
+        let agg_indices: Vec<u32> = aggregate.entries.iter().map(|e| e.session_number).collect();
+        assert_eq!(agg_indices, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    }
+
+    /// `last_hint` falls back to the compacted aggregate when no live
+    /// session carries a hint.
+    #[test]
+    fn last_hint_falls_back_to_aggregate() {
+        let (_tmp, log) = tmp_log();
+
+        // Three sessions, only the oldest carries a hint.
+        let mut s1 = Session::begin(1);
+        s1.next_session_hint = Some("aggregate hint".to_owned());
+        s1.end(SessionEndTrigger::Completed);
+        log.save(&s1).unwrap_or_else(|e| panic!("{e}"));
+        for i in 2..=3_u32 {
+            let mut s = Session::begin(i);
+            s.end(SessionEndTrigger::Completed);
+            log.save(&s).unwrap_or_else(|e| panic!("{e}"));
+        }
+
+        // Compact the oldest into the aggregate.
+        log.compress_old_sessions(2)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        // No live session has a hint; the aggregate still does.
+        let hint = log.last_hint().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(hint.as_deref(), Some("aggregate hint"));
+    }
+
+    /// `compress_old_sessions(0)` compacts every session.
+    #[test]
+    fn compress_old_sessions_zero_keep_recent_compacts_all() {
+        let (_tmp, log) = tmp_log();
+        for i in 1..=4_u32 {
+            let mut s = Session::begin(i);
+            s.end(SessionEndTrigger::Completed);
+            log.save(&s).unwrap_or_else(|e| panic!("{e}"));
+        }
+        log.compress_old_sessions(0)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let listed = log.list().unwrap_or_else(|e| panic!("{e}"));
+        assert!(listed.is_empty());
+        assert!(log.summary_aggregate_path().exists());
     }
 }

--- a/crates/tmg-harness/src/artifacts/session_log.rs
+++ b/crates/tmg-harness/src/artifacts/session_log.rs
@@ -140,6 +140,15 @@ impl SessionLog {
     /// the live `session_NNN.json` files do not carry a hint (e.g. all
     /// recent sessions ended without explicitly setting one), the
     /// aggregate is parsed and its newest non-empty hint is returned.
+    ///
+    /// **Cost:** `O(N)` worst case in the number of live
+    /// `session_NNN.json` files: the implementation calls
+    /// [`Self::list`] once and then `load`s the individual session
+    /// files newest-first until a non-empty hint is found. When every
+    /// recent session lacks a hint, the entire live set is read off
+    /// disk and the compacted aggregate is parsed once on top.
+    /// Optimisation (e.g. caching the hint pointer in `run.toml` or
+    /// a small index file) is tracked as a follow-up.
     pub fn last_hint(&self) -> Result<Option<String>, HarnessError> {
         let mut entries = self.list()?;
         entries.sort_by_key(|e| std::cmp::Reverse(e.index));
@@ -325,6 +334,23 @@ pub struct SessionSummaryAggregate {
 
 /// One compacted session entry inside a
 /// [`SessionSummaryAggregate`].
+///
+/// **Field-loss notice:** [`Self::from_session`] preserves only the
+/// SPEC §9.11 minimum (identity + summary + hint). The following
+/// [`Session`] fields are intentionally **not** carried into the
+/// aggregate:
+///
+/// - [`Session::tool_calls_count`]
+/// - [`Session::files_modified`]
+/// - [`Session::features_marked_passing`]
+/// - [`Session::context_usage_peak`]
+///
+/// Once the live `session_NNN.json` is removed by
+/// [`SessionLog::compress_old_sessions`] these values are no longer
+/// recoverable. **TODO:** include in a future SPEC §9.11 enhancement
+/// when consumers (e.g. analytics dashboards or post-mortem tooling)
+/// need them. Until then, callers that require these fields must
+/// snapshot them before compaction.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SessionSummaryEntry {
     /// Session sequence number within the parent run.

--- a/crates/tmg-harness/src/error.rs
+++ b/crates/tmg-harness/src/error.rs
@@ -119,6 +119,17 @@ pub enum HarnessError {
         /// The id that was looked up.
         feature_id: String,
     },
+
+    /// A session-end operation was invoked while no session was active.
+    ///
+    /// Currently raised by
+    /// [`RunRunner::end_session_with_rotation`](crate::runner::RunRunner::end_session_with_rotation)
+    /// to refuse rotating an empty runner: rotating without an
+    /// active session would create a `session_count` hole (the
+    /// successor would be persisted with no predecessor on disk),
+    /// so we bail out and leave the runner untouched.
+    #[error("end_session_with_rotation called without an active session")]
+    NoActiveSession,
 }
 
 impl HarnessError {

--- a/crates/tmg-harness/src/lib.rs
+++ b/crates/tmg-harness/src/lib.rs
@@ -39,7 +39,8 @@ pub mod tools;
 
 pub use artifacts::{
     Feature, FeatureList, Features, FeaturesSummary, FeaturesSummaryEntry, InitScript,
-    InitScriptError, InitScriptOutput, ProgressLog, SessionLog, SessionLogEntry,
+    InitScriptError, InitScriptOutput, ProgressLog, SUMMARY_AGGREGATE_FILENAME, SessionLog,
+    SessionLogEntry, SessionSummaryAggregate, SessionSummaryEntry,
 };
 pub use error::HarnessError;
 pub use escalation::{
@@ -47,7 +48,11 @@ pub use escalation::{
     EscalationEvaluator, EscalationSignal, EscalatorLauncher, SubagentEscalatorLauncher,
 };
 pub use run::{Run, RunId, RunScope, RunStatus, RunSummary};
-pub use runner::{DEFAULT_BOOTSTRAP_MAX_TOKENS, RunProgressEvent, RunProgressReceiver, RunRunner};
+pub use runner::{
+    DEFAULT_BOOTSTRAP_MAX_TOKENS, DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD,
+    DEFAULT_SESSION_LOG_COMPRESS_AFTER, DEFAULT_SESSION_TIMEOUT, RunProgressEvent,
+    RunProgressReceiver, RunRunner,
+};
 pub use session::{Session, SessionEndTrigger, SessionHandle};
 pub use sink::HarnessStreamSink;
 pub use state::{SessionState, TurnSummary};

--- a/crates/tmg-harness/src/runner.rs
+++ b/crates/tmg-harness/src/runner.rs
@@ -56,11 +56,11 @@ const RUN_PROGRESS_CHANNEL_CAPACITY: usize = 16;
 /// Async events emitted by [`RunRunner`] for higher-level surfaces
 /// (TUI banner, CLI status line, ...).
 ///
-/// The variants correspond to events surfaced by SPEC §9.3 and §9.10
-/// that a UI may want to display without polling the runner. The TUI
-/// banner integration is tracked separately (#46); the channel itself
-/// is wired here so the harness can fire events even before the UI
-/// subscribes.
+/// The variants correspond to events surfaced by SPEC §9.3, §9.4, and
+/// §9.10 that a UI may want to display without polling the runner.
+/// The TUI banner integration is tracked separately (#46); the
+/// channel itself is wired here so the harness can fire events even
+/// before the UI subscribes.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RunProgressEvent {
     /// The active run was just promoted from ad-hoc to harnessed.
@@ -70,6 +70,18 @@ pub enum RunProgressEvent {
     ScopeUpgraded {
         /// Optional `estimated_features` from the verdict.
         features_count: Option<u32>,
+    },
+    /// A session boundary was crossed (SPEC §9.4): the active session
+    /// was persisted with the carried trigger and (for everything
+    /// except [`SessionEndTrigger::UserExit`]) a fresh successor
+    /// session was begun.
+    ///
+    /// The TUI banner UI consumer is out-of-scope for issue #38 (see
+    /// #46); the event is wired now so a future UI iteration can
+    /// subscribe without further changes to the runner.
+    SessionEnded {
+        /// The trigger recorded on the just-closed session.
+        trigger: SessionEndTrigger,
     },
 }
 
@@ -86,6 +98,25 @@ pub type RunProgressReceiver = mpsc::Receiver<RunProgressEvent>;
 /// (`30m`); used as a fallback when the runner has not been
 /// configured with a value from `tsumugi.toml`.
 pub const DEFAULT_SESSION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Default context-usage threshold above which
+/// [`RunRunner::maybe_force_rotate`] returns `true` and the harness
+/// rotates to a new session (SPEC §2.3).
+///
+/// Mirrors the CLI's `[harness] context_force_rotate_threshold`
+/// default. The auto-compact at 80% (configured via
+/// [`tmg_core::ContextConfig::compression_threshold`]) is the first
+/// line of defence; force-rotate is triggered only when compaction
+/// has already happened and the post-compaction usage is *still*
+/// above this fraction.
+pub const DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD: f32 = 0.95;
+
+/// Default cap on the number of recent live `session_NNN.json` files
+/// preserved before [`SessionLog::compress_old_sessions`] aggregates
+/// older entries into `session_summaries.json`.
+///
+/// Mirrors the CLI's `[harness] session_log_compress_after` default.
+pub const DEFAULT_SESSION_LOG_COMPRESS_AFTER: usize = 20;
 
 /// Marker substring written by [`RunRunner::escalate_to_harnessed`]
 /// into `progress.md` when promoting a run.
@@ -175,6 +206,34 @@ pub struct RunRunner {
     /// Defaults to [`DEFAULT_SESSION_TIMEOUT`].
     default_session_timeout: Duration,
 
+    /// Threshold above which [`Self::maybe_force_rotate`] reports a
+    /// force-rotate is required.
+    ///
+    /// Reads from `[harness] context_force_rotate_threshold` in
+    /// `tsumugi.toml`; defaults to
+    /// [`DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD`].
+    context_force_rotate_threshold: f32,
+
+    /// Recent-session cap honoured by
+    /// [`SessionLog::compress_old_sessions`] when the runner
+    /// auto-compacts after [`Self::end_session_with_rotation`].
+    ///
+    /// Reads from `[harness] session_log_compress_after` in
+    /// `tsumugi.toml`; defaults to
+    /// [`DEFAULT_SESSION_LOG_COMPRESS_AFTER`].
+    session_log_compress_after: usize,
+
+    /// Cancellation handle for the per-session timeout watchdog.
+    ///
+    /// `Some(handle)` between [`Self::begin_session`] and
+    /// [`Self::end_session_with_rotation`] when a watchdog has been
+    /// armed via [`Self::arm_session_timeout_watchdog`]; `None`
+    /// otherwise. Aborting the handle cancels the pending
+    /// [`SessionEndTrigger::Timeout`] event before it fires (the
+    /// watchdog is implemented with `tokio::time::sleep` so abort is
+    /// the cleanest way to disarm it).
+    timeout_watchdog: Option<tokio::task::JoinHandle<()>>,
+
     /// Aggregate state observed across the active session, fed by the
     /// harness's [`AgentLoop::set_turn_observer`](tmg_core::AgentLoop::set_turn_observer)
     /// callback via [`Self::after_turn`]. Read by the
@@ -228,6 +287,9 @@ impl RunRunner {
             active_session: None,
             bootstrap_max_tokens: DEFAULT_BOOTSTRAP_MAX_TOKENS,
             default_session_timeout: DEFAULT_SESSION_TIMEOUT,
+            context_force_rotate_threshold: DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD,
+            session_log_compress_after: DEFAULT_SESSION_LOG_COMPRESS_AFTER,
+            timeout_watchdog: None,
             session_state,
             progress_tx: None,
             escalation_in_progress: AtomicBool::new(false),
@@ -278,6 +340,43 @@ impl RunRunner {
     #[must_use]
     pub fn default_session_timeout(&self) -> Duration {
         self.default_session_timeout
+    }
+
+    /// Set the context-usage threshold above which
+    /// [`Self::maybe_force_rotate`] reports `true`.
+    ///
+    /// Values are clamped to `(0.0, 1.0]`; non-positive or non-finite
+    /// inputs reset the threshold to
+    /// [`DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD`] so a misconfigured
+    /// caller cannot disable rotation by passing `0.0`.
+    pub fn set_context_force_rotate_threshold(&mut self, threshold: f32) {
+        self.context_force_rotate_threshold = if threshold.is_finite() && threshold > 0.0 {
+            threshold.min(1.0)
+        } else {
+            DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD
+        };
+    }
+
+    /// Return the active context-rotate threshold.
+    #[must_use]
+    pub fn context_force_rotate_threshold(&self) -> f32 {
+        self.context_force_rotate_threshold
+    }
+
+    /// Set the recent-session cap used during automatic compaction
+    /// of the session log.
+    ///
+    /// Values below `1` are clamped to `1`: keeping zero recent
+    /// sessions would compact the just-finished session immediately,
+    /// which defeats the purpose of the live JSON files.
+    pub fn set_session_log_compress_after(&mut self, n: usize) {
+        self.session_log_compress_after = n.max(1);
+    }
+
+    /// Return the active recent-session cap.
+    #[must_use]
+    pub fn session_log_compress_after(&self) -> usize {
+        self.session_log_compress_after
     }
 
     /// Borrow the active run.
@@ -449,8 +548,180 @@ impl RunRunner {
             session.end(trigger);
             self.session_log.save(&session)?;
         }
+        // Cancel the timeout watchdog if it was armed for this session.
+        self.disarm_timeout_watchdog();
         self.store.save(&self.run)?;
         Ok(())
+    }
+
+    // -----------------------------------------------------------------
+    // Force-rotate and unified session-boundary handling (issue #38)
+    // -----------------------------------------------------------------
+
+    /// Whether the latest observed `usage` exceeds the configured
+    /// [`Self::context_force_rotate_threshold`] and a force-rotate
+    /// should fire (SPEC §2.3).
+    ///
+    /// Stamps the active session's
+    /// [`Session::context_usage_peak`](crate::session::Session::context_usage_peak)
+    /// with `usage` whenever the new value is higher than the
+    /// previously-recorded peak so the saved `session_NNN.json` carries
+    /// the highest observed usage even when no rotation fires.
+    ///
+    /// `usage` is interpreted as a fraction `[0.0, 1.0]`. Non-finite
+    /// values are treated as `0.0` (no rotation).
+    ///
+    /// # Errors
+    ///
+    /// This method is currently infallible (the signature returns
+    /// `Result` so a future revision can fail the rotation gate
+    /// without changing call sites). Callers should treat any error
+    /// as "rotation suppressed for this turn".
+    pub fn maybe_force_rotate(&mut self, usage: f32) -> Result<bool, HarnessError> {
+        let normalized = if usage.is_finite() && usage >= 0.0 {
+            usage
+        } else {
+            0.0
+        };
+
+        // Track peak usage on the active session so the saved record
+        // always carries the highest observed value, regardless of
+        // whether the rotation actually fires.
+        if let Some(session) = self.active_session.as_mut() {
+            let peak = f64::from(normalized);
+            if peak > session.context_usage_peak {
+                session.context_usage_peak = peak;
+            }
+        }
+
+        Ok(normalized > self.context_force_rotate_threshold)
+    }
+
+    /// End the active session with `trigger`, persist it, and (for
+    /// every trigger except [`SessionEndTrigger::UserExit`]) begin a
+    /// fresh successor session.
+    ///
+    /// The flow follows SPEC §9.4:
+    ///
+    /// 1. (TODO when LLM-summary lands) Generate a session summary via
+    ///    the compaction-turn machinery in `tmg-core`. Until that step
+    ///    is wired the just-saved session inherits whatever
+    ///    `summary` / `next_session_hint` was already set by
+    ///    `session_summary_save` or other tooling.
+    /// 2. Persist the closed session via [`SessionLog::save`] with
+    ///    `trigger` recorded.
+    /// 3. Compact older session log entries if the live count exceeds
+    ///    [`Self::session_log_compress_after`].
+    /// 4. For every trigger except [`SessionEndTrigger::UserExit`],
+    ///    begin a fresh session via [`Self::begin_session`]. The next
+    ///    session's `next_session_hint`-driven bootstrap is fed by
+    ///    [`SessionLog::last_hint`] when the consumer (typically the
+    ///    `session_bootstrap` tool) re-reads the log.
+    /// 5. Emit [`RunProgressEvent::SessionEnded`] on the progress
+    ///    channel so a TUI banner consumer can react.
+    ///
+    /// Returns `Ok(true)` when a successor session was begun,
+    /// `Ok(false)` when the run is fully ended (i.e.
+    /// [`SessionEndTrigger::UserExit`]).
+    ///
+    /// # Errors
+    ///
+    /// Bubbles up [`HarnessError`] from session/run persistence.
+    pub fn end_session_with_rotation(
+        &mut self,
+        trigger: SessionEndTrigger,
+    ) -> Result<bool, HarnessError> {
+        // Disarm any active watchdog so a late `Timeout` event cannot
+        // race the rotation we are about to perform.
+        self.disarm_timeout_watchdog();
+
+        // Step 1+2: finalize the active session with the trigger. Use
+        // `Session::end` directly so a missing-active-session case
+        // still calls `store.save` (the legacy `end_session` path
+        // returned early without persisting).
+        let trigger_for_event = trigger.clone();
+        if let Some(mut session) = self.active_session.take() {
+            // Capture the current `next_session_hint` already set by
+            // tools (`session_summary_save`); leave None as-is for now.
+            // The LLM-generated summary path is a TODO until the
+            // compaction-turn machinery is plumbed through.
+            session.end(trigger);
+            self.session_log.save(&session)?;
+        } else {
+            tracing::warn!(
+                "end_session_with_rotation called without an active session; recording trigger only",
+            );
+        }
+
+        // Step 3: compact the log if it has grown past the cap.
+        if let Err(e) = self
+            .session_log
+            .compress_old_sessions(self.session_log_compress_after)
+        {
+            tracing::warn!(?e, "session_log compaction failed; continuing");
+        }
+
+        self.store.save(&self.run)?;
+
+        // Step 5 (publish event before begin_session so a UI consumer
+        // sees "old session ended" before "new session began").
+        self.publish_progress(RunProgressEvent::SessionEnded {
+            trigger: trigger_for_event.clone(),
+        });
+
+        // Step 4: begin a new session unless the trigger ends the run.
+        if matches!(trigger_for_event, SessionEndTrigger::UserExit) {
+            return Ok(false);
+        }
+
+        let _handle = self.begin_session()?;
+        Ok(true)
+    }
+
+    /// Arm the per-session watchdog: spawn a tokio task that sleeps
+    /// for `timeout` and then sends a [`SessionEndTrigger::Timeout`]
+    /// trigger over `tx`.
+    ///
+    /// The watchdog is automatically cancelled by
+    /// [`Self::end_session`] / [`Self::end_session_with_rotation`].
+    /// Callers that want a different cancellation discipline can call
+    /// [`Self::disarm_timeout_watchdog`] manually.
+    ///
+    /// **Ownership:** at most one watchdog can be armed at a time;
+    /// arming a second one aborts the previous one (a `tracing::warn!`
+    /// is emitted so the operator can investigate stray re-arms).
+    pub fn arm_session_timeout_watchdog(
+        &mut self,
+        timeout: Duration,
+        tx: mpsc::Sender<SessionEndTrigger>,
+    ) {
+        if self.timeout_watchdog.is_some() {
+            tracing::warn!(
+                "arm_session_timeout_watchdog called while a watchdog is active; \
+                 aborting the previous one",
+            );
+            self.disarm_timeout_watchdog();
+        }
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(timeout).await;
+            // Use `try_send` so a closed receiver does not stall the
+            // task; the watchdog is best-effort.
+            if let Err(err) = tx.try_send(SessionEndTrigger::Timeout) {
+                tracing::debug!(
+                    ?err,
+                    "session timeout watchdog could not deliver Timeout trigger",
+                );
+            }
+        });
+        self.timeout_watchdog = Some(handle);
+    }
+
+    /// Cancel a previously armed watchdog. Idempotent — a no-op when
+    /// no watchdog is active.
+    pub fn disarm_timeout_watchdog(&mut self) {
+        if let Some(handle) = self.timeout_watchdog.take() {
+            handle.abort();
+        }
     }
 
     // -----------------------------------------------------------------
@@ -1151,5 +1422,267 @@ mod tests {
             !progress.contains("reason: second attempt"),
             "second-attempt block must NOT be appended: {progress}",
         );
+    }
+
+    // ----- force-rotate and unified session-end (issue #38) -----
+
+    /// Acceptance: a 95.5% usage report fires force-rotate.
+    #[test]
+    fn maybe_force_rotate_fires_above_threshold() {
+        let (_tmp, mut runner) = make_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        // Default threshold is 0.95.
+        assert!(
+            runner
+                .maybe_force_rotate(0.955)
+                .unwrap_or_else(|e| panic!("{e}")),
+            "0.955 must exceed the 0.95 default threshold",
+        );
+        // The session record must carry the latest peak.
+        let session = runner
+            .active_session()
+            .unwrap_or_else(|| panic!("active session"));
+        assert!((session.context_usage_peak - 0.955).abs() < 1e-3);
+    }
+
+    #[test]
+    fn maybe_force_rotate_below_threshold_returns_false() {
+        let (_tmp, mut runner) = make_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            !runner
+                .maybe_force_rotate(0.5)
+                .unwrap_or_else(|e| panic!("{e}")),
+        );
+    }
+
+    /// Custom threshold honoured by `maybe_force_rotate`.
+    #[test]
+    fn maybe_force_rotate_custom_threshold() {
+        let (_tmp, mut runner) = make_runner();
+        runner.set_context_force_rotate_threshold(0.5);
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            runner
+                .maybe_force_rotate(0.51)
+                .unwrap_or_else(|e| panic!("{e}")),
+        );
+        assert!(
+            !runner
+                .maybe_force_rotate(0.49)
+                .unwrap_or_else(|e| panic!("{e}")),
+        );
+    }
+
+    /// Non-finite usage values do not cause a panic and never fire
+    /// rotation.
+    #[test]
+    fn maybe_force_rotate_handles_non_finite() {
+        let (_tmp, mut runner) = make_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            !runner
+                .maybe_force_rotate(f32::NAN)
+                .unwrap_or_else(|e| panic!("{e}")),
+        );
+        assert!(
+            !runner
+                .maybe_force_rotate(-1.0)
+                .unwrap_or_else(|e| panic!("{e}")),
+        );
+    }
+
+    /// `set_context_force_rotate_threshold` rejects garbage by
+    /// resetting to the default rather than disabling rotation.
+    #[test]
+    fn set_context_force_rotate_threshold_clamps_garbage() {
+        let (_tmp, mut runner) = make_runner();
+        runner.set_context_force_rotate_threshold(0.0);
+        assert!(
+            (runner.context_force_rotate_threshold() - DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD)
+                .abs()
+                < 1e-6,
+        );
+        runner.set_context_force_rotate_threshold(f32::NAN);
+        assert!(
+            (runner.context_force_rotate_threshold() - DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD)
+                .abs()
+                < 1e-6,
+        );
+        runner.set_context_force_rotate_threshold(2.0);
+        assert!((runner.context_force_rotate_threshold() - 1.0).abs() < 1e-6);
+    }
+
+    /// Acceptance: force-rotate path closes the active session,
+    /// records the rotation trigger on disk, and starts a new
+    /// session.
+    #[tokio::test]
+    async fn end_session_with_rotation_context_starts_new_session() {
+        let (_tmp, mut runner) = make_runner();
+        let mut rx = runner.progress_channel();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(runner.run().session_count, 1);
+
+        let started_new = runner
+            .end_session_with_rotation(SessionEndTrigger::ContextRotation)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(started_new);
+        assert_eq!(runner.run().session_count, 2);
+
+        // Old session was persisted with the rotation trigger.
+        let s1 = runner
+            .session_log()
+            .load(1)
+            .unwrap_or_else(|e| panic!("{e}"))
+            .unwrap_or_else(|| panic!("session 1 persisted"));
+        assert_eq!(s1.end_trigger, Some(SessionEndTrigger::ContextRotation));
+
+        // SessionEnded event was published.
+        let event = rx.recv().await.unwrap_or_else(|| panic!("event"));
+        assert_eq!(
+            event,
+            RunProgressEvent::SessionEnded {
+                trigger: SessionEndTrigger::ContextRotation,
+            },
+        );
+
+        // A successor session is active.
+        let active = runner
+            .active_session()
+            .unwrap_or_else(|| panic!("active session"));
+        assert_eq!(active.index, 2);
+    }
+
+    /// All four SPEC §9.4 triggers exercise the common flow; only
+    /// `UserExit` ends the run.
+    #[tokio::test]
+    async fn end_session_with_rotation_all_triggers_drive_common_flow() {
+        for trigger in [
+            SessionEndTrigger::ContextRotation,
+            SessionEndTrigger::Timeout,
+            SessionEndTrigger::UserNewSession,
+        ] {
+            let (_tmp, mut runner) = make_runner();
+            let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+            let started = runner
+                .end_session_with_rotation(trigger.clone())
+                .unwrap_or_else(|e| panic!("{e}"));
+            assert!(
+                started,
+                "trigger {trigger:?} must spawn a successor session",
+            );
+            assert!(runner.active_session().is_some());
+            // Persisted trigger matches.
+            let s1 = runner
+                .session_log()
+                .load(1)
+                .unwrap_or_else(|e| panic!("{e}"))
+                .unwrap_or_else(|| panic!("session 1"));
+            assert_eq!(s1.end_trigger, Some(trigger));
+        }
+
+        // UserExit ends the run.
+        let (_tmp, mut runner) = make_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        let started = runner
+            .end_session_with_rotation(SessionEndTrigger::UserExit)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(!started, "UserExit must NOT spawn a successor session");
+        assert!(runner.active_session().is_none());
+    }
+
+    /// `next_session_hint` round-trip: after a force-rotate, the new
+    /// session's bootstrap inputs see the previous session's hint via
+    /// [`SessionLog::last_hint`].
+    #[tokio::test]
+    async fn next_session_hint_round_trips_through_force_rotate() {
+        let (_tmp, mut runner) = make_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        if let Some(s) = runner.active_session_mut() {
+            s.next_session_hint = Some("foo".to_owned());
+            s.summary = "did foo".to_owned();
+        }
+
+        runner
+            .end_session_with_rotation(SessionEndTrigger::ContextRotation)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let hint = runner
+            .session_log()
+            .last_hint()
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(hint.as_deref(), Some("foo"));
+    }
+
+    /// Watchdog fires the Timeout trigger on the configured channel.
+    #[tokio::test]
+    async fn timeout_watchdog_fires_after_short_timeout() {
+        let (_tmp, mut runner) = make_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        let (tx, mut rx) = mpsc::channel::<SessionEndTrigger>(2);
+        runner.arm_session_timeout_watchdog(Duration::from_millis(100), tx);
+
+        // The watchdog should deliver the trigger inside our generous
+        // budget. Use `tokio::time::timeout` so a hung watchdog
+        // surfaces as a test failure rather than a hang.
+        let received = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .unwrap_or_else(|_| panic!("watchdog did not fire within 5s"))
+            .unwrap_or_else(|| panic!("channel closed without delivering Timeout"));
+        assert_eq!(received, SessionEndTrigger::Timeout);
+    }
+
+    /// Disarming the watchdog before its sleep elapses prevents the
+    /// Timeout trigger from being delivered.
+    ///
+    /// The test channel keeps a second sender alive (`tx_keepalive`)
+    /// so `rx.recv()` does not return `None` from sender-drop alone;
+    /// we want to assert that *no Timeout trigger* arrives, distinct
+    /// from the channel closing.
+    #[tokio::test]
+    async fn timeout_watchdog_can_be_disarmed() {
+        let (_tmp, mut runner) = make_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        let (tx, mut rx) = mpsc::channel::<SessionEndTrigger>(2);
+        let tx_keepalive = tx.clone();
+        runner.arm_session_timeout_watchdog(Duration::from_secs(5), tx);
+        runner.disarm_timeout_watchdog();
+        let result = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await;
+        assert!(
+            result.is_err(),
+            "no event must be delivered after disarm; got {result:?}",
+        );
+        drop(tx_keepalive);
+    }
+
+    /// `end_session_with_rotation` disarms an active watchdog so a
+    /// late timeout cannot race the rotation.
+    #[tokio::test]
+    async fn end_session_with_rotation_disarms_watchdog() {
+        let (_tmp, mut runner) = make_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        let (tx, mut rx) = mpsc::channel::<SessionEndTrigger>(2);
+        let tx_keepalive = tx.clone();
+        runner.arm_session_timeout_watchdog(Duration::from_secs(5), tx);
+
+        runner
+            .end_session_with_rotation(SessionEndTrigger::UserNewSession)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let result = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await;
+        assert!(
+            result.is_err(),
+            "watchdog must be cancelled by end_session_with_rotation; got {result:?}",
+        );
+        drop(tx_keepalive);
+    }
+
+    /// `set_session_log_compress_after` clamps zero to one so the
+    /// just-finished session is never compacted immediately.
+    #[test]
+    fn set_session_log_compress_after_clamps_zero() {
+        let (_tmp, mut runner) = make_runner();
+        runner.set_session_log_compress_after(0);
+        assert_eq!(runner.session_log_compress_after(), 1);
     }
 }

--- a/crates/tmg-harness/src/runner.rs
+++ b/crates/tmg-harness/src/runner.rs
@@ -100,7 +100,7 @@ pub type RunProgressReceiver = mpsc::Receiver<RunProgressEvent>;
 pub const DEFAULT_SESSION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 /// Default context-usage threshold above which
-/// [`RunRunner::maybe_force_rotate`] returns `true` and the harness
+/// [`RunRunner::should_force_rotate`] returns `true` and the harness
 /// rotates to a new session (SPEC §2.3).
 ///
 /// Mirrors the CLI's `[harness] context_force_rotate_threshold`
@@ -206,7 +206,7 @@ pub struct RunRunner {
     /// Defaults to [`DEFAULT_SESSION_TIMEOUT`].
     default_session_timeout: Duration,
 
-    /// Threshold above which [`Self::maybe_force_rotate`] reports a
+    /// Threshold above which [`Self::should_force_rotate`] reports a
     /// force-rotate is required.
     ///
     /// Reads from `[harness] context_force_rotate_threshold` in
@@ -233,6 +233,21 @@ pub struct RunRunner {
     /// watchdog is implemented with `tokio::time::sleep` so abort is
     /// the cleanest way to disarm it).
     timeout_watchdog: Option<tokio::task::JoinHandle<()>>,
+
+    /// Optional `(sender, duration)` registered by the CLI startup
+    /// path so the runner can re-arm the per-session timeout
+    /// watchdog automatically on every [`Self::begin_session`].
+    ///
+    /// When `Some`, [`Self::begin_session`] invokes
+    /// [`Self::arm_session_timeout_watchdog`] for harnessed runs
+    /// using a clone of the sender; the configured duration is
+    /// applied verbatim. The CLI registers this config exactly once
+    /// at startup (see [`Self::set_session_timeout_config`]); without
+    /// it, sessions rotated via [`Self::end_session_with_rotation`]
+    /// would inherit no watchdog after the first rotation because the
+    /// initial one-shot arm happened only against the original
+    /// session.
+    timeout_config: Option<(mpsc::Sender<SessionEndTrigger>, Duration)>,
 
     /// Aggregate state observed across the active session, fed by the
     /// harness's [`AgentLoop::set_turn_observer`](tmg_core::AgentLoop::set_turn_observer)
@@ -290,6 +305,7 @@ impl RunRunner {
             context_force_rotate_threshold: DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD,
             session_log_compress_after: DEFAULT_SESSION_LOG_COMPRESS_AFTER,
             timeout_watchdog: None,
+            timeout_config: None,
             session_state,
             progress_tx: None,
             escalation_in_progress: AtomicBool::new(false),
@@ -343,7 +359,7 @@ impl RunRunner {
     }
 
     /// Set the context-usage threshold above which
-    /// [`Self::maybe_force_rotate`] reports `true`.
+    /// [`Self::should_force_rotate`] reports `true`.
     ///
     /// Values are clamped to `(0.0, 1.0]`; non-positive or non-finite
     /// inputs reset the threshold to
@@ -477,6 +493,28 @@ impl RunRunner {
         Ok(())
     }
 
+    /// Register the per-session timeout watchdog configuration so
+    /// every subsequent [`Self::begin_session`] (including the
+    /// implicit one inside [`Self::end_session_with_rotation`])
+    /// re-arms the watchdog automatically.
+    ///
+    /// Without this configuration the CLI startup path can only arm
+    /// the watchdog once for the first session; rotations via
+    /// [`Self::end_session_with_rotation`] would then leave the
+    /// successor session unprotected. Calling this setter once at
+    /// startup makes the harness re-arm on every session boundary.
+    ///
+    /// Re-arming happens only when [`Self::is_harnessed`] is `true`;
+    /// ad-hoc runs inherit no wall-clock deadline regardless of this
+    /// configuration. Pass `None` to clear a previously registered
+    /// configuration.
+    pub fn set_session_timeout_config(
+        &mut self,
+        config: Option<(mpsc::Sender<SessionEndTrigger>, Duration)>,
+    ) {
+        self.timeout_config = config;
+    }
+
     /// Begin a new session.
     ///
     /// - Increments `session_count` and stamps `last_session_at` on the run.
@@ -485,6 +523,11 @@ impl RunRunner {
     ///   `progress.md`.
     /// - Writes the initial `session_NNN.json` so external readers see a
     ///   consistent record (with `ended_at = None`) immediately.
+    /// - When [`Self::is_harnessed`] is `true` and a
+    ///   `timeout_config` was registered via
+    ///   [`Self::set_session_timeout_config`], the per-session
+    ///   timeout watchdog is automatically armed so rotated sessions
+    ///   inherit the same wall-clock budget as the first one.
     pub fn begin_session(&mut self) -> Result<SessionHandle, HarnessError> {
         let now = Utc::now();
         self.run.session_count = self.run.session_count.saturating_add(1);
@@ -505,6 +548,16 @@ impl RunRunner {
             index: session.index,
         };
         self.active_session = Some(session);
+
+        // Auto-arm the per-session timeout watchdog so rotated
+        // sessions inherit the same deadline as the original.
+        // Ad-hoc runs are skipped — they have no wall-clock budget.
+        if self.is_harnessed()
+            && let Some((tx, duration)) = self.timeout_config.clone()
+        {
+            self.arm_session_timeout_watchdog(duration, tx);
+        }
+
         Ok(handle)
     }
 
@@ -547,9 +600,13 @@ impl RunRunner {
         if let Some(mut session) = self.active_session.take() {
             session.end(trigger);
             self.session_log.save(&session)?;
+            // Cancel the timeout watchdog only when we actually
+            // closed the active session. On an early-return path
+            // (no active session, or `SessionMismatch` rejected
+            // above) we leave any watchdog armed so the underlying
+            // session retains its wall-clock budget.
+            self.disarm_timeout_watchdog();
         }
-        // Cancel the timeout watchdog if it was armed for this session.
-        self.disarm_timeout_watchdog();
         self.store.save(&self.run)?;
         Ok(())
     }
@@ -558,43 +615,57 @@ impl RunRunner {
     // Force-rotate and unified session-boundary handling (issue #38)
     // -----------------------------------------------------------------
 
-    /// Whether the latest observed `usage` exceeds the configured
-    /// [`Self::context_force_rotate_threshold`] and a force-rotate
-    /// should fire (SPEC §2.3).
+    /// Record the latest observed context usage on the active
+    /// session (SPEC §2.3 force-rotate observability).
     ///
     /// Stamps the active session's
     /// [`Session::context_usage_peak`](crate::session::Session::context_usage_peak)
     /// with `usage` whenever the new value is higher than the
-    /// previously-recorded peak so the saved `session_NNN.json` carries
-    /// the highest observed usage even when no rotation fires.
+    /// previously-recorded peak so the saved `session_NNN.json`
+    /// carries the highest observed usage even when no rotation
+    /// fires.
     ///
     /// `usage` is interpreted as a fraction `[0.0, 1.0]`. Non-finite
-    /// values are treated as `0.0` (no rotation).
+    /// or negative values are treated as `0.0`.
     ///
-    /// # Errors
-    ///
-    /// This method is currently infallible (the signature returns
-    /// `Result` so a future revision can fail the rotation gate
-    /// without changing call sites). Callers should treat any error
-    /// as "rotation suppressed for this turn".
-    pub fn maybe_force_rotate(&mut self, usage: f32) -> Result<bool, HarnessError> {
+    /// This method has **no side effect on rotation**; pair it with
+    /// [`Self::should_force_rotate`] to drive the actual rotation
+    /// decision.
+    pub fn record_context_usage(&mut self, usage: f32) {
         let normalized = if usage.is_finite() && usage >= 0.0 {
             usage
         } else {
             0.0
         };
 
-        // Track peak usage on the active session so the saved record
-        // always carries the highest observed value, regardless of
-        // whether the rotation actually fires.
         if let Some(session) = self.active_session.as_mut() {
             let peak = f64::from(normalized);
             if peak > session.context_usage_peak {
                 session.context_usage_peak = peak;
             }
         }
+    }
 
-        Ok(normalized > self.context_force_rotate_threshold)
+    /// Whether the supplied `usage` exceeds the configured
+    /// [`Self::context_force_rotate_threshold`] and a force-rotate
+    /// should fire (SPEC §2.3).
+    ///
+    /// Pure check: this method does **not** mutate any state. Callers
+    /// that also want to record the observed usage on the active
+    /// session should call [`Self::record_context_usage`] alongside
+    /// it.
+    ///
+    /// `usage` is interpreted as a fraction `[0.0, 1.0]`. Non-finite
+    /// or negative values are treated as `0.0` and never fire
+    /// rotation.
+    #[must_use]
+    pub fn should_force_rotate(&self, usage: f32) -> bool {
+        let normalized = if usage.is_finite() && usage >= 0.0 {
+            usage
+        } else {
+            0.0
+        };
+        normalized > self.context_force_rotate_threshold
     }
 
     /// End the active session with `trigger`, persist it, and (for
@@ -631,27 +702,47 @@ impl RunRunner {
         &mut self,
         trigger: SessionEndTrigger,
     ) -> Result<bool, HarnessError> {
+        // Refuse to rotate without an active session: emitting a
+        // `SessionEnded` event and starting a fresh session would
+        // create a `session_count` hole (no `session_NNN.json` for
+        // the just-incremented index would have a predecessor on
+        // disk). The caller should
+        // [`begin_session`](Self::begin_session) first.
+        if self.active_session.is_none() {
+            return Err(HarnessError::NoActiveSession);
+        }
+
         // Disarm any active watchdog so a late `Timeout` event cannot
         // race the rotation we are about to perform.
         self.disarm_timeout_watchdog();
 
-        // Step 1+2: finalize the active session with the trigger. Use
-        // `Session::end` directly so a missing-active-session case
-        // still calls `store.save` (the legacy `end_session` path
-        // returned early without persisting).
-        let trigger_for_event = trigger.clone();
-        if let Some(mut session) = self.active_session.take() {
+        // Bind a cheap copy of the variant tag for the
+        // `UserExit`-vs-rotate decision so we can move `trigger`
+        // itself into the persisted session without a redundant
+        // intermediate `clone()`.
+        let is_user_exit = matches!(trigger, SessionEndTrigger::UserExit);
+
+        // Step 1+2: finalize the active session with the trigger.
+        // We just verified `active_session.is_some()` so the take
+        // here is guaranteed to succeed.
+        let saved_trigger = if let Some(mut session) = self.active_session.take() {
             // Capture the current `next_session_hint` already set by
             // tools (`session_summary_save`); leave None as-is for now.
             // The LLM-generated summary path is a TODO until the
             // compaction-turn machinery is plumbed through.
             session.end(trigger);
             self.session_log.save(&session)?;
+            // The `Session::end_trigger` is now `Some(trigger)`; clone
+            // it back out for the published event.
+            session
+                .end_trigger
+                .clone()
+                .unwrap_or(SessionEndTrigger::Completed)
         } else {
-            tracing::warn!(
-                "end_session_with_rotation called without an active session; recording trigger only",
-            );
-        }
+            // Unreachable due to the guard above; keep a defensive
+            // path so a future refactor cannot silently regress.
+            return Err(HarnessError::NoActiveSession);
+        };
 
         // Step 3: compact the log if it has grown past the cap.
         if let Err(e) = self
@@ -666,13 +757,20 @@ impl RunRunner {
         // Step 5 (publish event before begin_session so a UI consumer
         // sees "old session ended" before "new session began").
         self.publish_progress(RunProgressEvent::SessionEnded {
-            trigger: trigger_for_event.clone(),
+            trigger: saved_trigger,
         });
 
         // Step 4: begin a new session unless the trigger ends the run.
-        if matches!(trigger_for_event, SessionEndTrigger::UserExit) {
+        if is_user_exit {
             return Ok(false);
         }
+
+        // Reset per-session signals so the successor session starts
+        // with clean state (size-keyword latch, workflow-loop
+        // counter, per-file edit tally, ...). Done before
+        // `begin_session` so observers that fire on the very first
+        // turn of the new session see the cleared state.
+        self.session_state.reset_for_new_session();
 
         let _handle = self.begin_session()?;
         Ok(true)
@@ -695,6 +793,13 @@ impl RunRunner {
         timeout: Duration,
         tx: mpsc::Sender<SessionEndTrigger>,
     ) {
+        if self.active_session.is_none() {
+            tracing::warn!(
+                "arming session timeout watchdog without an active session; \
+                 the watchdog will fire against whatever session is active when \
+                 the deadline elapses",
+            );
+        }
         if self.timeout_watchdog.is_some() {
             tracing::warn!(
                 "arm_session_timeout_watchdog called while a watchdog is active; \
@@ -704,6 +809,15 @@ impl RunRunner {
         }
         let handle = tokio::spawn(async move {
             tokio::time::sleep(timeout).await;
+            // Log *before* `try_send` so the firing is observable
+            // independently of whether a consumer is listening on the
+            // other end of the channel. Operators see the deadline
+            // elapsed even if a downstream pipeline (e.g. the live
+            // rotation hand-off in #46) has not been wired yet.
+            tracing::info!(
+                ?timeout,
+                "session timeout watchdog firing SessionEndTrigger::Timeout",
+            );
             // Use `try_send` so a closed receiver does not stall the
             // task; the watchdog is best-effort.
             if let Err(err) = tx.try_send(SessionEndTrigger::Timeout) {
@@ -976,6 +1090,24 @@ impl RunRunner {
     #[must_use]
     pub fn run_id(&self) -> &crate::run::RunId {
         &self.run.id
+    }
+}
+
+impl Drop for RunRunner {
+    /// Abort any live timeout watchdog so the spawned tokio task does
+    /// not outlive the runner.
+    ///
+    /// Without this impl an early-return / panic path that drops the
+    /// runner before [`Self::end_session`] /
+    /// [`Self::end_session_with_rotation`] would leak the watchdog
+    /// task: it would keep sleeping until its deadline fires, then
+    /// `try_send` against a now-orphaned channel. The impl is
+    /// idempotent — [`Self::disarm_timeout_watchdog`] is a no-op when
+    /// no watchdog is armed.
+    fn drop(&mut self) {
+        if let Some(handle) = self.timeout_watchdog.take() {
+            handle.abort();
+        }
     }
 }
 
@@ -1428,14 +1560,13 @@ mod tests {
 
     /// Acceptance: a 95.5% usage report fires force-rotate.
     #[test]
-    fn maybe_force_rotate_fires_above_threshold() {
+    fn should_force_rotate_fires_above_threshold() {
         let (_tmp, mut runner) = make_runner();
         let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
         // Default threshold is 0.95.
+        runner.record_context_usage(0.955);
         assert!(
-            runner
-                .maybe_force_rotate(0.955)
-                .unwrap_or_else(|e| panic!("{e}")),
+            runner.should_force_rotate(0.955),
             "0.955 must exceed the 0.95 default threshold",
         );
         // The session record must carry the latest peak.
@@ -1446,50 +1577,35 @@ mod tests {
     }
 
     #[test]
-    fn maybe_force_rotate_below_threshold_returns_false() {
+    fn should_force_rotate_below_threshold_returns_false() {
         let (_tmp, mut runner) = make_runner();
         let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
-        assert!(
-            !runner
-                .maybe_force_rotate(0.5)
-                .unwrap_or_else(|e| panic!("{e}")),
-        );
+        runner.record_context_usage(0.5);
+        assert!(!runner.should_force_rotate(0.5));
     }
 
-    /// Custom threshold honoured by `maybe_force_rotate`.
+    /// Custom threshold honoured by `should_force_rotate`.
     #[test]
-    fn maybe_force_rotate_custom_threshold() {
+    fn should_force_rotate_custom_threshold() {
         let (_tmp, mut runner) = make_runner();
         runner.set_context_force_rotate_threshold(0.5);
         let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
-        assert!(
-            runner
-                .maybe_force_rotate(0.51)
-                .unwrap_or_else(|e| panic!("{e}")),
-        );
-        assert!(
-            !runner
-                .maybe_force_rotate(0.49)
-                .unwrap_or_else(|e| panic!("{e}")),
-        );
+        assert!(runner.should_force_rotate(0.51));
+        assert!(!runner.should_force_rotate(0.49));
     }
 
     /// Non-finite usage values do not cause a panic and never fire
     /// rotation.
     #[test]
-    fn maybe_force_rotate_handles_non_finite() {
+    fn should_force_rotate_handles_non_finite() {
         let (_tmp, mut runner) = make_runner();
         let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
-        assert!(
-            !runner
-                .maybe_force_rotate(f32::NAN)
-                .unwrap_or_else(|e| panic!("{e}")),
-        );
-        assert!(
-            !runner
-                .maybe_force_rotate(-1.0)
-                .unwrap_or_else(|e| panic!("{e}")),
-        );
+        // Both `record_context_usage` and `should_force_rotate`
+        // tolerate non-finite / negative inputs without panicking.
+        runner.record_context_usage(f32::NAN);
+        runner.record_context_usage(-1.0);
+        assert!(!runner.should_force_rotate(f32::NAN));
+        assert!(!runner.should_force_rotate(-1.0));
     }
 
     /// `set_context_force_rotate_threshold` rejects garbage by
@@ -1684,5 +1800,134 @@ mod tests {
         let (_tmp, mut runner) = make_runner();
         runner.set_session_log_compress_after(0);
         assert_eq!(runner.session_log_compress_after(), 1);
+    }
+
+    /// Build a runner promoted to a harnessed scope so the watchdog
+    /// auto-arm path is exercised without going through the full
+    /// escalation flow.
+    fn make_harnessed_runner() -> (tempfile::TempDir, RunRunner) {
+        let (tmp, mut runner) = make_runner();
+        let store = Arc::clone(&runner.store);
+        let upgraded = store
+            .upgrade_to_harnessed(&runner.run().id, runner.run().session_count, "test setup")
+            .unwrap_or_else(|e| panic!("{e}"));
+        runner.run = upgraded;
+        runner.session_state.set_scope(runner.run.scope.clone());
+        (tmp, runner)
+    }
+
+    /// `end_session_with_rotation` re-arms the timeout watchdog on
+    /// the successor session (Fix 1): registering a
+    /// `timeout_config` once at startup is enough — every rotated
+    /// session inherits the same wall-clock budget.
+    #[tokio::test]
+    async fn rotation_re_arms_timeout_watchdog_for_new_session() {
+        let (_tmp, mut runner) = make_harnessed_runner();
+        let (tx, mut rx) = mpsc::channel::<SessionEndTrigger>(4);
+        // Configure a tiny duration so the re-armed watchdog fires
+        // promptly on the successor session.
+        runner.set_session_timeout_config(Some((tx, Duration::from_millis(150))));
+
+        // Begin the first session — auto-arm fires here.
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        // Immediately rotate, which must (a) disarm the first
+        // watchdog and (b) re-arm the watchdog for the new session.
+        let started_new = runner
+            .end_session_with_rotation(SessionEndTrigger::ContextRotation)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(started_new);
+        assert_eq!(runner.run().session_count, 2);
+
+        // The re-armed watchdog on the successor session must fire
+        // its Timeout trigger within the test budget.
+        let received = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .unwrap_or_else(|_| panic!("watchdog did not fire on successor session"))
+            .unwrap_or_else(|| panic!("channel closed before delivering Timeout"));
+        assert_eq!(received, SessionEndTrigger::Timeout);
+    }
+
+    /// Without a registered `timeout_config`, rotation does not arm
+    /// any watchdog (callers opt in explicitly).
+    #[tokio::test]
+    async fn rotation_without_timeout_config_does_not_arm_watchdog() {
+        let (_tmp, mut runner) = make_harnessed_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        // No `set_session_timeout_config` call — the runner must not
+        // auto-arm.
+        runner
+            .end_session_with_rotation(SessionEndTrigger::ContextRotation)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(runner.timeout_watchdog.is_none());
+    }
+
+    /// `end_session_with_rotation` with no active session returns
+    /// `NoActiveSession` and leaves the runner untouched (Fix 4).
+    #[tokio::test]
+    async fn rotation_without_active_session_returns_no_active_session() {
+        let (_tmp, mut runner) = make_runner();
+        let mut rx = runner.progress_channel();
+        // No `begin_session` call — the runner has no active session.
+        assert_eq!(runner.run().session_count, 0);
+
+        let err = runner
+            .end_session_with_rotation(SessionEndTrigger::ContextRotation)
+            .err()
+            .unwrap_or_else(|| panic!("expected NoActiveSession error"));
+        assert!(
+            matches!(err, HarnessError::NoActiveSession),
+            "expected NoActiveSession, got {err:?}",
+        );
+        // No state mutation: no SessionEnded event, no session count
+        // increment, no on-disk session log entry.
+        assert_eq!(runner.run().session_count, 0);
+        let listed = runner
+            .session_log()
+            .list()
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(listed.is_empty(), "no session_NNN.json must be persisted");
+        let result = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await;
+        assert!(
+            result.is_err(),
+            "no SessionEnded event must be published on the bail path; got {result:?}",
+        );
+    }
+
+    /// `SessionState::reset_for_new_session` clears every session-
+    /// scoped signal across the rotation boundary (Fix 5).
+    #[tokio::test]
+    async fn rotation_resets_session_state_signals() {
+        let (_tmp, mut runner) = make_runner();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+
+        // Seed every session-scoped signal so rotation has something
+        // to clear.
+        let summary = TurnSummary {
+            tokens_used: 4096,
+            tool_calls: 5,
+            files_modified: vec!["src/foo.rs".to_owned(), "src/foo.rs".to_owned()],
+            diff_lines: 200,
+            user_message: "アプリ全体 を フルスクラッチ で書き直したい".to_owned(),
+        };
+        runner.after_turn(&summary, 8192);
+        runner.after_turn(&summary, 8192);
+        // Sanity: every signal we expect to clear is currently non-default.
+        let pre = runner.session_state();
+        assert!(pre.last_user_input_size_signal);
+        assert!(pre.pending_subtasks > 0);
+        assert!(pre.session_diff_lines > 0);
+        assert!(pre.workflow_loop_count > 0);
+        assert!(pre.same_file_edit_count > 0);
+
+        runner
+            .end_session_with_rotation(SessionEndTrigger::UserNewSession)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let post = runner.session_state();
+        assert!(!post.last_user_input_size_signal);
+        assert_eq!(post.pending_subtasks, 0);
+        assert_eq!(post.session_diff_lines, 0);
+        assert_eq!(post.workflow_loop_count, 0);
+        assert_eq!(post.same_file_edit_count, 0);
     }
 }

--- a/crates/tmg-harness/src/session.rs
+++ b/crates/tmg-harness/src/session.rs
@@ -108,7 +108,19 @@ impl Session {
     }
 }
 
-/// Why a session ended. SPEC §9.5.
+/// Why a session ended. SPEC §9.4 / §9.5.
+///
+/// Issue #38 grew the enum with the four "session-boundary"
+/// causes prescribed by SPEC §9.4 ([`UserExit`](Self::UserExit),
+/// [`ContextRotation`](Self::ContextRotation),
+/// [`Timeout`](Self::Timeout),
+/// [`UserNewSession`](Self::UserNewSession)). The original
+/// [`Completed`](Self::Completed) / [`UserCancelled`](Self::UserCancelled)
+/// / [`Rotated`](Self::Rotated) / [`Errored`](Self::Errored) variants
+/// are preserved for backwards-compatibility with on-disk
+/// `session_NNN.json` files written by earlier versions and for
+/// callers that still want a richer trigger payload (e.g.
+/// [`Errored`](Self::Errored) carries a message).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SessionEndTrigger {
@@ -117,6 +129,12 @@ pub enum SessionEndTrigger {
     /// Cancelled by the user (e.g. Ctrl-C).
     UserCancelled,
     /// The harness rotated to a new session (e.g. context exhaustion).
+    ///
+    /// Carries a free-form reason. Prefer the
+    /// [`ContextRotation`](Self::ContextRotation) variant for the
+    /// canonical SPEC §9.4 force-rotate path; this richer variant is
+    /// kept for cases where the caller wants to attribute the rotation
+    /// to a specific subsystem (e.g. `"manual /compact"`).
     Rotated {
         /// Reason for rotation, surfaced to the operator.
         reason: String,
@@ -126,6 +144,25 @@ pub enum SessionEndTrigger {
         /// Error message.
         message: String,
     },
+    /// SPEC §9.4 case 1: the user ended the run (closed the CLI / TUI
+    /// without resuming). Distinct from
+    /// [`UserCancelled`](Self::UserCancelled) in that the run is not
+    /// expected to spawn a successor session.
+    UserExit,
+    /// SPEC §9.4 case 2: the harness's force-rotate fired because
+    /// `context_usage` exceeded
+    /// [`HarnessConfig::context_force_rotate_threshold`](crate::runner::DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD).
+    /// The runner immediately begins a new session after persisting
+    /// the old one.
+    ContextRotation,
+    /// SPEC §9.4 case 3: the per-session wall-clock budget configured
+    /// via [`HarnessConfig::default_session_timeout`] elapsed without
+    /// the session completing. Fired by the watchdog spawned in
+    /// [`RunRunner::begin_session`](crate::runner::RunRunner::begin_session).
+    Timeout,
+    /// SPEC §9.4 case 4: the user explicitly rolled to a new session
+    /// (e.g. via the `/run new-session` command).
+    UserNewSession,
 }
 
 /// Opaque handle returned by `RunRunner::begin_session` and consumed by

--- a/crates/tmg-harness/src/session.rs
+++ b/crates/tmg-harness/src/session.rs
@@ -158,7 +158,11 @@ pub enum SessionEndTrigger {
     /// SPEC §9.4 case 3: the per-session wall-clock budget configured
     /// via [`HarnessConfig::default_session_timeout`] elapsed without
     /// the session completing. Fired by the watchdog spawned in
-    /// [`RunRunner::begin_session`](crate::runner::RunRunner::begin_session).
+    /// [`RunRunner::arm_session_timeout_watchdog`](crate::runner::RunRunner::arm_session_timeout_watchdog),
+    /// which is invoked automatically from
+    /// [`RunRunner::begin_session`](crate::runner::RunRunner::begin_session)
+    /// when a `timeout_config` was registered via
+    /// [`RunRunner::set_session_timeout_config`](crate::runner::RunRunner::set_session_timeout_config).
     Timeout,
     /// SPEC §9.4 case 4: the user explicitly rolled to a new session
     /// (e.g. via the `/run new-session` command).

--- a/crates/tmg-harness/src/state.rs
+++ b/crates/tmg-harness/src/state.rs
@@ -185,6 +185,29 @@ impl SessionState {
         self.file_edits.clear();
         self.last_user_message.clear();
     }
+
+    /// Reset the per-session signals across a session-rotation
+    /// boundary (SPEC §9.4) so the successor session starts with
+    /// clean state.
+    ///
+    /// Conceptually this clears every signal that was scoped to "the
+    /// previous session's turn observations": the size-keyword latch,
+    /// the workflow-loop counter, the per-file edit tally, and the
+    /// session-cumulative diff line count. The active run scope is
+    /// preserved (the rotation does not flip ad-hoc <-> harnessed),
+    /// and [`context_usage`](Self::context_usage) is reset so the
+    /// fresh session starts at `0.0` until the first new turn fires
+    /// `observe`.
+    pub fn reset_for_new_session(&mut self) {
+        self.last_user_input_size_signal = false;
+        self.context_usage = 0.0;
+        self.pending_subtasks = 0;
+        self.session_diff_lines = 0;
+        self.workflow_loop_count = 0;
+        self.same_file_edit_count = 0;
+        self.last_user_message.clear();
+        self.file_edits.clear();
+    }
 }
 
 #[cfg(test)]

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -144,6 +144,15 @@ struct PartialHarnessConfig {
     /// [`load_config`] runs rather than only when the harness tries to
     /// schedule a session.
     pub default_session_timeout: Option<String>,
+    /// Maximum number of recent live `session_NNN.json` files
+    /// preserved before
+    /// [`SessionLog::compress_old_sessions`](tmg_harness::SessionLog::compress_old_sessions)
+    /// aggregates older entries. Must be `>= 1` after merging.
+    pub session_log_compress_after: Option<usize>,
+    /// Context-usage threshold above which
+    /// [`RunRunner::maybe_force_rotate`](tmg_harness::RunRunner::maybe_force_rotate)
+    /// reports `true` (SPEC §2.3). Must be in `(0.0, 1.0]`.
+    pub context_force_rotate_threshold: Option<f64>,
     /// `[harness.escalator]` overrides for the scope-escalation
     /// subagent (SPEC §10.1 / §9.10 / issue #36).
     #[serde(default)]
@@ -331,6 +340,12 @@ impl PartialHarnessConfig {
             self.default_session_timeout
                 .clone_from(&other.default_session_timeout);
         }
+        if other.session_log_compress_after.is_some() {
+            self.session_log_compress_after = other.session_log_compress_after;
+        }
+        if other.context_force_rotate_threshold.is_some() {
+            self.context_force_rotate_threshold = other.context_force_rotate_threshold;
+        }
         self.escalator.merge_from(&other.escalator);
         self.escalation.merge_from(&other.escalation);
     }
@@ -382,6 +397,31 @@ impl PartialHarnessConfig {
             });
         }
 
+        let session_log_compress_after = self
+            .session_log_compress_after
+            .unwrap_or_else(default_session_log_compress_after);
+        if session_log_compress_after == 0 {
+            return Err(ConfigError::InvalidValue {
+                field: "harness.session_log_compress_after".to_owned(),
+                value: session_log_compress_after.to_string(),
+                reason: "must be a positive integer (>= 1)".to_owned(),
+            });
+        }
+
+        let context_force_rotate_threshold = self
+            .context_force_rotate_threshold
+            .unwrap_or_else(default_context_force_rotate_threshold);
+        if !context_force_rotate_threshold.is_finite()
+            || context_force_rotate_threshold <= 0.0
+            || context_force_rotate_threshold > 1.0
+        {
+            return Err(ConfigError::InvalidValue {
+                field: "harness.context_force_rotate_threshold".to_owned(),
+                value: context_force_rotate_threshold.to_string(),
+                reason: "must be in the range (0.0, 1.0]".to_owned(),
+            });
+        }
+
         let escalation = self.escalation.into_final()?;
 
         Ok(HarnessConfig {
@@ -395,6 +435,8 @@ impl PartialHarnessConfig {
             smoke_test_every_n_sessions,
             default_max_sessions,
             default_session_timeout,
+            session_log_compress_after,
+            context_force_rotate_threshold,
             escalator: self.escalator.into_final(),
             escalation,
         })
@@ -577,6 +619,36 @@ impl PartialTsumugiConfig {
                 });
             }
             self.harness.default_session_timeout = Some(v);
+        }
+        if let Some(v) = env_fn("TMG_HARNESS_SESSION_LOG_COMPRESS_AFTER") {
+            let n = v.parse::<usize>().map_err(|_| ConfigError::InvalidValue {
+                field: "TMG_HARNESS_SESSION_LOG_COMPRESS_AFTER".to_owned(),
+                value: v.clone(),
+                reason: "must be a non-negative integer".to_owned(),
+            })?;
+            if n == 0 {
+                return Err(ConfigError::InvalidValue {
+                    field: "TMG_HARNESS_SESSION_LOG_COMPRESS_AFTER".to_owned(),
+                    value: v,
+                    reason: "must be a positive integer (>= 1)".to_owned(),
+                });
+            }
+            self.harness.session_log_compress_after = Some(n);
+        }
+        if let Some(v) = env_fn("TMG_HARNESS_CONTEXT_FORCE_ROTATE_THRESHOLD") {
+            let n = v.parse::<f64>().map_err(|_| ConfigError::InvalidValue {
+                field: "TMG_HARNESS_CONTEXT_FORCE_ROTATE_THRESHOLD".to_owned(),
+                value: v.clone(),
+                reason: "must be a floating-point number".to_owned(),
+            })?;
+            if !n.is_finite() || n <= 0.0 || n > 1.0 {
+                return Err(ConfigError::InvalidValue {
+                    field: "TMG_HARNESS_CONTEXT_FORCE_ROTATE_THRESHOLD".to_owned(),
+                    value: v,
+                    reason: "must be in the range (0.0, 1.0]".to_owned(),
+                });
+            }
+            self.harness.context_force_rotate_threshold = Some(n);
         }
         if let Some(v) = env_fn("TMG_HARNESS_ESCALATOR_ENDPOINT") {
             self.harness.escalator.endpoint = Some(v);
@@ -822,6 +894,18 @@ pub struct HarnessConfig {
     #[serde(with = "humantime_serde")]
     pub default_session_timeout: std::time::Duration,
 
+    /// Maximum number of recent live `session_NNN.json` files preserved
+    /// before
+    /// [`SessionLog::compress_old_sessions`](tmg_harness::SessionLog::compress_old_sessions)
+    /// aggregates older entries into `session_summaries.json`.
+    pub session_log_compress_after: usize,
+
+    /// Context-usage threshold above which
+    /// [`RunRunner::maybe_force_rotate`](tmg_harness::RunRunner::maybe_force_rotate)
+    /// returns `true` and the harness rotates to a fresh session
+    /// (SPEC §2.3). Must be in `(0.0, 1.0]`.
+    pub context_force_rotate_threshold: f64,
+
     /// `[harness.escalator]` overrides for the scope-escalation
     /// subagent.
     #[serde(default)]
@@ -875,6 +959,14 @@ fn default_session_timeout() -> std::time::Duration {
     std::time::Duration::from_secs(30 * 60)
 }
 
+const fn default_session_log_compress_after() -> usize {
+    tmg_harness::DEFAULT_SESSION_LOG_COMPRESS_AFTER
+}
+
+const fn default_context_force_rotate_threshold() -> f64 {
+    tmg_harness::DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD as f64
+}
+
 impl Default for HarnessConfig {
     fn default() -> Self {
         Self {
@@ -884,6 +976,8 @@ impl Default for HarnessConfig {
             smoke_test_every_n_sessions: default_smoke_test_every_n_sessions(),
             default_max_sessions: default_default_max_sessions(),
             default_session_timeout: default_session_timeout(),
+            session_log_compress_after: default_session_log_compress_after(),
+            context_force_rotate_threshold: default_context_force_rotate_threshold(),
             escalator: EscalatorConfig::default(),
             escalation: tmg_harness::EscalationConfig::default(),
         }
@@ -2063,5 +2157,109 @@ diff_size_threshold = 500
         let final_config = partial.into_final().unwrap_or_else(|e| panic!("{e}"));
         assert!(!final_config.harness.escalation.enabled);
         assert_eq!(final_config.harness.escalation.diff_size_threshold, 750);
+    }
+
+    /// Issue #38: `[harness] session_log_compress_after` and
+    /// `[harness] context_force_rotate_threshold` parse from TOML and
+    /// flow through to the validated `HarnessConfig`.
+    #[test]
+    fn force_rotate_and_compress_after_load_from_toml() {
+        let toml = r"
+[harness]
+session_log_compress_after = 25
+context_force_rotate_threshold = 0.9
+";
+        let partial: PartialTsumugiConfig = toml::from_str(toml).unwrap_or_else(|e| panic!("{e}"));
+        let final_config = partial.into_final().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(final_config.harness.session_log_compress_after, 25);
+        assert!((final_config.harness.context_force_rotate_threshold - 0.9).abs() < 1e-6);
+    }
+
+    /// `session_log_compress_after = 0` is rejected.
+    #[test]
+    fn session_log_compress_after_zero_rejected() {
+        let toml = r"
+[harness]
+session_log_compress_after = 0
+";
+        let partial: PartialTsumugiConfig = toml::from_str(toml).unwrap_or_else(|e| panic!("{e}"));
+        let Err(err) = partial.into_final() else {
+            panic!("zero session_log_compress_after must be rejected");
+        };
+        assert!(
+            matches!(
+                err,
+                ConfigError::InvalidValue { ref field, .. }
+                    if field == "harness.session_log_compress_after"
+            ),
+            "got {err:?}",
+        );
+    }
+
+    /// `context_force_rotate_threshold` outside `(0.0, 1.0]` is
+    /// rejected.
+    #[test]
+    fn context_force_rotate_threshold_out_of_range_rejected() {
+        for bad in ["0.0", "1.5", "-0.1"] {
+            let toml = format!(
+                r"
+[harness]
+context_force_rotate_threshold = {bad}
+"
+            );
+            let partial: PartialTsumugiConfig =
+                toml::from_str(&toml).unwrap_or_else(|e| panic!("{e}"));
+            let Err(err) = partial.into_final() else {
+                panic!("out-of-range threshold {bad} must be rejected");
+            };
+            assert!(
+                matches!(
+                    err,
+                    ConfigError::InvalidValue { ref field, .. }
+                        if field == "harness.context_force_rotate_threshold"
+                ),
+                "got {err:?} for {bad}",
+            );
+        }
+    }
+
+    /// Env-var overrides for the new knobs validate their inputs.
+    #[test]
+    fn force_rotate_env_overrides_apply() {
+        let mut partial = PartialTsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            match key {
+                "TMG_HARNESS_SESSION_LOG_COMPRESS_AFTER" => Some("33".to_owned()),
+                "TMG_HARNESS_CONTEXT_FORCE_ROTATE_THRESHOLD" => Some("0.85".to_owned()),
+                _ => None,
+            }
+        };
+        partial
+            .apply_env_overrides(&env_fn)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let final_config = partial.into_final().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(final_config.harness.session_log_compress_after, 33);
+        assert!((final_config.harness.context_force_rotate_threshold - 0.85).abs() < 1e-6);
+    }
+
+    #[test]
+    fn force_rotate_env_override_bad_value_rejected() {
+        let mut partial = PartialTsumugiConfig::default();
+        let env_fn = |key: &str| -> Option<String> {
+            if key == "TMG_HARNESS_CONTEXT_FORCE_ROTATE_THRESHOLD" {
+                Some("2.0".to_owned())
+            } else {
+                None
+            }
+        };
+        let result = partial.apply_env_overrides(&env_fn);
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::InvalidValue { ref field, .. })
+                    if field == "TMG_HARNESS_CONTEXT_FORCE_ROTATE_THRESHOLD"
+            ),
+            "got {result:?}",
+        );
     }
 }

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -150,7 +150,7 @@ struct PartialHarnessConfig {
     /// aggregates older entries. Must be `>= 1` after merging.
     pub session_log_compress_after: Option<usize>,
     /// Context-usage threshold above which
-    /// [`RunRunner::maybe_force_rotate`](tmg_harness::RunRunner::maybe_force_rotate)
+    /// [`RunRunner::should_force_rotate`](tmg_harness::RunRunner::should_force_rotate)
     /// reports `true` (SPEC §2.3). Must be in `(0.0, 1.0]`.
     pub context_force_rotate_threshold: Option<f64>,
     /// `[harness.escalator]` overrides for the scope-escalation
@@ -901,7 +901,7 @@ pub struct HarnessConfig {
     pub session_log_compress_after: usize,
 
     /// Context-usage threshold above which
-    /// [`RunRunner::maybe_force_rotate`](tmg_harness::RunRunner::maybe_force_rotate)
+    /// [`RunRunner::should_force_rotate`](tmg_harness::RunRunner::should_force_rotate)
     /// returns `true` and the harness rotates to a fresh session
     /// (SPEC §2.3). Must be in `(0.0, 1.0]`.
     pub context_force_rotate_threshold: f64,

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -279,6 +279,16 @@ fn run_tui(
         let mut runner = RunRunner::new(run, Arc::clone(&store));
         runner.set_bootstrap_max_tokens(harness_config.bootstrap_max_tokens);
         runner.set_default_session_timeout(harness_config.default_session_timeout);
+        runner.set_session_log_compress_after(harness_config.session_log_compress_after);
+        // The runner stores the threshold as `f32` (matching the
+        // SessionState observers); narrow once at the boundary.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "threshold validated to be in (0.0, 1.0] which is exactly representable in f32"
+        )]
+        runner.set_context_force_rotate_threshold(
+            harness_config.context_force_rotate_threshold as f32,
+        );
         // One-time warning when the user's `[sandbox] mode` is stricter
         // than the harnessed `init.sh` execution path honours; see
         // `harness_init::warn_if_sandbox_mode_mismatch` for details.
@@ -289,6 +299,22 @@ fn run_tui(
             .begin_session()
             .context("beginning harness session")?;
         let run_summary: RunSummary = runner.summary();
+
+        // Per-session timeout channel: the watchdog feeds
+        // `SessionEndTrigger::Timeout` here; the dedicated rx is held
+        // by the TUI consumer in a future iteration (#46). For now we
+        // keep the rx alive so the channel does not close immediately
+        // and a `tracing::warn!` from the watchdog can still record
+        // the deadline; live rotation hand-off is wired in #46.
+        let (timeout_tx, _timeout_rx) =
+            tokio::sync::mpsc::channel::<tmg_harness::SessionEndTrigger>(4);
+        // Arm the watchdog only for harnessed runs; ad-hoc TUI
+        // sessions inherit no wall-clock deadline (the user can
+        // close the TUI whenever).
+        let session_timeout = runner.default_session_timeout();
+        if matches!(runner.scope(), tmg_harness::RunScope::Harnessed { .. }) {
+            runner.arm_session_timeout_watchdog(session_timeout, timeout_tx);
+        }
 
         // Wrap the runner in Arc<Mutex<...>> so the Run-scoped tools and
         // the bootstrap path share one source of truth for the active
@@ -550,9 +576,47 @@ fn install_turn_observer(
                 user_message,
             };
 
-            // Step 3: feed the summary into the runner.
+            // Step 3: feed the summary into the runner and check
+            // whether the SPEC §2.3 force-rotate threshold has been
+            // exceeded. The actual `clear_history` / `begin_session`
+            // sequence is owned by the higher-level TUI loop because
+            // it requires mutable access to the live `AgentLoop`; we
+            // only flip the rotation flag here so the consumer can
+            // observe it on the next iteration.
             let mut guard = runner.lock().await;
             guard.after_turn(&harness_summary, max_context_tokens);
+
+            let usage = if max_context_tokens == 0 {
+                0.0
+            } else {
+                #[expect(
+                    clippy::cast_precision_loss,
+                    reason = "usage is clamped to [0.0, 1.0] before consumption"
+                )]
+                let raw = tokens_used as f64 / max_context_tokens as f64;
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "ratio clamped to [0.0, 1.0] which fits in f32"
+                )]
+                {
+                    raw.clamp(0.0, 1.0) as f32
+                }
+            };
+            match guard.maybe_force_rotate(usage) {
+                Ok(true) => {
+                    // Emit the SessionEnded event channel-side so a
+                    // downstream consumer wakes; the live rotation
+                    // (clear_history + begin_session) is wired by the
+                    // CLI / TUI follow-up (#46) which owns the agent.
+                    tracing::warn!(
+                        usage,
+                        "context usage exceeded force-rotate threshold; \
+                         rotation must be driven by the TUI consumer",
+                    );
+                }
+                Ok(false) => {}
+                Err(err) => tracing::warn!(?err, "maybe_force_rotate failed"),
+            }
         });
     });
     agent.set_turn_observer(Some(observer));

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -284,7 +284,7 @@ fn run_tui(
         // SessionState observers); narrow once at the boundary.
         #[expect(
             clippy::cast_possible_truncation,
-            reason = "threshold validated to be in (0.0, 1.0] which is exactly representable in f32"
+            reason = "threshold is in (0.0, 1.0]; precision loss bounded by f32 epsilon, acceptable for a coarse threshold check."
         )]
         runner.set_context_force_rotate_threshold(
             harness_config.context_force_rotate_threshold as f32,
@@ -295,26 +295,40 @@ fn run_tui(
         if matches!(runner.scope(), tmg_harness::RunScope::Harnessed { .. }) {
             harness_init::warn_if_sandbox_mode_mismatch(sandbox_config);
         }
+
+        // Per-session timeout channel: the watchdog feeds
+        // `SessionEndTrigger::Timeout` here. Live rotation hand-off
+        // is wired in #46; until then we spawn a loud-fallback
+        // consumer that emits a `tracing::warn!` whenever the
+        // deadline elapses so operators can see the timeout fired
+        // even though the rotation is not yet executed.
+        let (timeout_tx, mut timeout_rx) =
+            tokio::sync::mpsc::channel::<tmg_harness::SessionEndTrigger>(4);
+        // Register the (sender, duration) pair so EVERY future
+        // `begin_session` (including the implicit one inside
+        // `end_session_with_rotation`) re-arms the watchdog. Without
+        // this, sessions after the first rotation would have no
+        // wall-clock protection.
+        let session_timeout = runner.default_session_timeout();
+        if matches!(runner.scope(), tmg_harness::RunScope::Harnessed { .. }) {
+            runner.set_session_timeout_config(Some((timeout_tx, session_timeout)));
+        }
+        // Loud-fallback consumer: drain the receiver and warn on
+        // every Timeout trigger. Replace this spawn with the real
+        // rotation hand-off once #46 lands.
+        tokio::spawn(async move {
+            while let Some(trigger) = timeout_rx.recv().await {
+                tracing::warn!(
+                    ?trigger,
+                    "session timeout fired but live hand-off is not yet wired (issue #46)",
+                );
+            }
+        });
+
         let session_handle = runner
             .begin_session()
             .context("beginning harness session")?;
         let run_summary: RunSummary = runner.summary();
-
-        // Per-session timeout channel: the watchdog feeds
-        // `SessionEndTrigger::Timeout` here; the dedicated rx is held
-        // by the TUI consumer in a future iteration (#46). For now we
-        // keep the rx alive so the channel does not close immediately
-        // and a `tracing::warn!` from the watchdog can still record
-        // the deadline; live rotation hand-off is wired in #46.
-        let (timeout_tx, _timeout_rx) =
-            tokio::sync::mpsc::channel::<tmg_harness::SessionEndTrigger>(4);
-        // Arm the watchdog only for harnessed runs; ad-hoc TUI
-        // sessions inherit no wall-clock deadline (the user can
-        // close the TUI whenever).
-        let session_timeout = runner.default_session_timeout();
-        if matches!(runner.scope(), tmg_harness::RunScope::Harnessed { .. }) {
-            runner.arm_session_timeout_watchdog(session_timeout, timeout_tx);
-        }
 
         // Wrap the runner in Arc<Mutex<...>> so the Run-scoped tools and
         // the bootstrap path share one source of truth for the active
@@ -602,20 +616,20 @@ fn install_turn_observer(
                     raw.clamp(0.0, 1.0) as f32
                 }
             };
-            match guard.maybe_force_rotate(usage) {
-                Ok(true) => {
-                    // Emit the SessionEnded event channel-side so a
-                    // downstream consumer wakes; the live rotation
-                    // (clear_history + begin_session) is wired by the
-                    // CLI / TUI follow-up (#46) which owns the agent.
-                    tracing::warn!(
-                        usage,
-                        "context usage exceeded force-rotate threshold; \
-                         rotation must be driven by the TUI consumer",
-                    );
-                }
-                Ok(false) => {}
-                Err(err) => tracing::warn!(?err, "maybe_force_rotate failed"),
+            // Side-effect first: stamp the active session's
+            // `context_usage_peak`. Then the pure check decides
+            // whether to fire the rotation banner.
+            guard.record_context_usage(usage);
+            if guard.should_force_rotate(usage) {
+                // Emit the SessionEnded event channel-side so a
+                // downstream consumer wakes; the live rotation
+                // (clear_history + begin_session) is wired by the
+                // CLI / TUI follow-up (#46) which owns the agent.
+                tracing::warn!(
+                    usage,
+                    "context usage exceeded force-rotate threshold; \
+                     rotation must be driven by the TUI consumer",
+                );
             }
         });
     });


### PR DESCRIPTION
Closes #38.

## Summary

Implements SPEC §2.3 / §9.4 / §9.11 — context force-rotate, the four
unified session-boundary triggers, mechanical compaction of the
`session_log/` directory, and the per-session timeout watchdog. Builds
on #32 / #33 / #37.

### New runner API

- `RunRunner::maybe_force_rotate(usage: f32) -> Result<bool>` reports
  when context usage exceeds the configured
  `context_force_rotate_threshold` (default `0.95`) and stamps the
  active session's `context_usage_peak` with the latest value (so the
  saved `session_NNN.json` always carries the highest observed usage).
- `RunRunner::end_session_with_rotation(trigger) -> Result<bool>` runs
  the SPEC §9.4 common flow: persist the closed session, compact the
  log if it has grown past `session_log_compress_after`, emit a
  `RunProgressEvent::SessionEnded { trigger }`, and (for every trigger
  except `UserExit`) begin a successor session via `begin_session`. The
  next session's bootstrap reads `last_hint` straight from
  `SessionLog::last_hint`.
- `RunRunner::arm_session_timeout_watchdog(timeout, tx)` /
  `disarm_timeout_watchdog` — tokio-task watchdog that fires
  `SessionEndTrigger::Timeout` over an `mpsc::Sender`; auto-cancelled
  by `end_session` / `end_session_with_rotation`.

### `SessionEndTrigger`

Extended with the four SPEC §9.4 variants (`UserExit`,
`ContextRotation`, `Timeout`, `UserNewSession`). Existing variants
(`Completed`, `UserCancelled`, `Rotated`, `Errored`) are preserved for
on-disk backward compatibility.

### Session log compaction

- `SessionLog::compress_old_sessions(keep_recent)` aggregates every
  session older than the most recent `keep_recent` into
  `session_summaries.json` (atomic `*.tmp` + rename **before**
  deleting originals), merging with any pre-existing aggregate on
  subsequent passes.
- `last_hint` falls back to the aggregate when no live file carries a
  hint, so post-compaction runs still see the most recent persisted
  hint.
- Filename choice: a single `session_summaries.json` rather than
  `session_NNN-MMM.summary.json` — see the new
  `summary_aggregate_path` doc comment for the rationale (simple
  merging across passes).

### Config

`[harness]` gains two knobs validated at load time:

```toml
[harness]
session_log_compress_after = 20          # >= 1
context_force_rotate_threshold = 0.95    # in (0.0, 1.0]
```

With env overrides `TMG_HARNESS_SESSION_LOG_COMPRESS_AFTER` and
`TMG_HARNESS_CONTEXT_FORCE_ROTATE_THRESHOLD`, both wired into the
runner from `run_tui`.

### TUI event channel

`RunProgressEvent::SessionEnded { trigger: SessionEndTrigger }` is
added to the existing enum. Wiring the banner UI consumer is
out-of-scope (#46) — this PR only surfaces the event so a future TUI
iteration can subscribe.

### Wiring into `run_tui`

- The post-turn observer now calls `maybe_force_rotate(usage)` after
  every `after_turn`. The live `clear_history` + `begin_session`
  hand-off needs the agent loop and TUI event loop to coordinate; that
  remains the #46 follow-up. Today the runner records the rotation
  intent and a `tracing::warn!` surfaces the deadline.
- The watchdog is armed when a harnessed session begins; ad-hoc TUI
  sessions inherit no wall-clock deadline.

### TODO captured in code

- LLM-generated session summary inside `end_session_with_rotation` —
  the compaction-turn machinery in `tmg-core` is not yet plumbed
  through, so the saved summary is whatever `session_summary_save` /
  the active session already carry. Comment in `runner.rs` flags this.

### Tests

Added in this PR (all passing):

- `maybe_force_rotate_fires_above_threshold` — 0.955 default trips.
- `maybe_force_rotate_below_threshold_returns_false` — sanity.
- `maybe_force_rotate_custom_threshold` — 0.5 threshold, 0.51/0.49.
- `maybe_force_rotate_handles_non_finite` — NaN, -1.0 ⇒ false.
- `set_context_force_rotate_threshold_clamps_garbage` — 0.0 / NaN /
  >1.0 reset / clamp.
- `end_session_with_rotation_context_starts_new_session` —
  acceptance: rotation closes session 1 with `ContextRotation`,
  publishes the event, and begins session 2.
- `end_session_with_rotation_all_triggers_drive_common_flow` — all
  four §9.4 triggers exercise the common flow; `UserExit` ends the
  run.
- `next_session_hint_round_trips_through_force_rotate` — hint set on
  session 1 is reachable via `last_hint` after rotation.
- `timeout_watchdog_fires_after_short_timeout` — 100ms watchdog
  delivers Timeout.
- `timeout_watchdog_can_be_disarmed` — disarm before sleep elapses
  swallows the trigger.
- `end_session_with_rotation_disarms_watchdog` — rotation cancels a
  late watchdog.
- `set_session_log_compress_after_clamps_zero` — 0 → 1.
- `compress_old_sessions_aggregates_oldest_keeps_recent` —
  acceptance: 25 sessions, `keep_recent = 20` ⇒ 1..=5 compacted into
  the aggregate, 6..=25 remain as live JSONs.
- `compress_old_sessions_no_op_when_below_keep_recent`.
- `compress_old_sessions_merges_into_existing_aggregate` — repeated
  passes accumulate.
- `compress_old_sessions_zero_keep_recent_compacts_all`.
- `last_hint_falls_back_to_aggregate`.
- `force_rotate_and_compress_after_load_from_toml`,
  `session_log_compress_after_zero_rejected`,
  `context_force_rotate_threshold_out_of_range_rejected`,
  `force_rotate_env_overrides_apply`,
  `force_rotate_env_override_bad_value_rejected`.

## Quality gates

- `cargo build --workspace` — pass
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` — pass
- `cargo fmt --all -- --check` — pass
- `cargo test --workspace` — 170 tests pass for tmg-harness, 72 for
  tmg-cli, no regressions across the workspace

### Runtime Verification

- LLM server: available
- One-shot mode: PASS
  - Events: 1 token, 0 tool calls, 0 errors. Event log
    `/tmp/tmg-verify-issue38-oneshot.jsonl` contains thinking deltas,
    a final `token` event, and a clean `done`.
- TUI mode: SKIP (the issue #38 changes do not affect the TUI render
  path; live banner integration is the #46 follow-up).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] One-shot smoke run with `--event-log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)