### PR TITLE
tmg-workflow: control-flow steps (loop / branch / parallel / group / human) (#40)

### DIFF
--- a/crates/tmg-workflow/src/def.rs
+++ b/crates/tmg-workflow/src/def.rs
@@ -4,7 +4,7 @@
 //! by the engine. Raw YAML is parsed into these via [`crate::parse`].
 //!
 //! Control-flow steps (`Loop`, `Branch`, `Parallel`, `Group`, `Human`)
-//! are explicitly out of scope for this iteration; see issue #40.
+//! were added in issue #40 and dispatch through [`crate::engine`].
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -47,7 +47,9 @@ pub struct InputDef {
 
 /// A single workflow step.
 ///
-/// Only `Agent`, `Shell`, and `WriteFile` are supported in this iteration.
+/// Leaf step types (`Agent`, `Shell`, `WriteFile`) execute directly;
+/// control-flow types (`Loop`, `Branch`, `Parallel`, `Group`, `Human`)
+/// recursively dispatch their children through the engine.
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum StepDef {
@@ -96,6 +98,99 @@ pub enum StepDef {
         /// File contents template.
         content: String,
     },
+
+    /// Iterate `steps` until `until` evaluates to `true` or
+    /// `max_iterations` is reached.
+    ///
+    /// The inner step ids are re-tagged per iteration as `id[1]`,
+    /// `id[2]`, ... so each iteration's `StepResult` is addressable
+    /// independently in `steps.<inner>[N]` lookups. The loop step's
+    /// own `StepResult` carries either `{"max_iterations_reached":
+    /// true}` (no `until` success) or `{"max_iterations_reached":
+    /// false, "iterations": N}` on a successful exit.
+    Loop {
+        /// Step identifier.
+        id: String,
+        /// Maximum number of iterations to run.
+        max_iterations: u32,
+        /// `${{ ... }}` boolean expression evaluated *after* each
+        /// iteration; iteration stops on `true`.
+        until: String,
+        /// Steps to execute on every iteration (in order).
+        steps: Vec<StepDef>,
+    },
+
+    /// Evaluate each `(when, steps)` pair in order; execute the steps
+    /// of the first pair whose `when` is truthy. If none match, run
+    /// `default` (or no-op when absent).
+    Branch {
+        /// Step identifier.
+        id: String,
+        /// `(when_expression, steps)` pairs. The first matching pair
+        /// wins; remaining pairs are not evaluated.
+        conditions: Vec<(String, Vec<StepDef>)>,
+        /// Optional fallback steps when no `conditions` match.
+        default: Option<Vec<StepDef>>,
+    },
+
+    /// Spawn each child step concurrently. Honours the
+    /// `[workflow] max_parallel_agents` cap (agent steps only); shell
+    /// and `write_file` steps are not capped.
+    Parallel {
+        /// Step identifier.
+        id: String,
+        /// Steps to execute concurrently.
+        steps: Vec<StepDef>,
+    },
+
+    /// Group multiple steps under a single failure policy.
+    Group {
+        /// Step identifier.
+        id: String,
+        /// What to do if any inner step fails.
+        on_failure: FailurePolicy,
+        /// Maximum retry count when `on_failure == Retry`. Ignored for
+        /// other policies.
+        max_retries: u32,
+        /// Steps to execute as a group.
+        steps: Vec<StepDef>,
+    },
+
+    /// Pause the workflow and ask the user (TUI / CLI) for a decision.
+    ///
+    /// The engine emits [`crate::progress::WorkflowProgress::HumanInputRequired`]
+    /// and awaits a [`crate::progress::HumanResponse`]. `revise`
+    /// rewinds workflow state to the snapshot taken before
+    /// `revise_target`'s execution and re-runs the workflow from that
+    /// step.
+    Human {
+        /// Step identifier.
+        id: String,
+        /// Prompt shown to the user.
+        message: String,
+        /// Optional `${{ ... }}` template rendered as additional
+        /// context (e.g. `${{ steps.ux_design.output }}`).
+        show: Option<String>,
+        /// Allowed response keywords (e.g. `["approve", "reject", "revise"]`).
+        options: Vec<String>,
+        /// Step id to rewind to when the user picks `revise`. Required
+        /// when `revise` is in `options`.
+        revise_target: Option<String>,
+    },
+}
+
+/// Failure handling policy for a [`StepDef::Group`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum FailurePolicy {
+    /// Propagate the inner failure upward and abort the workflow.
+    #[default]
+    Abort,
+    /// Retry the entire group up to `max_retries` times before giving up.
+    Retry,
+    /// Log the failure but continue running subsequent steps.
+    Continue,
 }
 
 impl StepDef {
@@ -103,7 +198,14 @@ impl StepDef {
     #[must_use]
     pub fn id(&self) -> &str {
         match self {
-            Self::Agent { id, .. } | Self::Shell { id, .. } | Self::WriteFile { id, .. } => id,
+            Self::Agent { id, .. }
+            | Self::Shell { id, .. }
+            | Self::WriteFile { id, .. }
+            | Self::Loop { id, .. }
+            | Self::Branch { id, .. }
+            | Self::Parallel { id, .. }
+            | Self::Group { id, .. }
+            | Self::Human { id, .. } => id,
         }
     }
 
@@ -114,6 +216,11 @@ impl StepDef {
             Self::Agent { .. } => "agent",
             Self::Shell { .. } => "shell",
             Self::WriteFile { .. } => "write_file",
+            Self::Loop { .. } => "loop",
+            Self::Branch { .. } => "branch",
+            Self::Parallel { .. } => "parallel",
+            Self::Group { .. } => "group",
+            Self::Human { .. } => "human",
         }
     }
 
@@ -122,8 +229,65 @@ impl StepDef {
     pub fn when(&self) -> Option<&str> {
         match self {
             Self::Agent { when, .. } | Self::Shell { when, .. } => when.as_deref(),
-            // write_file does not currently support `when` per SPEC §8.4.
-            Self::WriteFile { .. } => None,
+            // write_file / control-flow steps do not currently expose
+            // a `when` clause at the outer level — control flow steps
+            // express conditional execution via their own grammar
+            // (`until`, `conditions`, etc.), and `write_file` is
+            // intentionally always-on per SPEC §8.4.
+            Self::WriteFile { .. }
+            | Self::Loop { .. }
+            | Self::Branch { .. }
+            | Self::Parallel { .. }
+            | Self::Group { .. }
+            | Self::Human { .. } => None,
+        }
+    }
+
+    /// Re-tag this step's id (and recursively, child step ids) by
+    /// rewriting `id` to `f(id)`. Used by the loop runner to suffix
+    /// inner steps as `id[1]`, `id[2]`, ... per iteration.
+    ///
+    /// The function is applied once per step node visited; child step
+    /// ids are independent (each child sees its own original id).
+    pub(crate) fn retag_ids(&mut self, f: &impl Fn(&str) -> String) {
+        match self {
+            Self::Agent { id, .. }
+            | Self::Shell { id, .. }
+            | Self::WriteFile { id, .. }
+            | Self::Loop { id, .. }
+            | Self::Branch { id, .. }
+            | Self::Parallel { id, .. }
+            | Self::Group { id, .. }
+            | Self::Human { id, .. } => {
+                *id = f(id);
+            }
+        }
+        match self {
+            Self::Loop { steps, .. } | Self::Parallel { steps, .. } | Self::Group { steps, .. } => {
+                for s in steps {
+                    s.retag_ids(f);
+                }
+            }
+            Self::Branch {
+                conditions,
+                default,
+                ..
+            } => {
+                for (_, steps) in conditions {
+                    for s in steps {
+                        s.retag_ids(f);
+                    }
+                }
+                if let Some(default_steps) = default {
+                    for s in default_steps {
+                        s.retag_ids(f);
+                    }
+                }
+            }
+            Self::Agent { .. }
+            | Self::Shell { .. }
+            | Self::WriteFile { .. }
+            | Self::Human { .. } => {}
         }
     }
 }

--- a/crates/tmg-workflow/src/engine.rs
+++ b/crates/tmg-workflow/src/engine.rs
@@ -11,17 +11,25 @@
 //!
 //! ## Snapshot map for `revise` rewinds
 //!
-//! Before running every leaf step the engine snapshots the *current*
-//! `step_results` map (a `BTreeMap<String, StepResult>`) and stores it
-//! by step id in a side `snapshots` map. When a `human` step returns
-//! `revise { target: <step_id> }`, the engine restores
+//! Before running every top-level step the engine snapshots the
+//! *current* `step_results` map (a `BTreeMap<String, StepResult>`) and
+//! stores it by step id in a side `snapshots` map. When a `human` step
+//! returns `revise { target: <step_id> }`, the engine restores
 //! `step_results = snapshots[<step_id>]` and re-enters dispatch from
 //! the matching outer step.
 //!
-//! The memory cost is `O(steps × leaf_results_so_far)`. For typical
-//! workflows (≤ tens of steps with small JSON outputs) this is well
-//! under a megabyte and is *not* released until the engine returns.
-//! Long-running workflows that emit large step outputs should
+//! On every revise rewind we also *prune* `snapshots` of any entries
+//! belonging to indices `>= target_idx`. Those steps are about to
+//! re-run and will re-insert their own entries, so the prior snapshots
+//! would otherwise pile up across rewinds. With the
+//! pruning the snapshot map is bounded by `top_level_steps`
+//! independent of how many rewinds happen — the safety budget of 64
+//! rewinds is purely a runaway-revise guard, not a memory bound.
+//!
+//! The per-snapshot memory cost is `O(leaf_results_so_far)`. For
+//! typical workflows (≤ tens of steps with small JSON outputs) this is
+//! well under a megabyte and is *not* released until the engine
+//! returns. Long-running workflows that emit large step outputs should
 //! prefer placing `human` steps near the start so the snapshots stay
 //! small.
 //!
@@ -37,6 +45,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 use tokio::sync::{Mutex, mpsc};
+use tokio_util::sync::CancellationToken;
 
 use tmg_agents::SubagentManager;
 use tmg_llm::LlmPool;
@@ -75,6 +84,11 @@ pub(crate) struct EngineCtx {
     /// agent-type leaves; `shell`/`write_file` run uncapped (issue #40
     /// SPEC: "agent ステップだけがカウント対象").
     pub(crate) agent_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Workflow-level cancellation token. Currently only observed by
+    /// the `human` step (which would otherwise block forever waiting
+    /// for a UI response that never comes). Reserved for broader
+    /// graceful-shutdown plumbing in #42.
+    pub(crate) cancel: CancellationToken,
 }
 
 /// Workflow executor.
@@ -190,6 +204,7 @@ impl WorkflowEngine {
             inputs: Arc::new(inputs_value),
             progress_tx,
             agent_semaphore,
+            cancel: CancellationToken::new(),
         };
 
         let mut step_results: BTreeMap<String, StepResult> = BTreeMap::new();
@@ -242,6 +257,21 @@ impl WorkflowEngine {
                         });
                     };
                     step_results = snap;
+                    // Drop snapshots for steps at or beyond
+                    // `target_idx`; they are about to re-run and will
+                    // re-insert their own entries on the next loop
+                    // turn. Without this, repeated revises across a
+                    // long workflow would let `snapshots` grow
+                    // unbounded.
+                    let stale_ids: Vec<String> = workflow
+                        .steps
+                        .iter()
+                        .skip(target_idx)
+                        .map(|s| s.id().to_owned())
+                        .collect();
+                    for sid in stale_ids {
+                        snapshots.remove(&sid);
+                    }
                     idx = target_idx;
                 }
             }
@@ -386,19 +416,34 @@ async fn dispatch_step_inner(
             steps::write_file::execute(&ctx.sandbox, path, content, &eval_ctx).await
         }
         StepDef::Loop { .. } => {
-            return steps::loop_step::execute(ctx, step, step_results).await;
+            return retag_control_flow_error(
+                steps::loop_step::execute(ctx, step, step_results).await,
+                &step_id,
+            );
         }
         StepDef::Branch { .. } => {
-            return steps::branch::execute(ctx, step, step_results).await;
+            return retag_control_flow_error(
+                steps::branch::execute(ctx, step, step_results).await,
+                &step_id,
+            );
         }
         StepDef::Parallel { .. } => {
-            return steps::parallel::execute(ctx, step, step_results).await;
+            return retag_control_flow_error(
+                steps::parallel::execute(ctx, step, step_results).await,
+                &step_id,
+            );
         }
         StepDef::Group { .. } => {
-            return steps::group::execute(ctx, step, step_results).await;
+            return retag_control_flow_error(
+                steps::group::execute(ctx, step, step_results).await,
+                &step_id,
+            );
         }
         StepDef::Human { .. } => {
-            return steps::human::execute(ctx, step, step_results).await;
+            return retag_control_flow_error(
+                steps::human::execute(ctx, step, step_results).await,
+                &step_id,
+            );
         }
     };
 
@@ -439,6 +484,27 @@ async fn dispatch_step_inner(
             Err(err)
         }
     }
+}
+
+/// Re-tag an error returned by a control-flow handler so the propagated
+/// `WorkflowError` carries the control-flow step's own id (matching
+/// the `StepFailed` progress event the handler emitted on the same id
+/// — see fix #2 in PR review for #64). This keeps the error stream and
+/// the progress stream in agreement: the deepest leaf's `StepFailed`
+/// already named the leaf, and the outer control-flow's `StepFailed`
+/// names the outer step; the returned `WorkflowError` follows the
+/// outer name.
+fn retag_control_flow_error(result: Result<StepOutcome>, outer_id: &str) -> Result<StepOutcome> {
+    result.map_err(|e| match e {
+        WorkflowError::StepFailed { message, .. } => WorkflowError::StepFailed {
+            step_id: outer_id.to_owned(),
+            message,
+        },
+        other => WorkflowError::StepFailed {
+            step_id: outer_id.to_owned(),
+            message: other.to_string(),
+        },
+    })
 }
 
 /// Validate caller-supplied inputs against the workflow's declared

--- a/crates/tmg-workflow/src/engine.rs
+++ b/crates/tmg-workflow/src/engine.rs
@@ -1,17 +1,36 @@
-//! Sequential workflow executor.
+//! Workflow executor with full control-flow support.
 //!
 //! `WorkflowEngine` owns the shared resources needed by step handlers
 //! ([`tmg_llm::LlmPool`], [`tmg_sandbox::SandboxContext`],
 //! [`tmg_tools::ToolRegistry`], [`tmg_agents::SubagentManager`]) and
-//! drives the steps in declaration order. Per-step results are
-//! captured into a `BTreeMap<String, StepResult>` and made available
-//! to subsequent expressions via [`crate::expr::ExprContext`].
+//! drives the workflow steps recursively. Each leaf step (`agent`,
+//! `shell`, `write_file`) executes through its dedicated handler in
+//! [`crate::steps`]; control-flow steps (`loop`, `branch`, `parallel`,
+//! `group`, `human`) dispatch back through the engine on their child
+//! steps.
 //!
-//! This iteration is intentionally *sequential*: control-flow steps
-//! (`loop`, `branch`, `parallel`, `group`, `human`) are out of scope
-//! and tracked in issue #40. The engine returns at the first
-//! [`crate::error::WorkflowError::StepFailed`] event after emitting
-//! the corresponding progress message.
+//! ## Snapshot map for `revise` rewinds
+//!
+//! Before running every leaf step the engine snapshots the *current*
+//! `step_results` map (a `BTreeMap<String, StepResult>`) and stores it
+//! by step id in a side `snapshots` map. When a `human` step returns
+//! `revise { target: <step_id> }`, the engine restores
+//! `step_results = snapshots[<step_id>]` and re-enters dispatch from
+//! the matching outer step.
+//!
+//! The memory cost is `O(steps × leaf_results_so_far)`. For typical
+//! workflows (≤ tens of steps with small JSON outputs) this is well
+//! under a megabyte and is *not* released until the engine returns.
+//! Long-running workflows that emit large step outputs should
+//! prefer placing `human` steps near the start so the snapshots stay
+//! small.
+//!
+//! ## Cancellation safety
+//!
+//! Top-level `run` is cancel-safe at await points between leaf-step
+//! dispatches. Parallel steps own a private [`CancellationToken`] that
+//! the engine fires when any child fails so siblings observe the
+//! cancellation deterministically.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -31,7 +50,34 @@ use crate::expr;
 use crate::progress::WorkflowProgress;
 use crate::steps;
 
-/// Sequential workflow executor.
+/// Shared, cheaply-cloned engine resources passed down through every
+/// recursive dispatch.
+///
+/// We hold these by `Arc` (the engine owns the original `Arc`) so a
+/// `parallel` step can `clone` cheap handles into spawned tasks.
+#[derive(Clone)]
+pub(crate) struct EngineCtx {
+    /// Sandbox used for shell commands and `write_file` write checks.
+    pub(crate) sandbox: Arc<SandboxContext>,
+    /// Subagent manager used by agent steps.
+    pub(crate) subagent_manager: Arc<Mutex<SubagentManager>>,
+    /// Engine-level configuration (timeouts, default model, ...).
+    pub(crate) config: WorkflowConfig,
+    /// `tsumugi.toml`-derived configuration as JSON.
+    pub(crate) config_json: Value,
+    /// Snapshot of the process environment, captured once per run.
+    pub(crate) env: Arc<BTreeMap<String, String>>,
+    /// Workflow inputs, captured once per run.
+    pub(crate) inputs: Arc<Value>,
+    /// Progress sender. Cloned into spawned tasks when needed.
+    pub(crate) progress_tx: mpsc::Sender<WorkflowProgress>,
+    /// Semaphore capping concurrent agent steps. Counted only for
+    /// agent-type leaves; `shell`/`write_file` run uncapped (issue #40
+    /// SPEC: "agent ステップだけがカウント対象").
+    pub(crate) agent_semaphore: Arc<tokio::sync::Semaphore>,
+}
+
+/// Workflow executor.
 ///
 /// Constructed once per CLI run and reused across multiple workflow
 /// invocations.
@@ -40,10 +86,9 @@ pub struct WorkflowEngine {
     /// route through [`SubagentManager`] which owns its own client).
     #[expect(
         dead_code,
-        reason = "kept on the struct so the engine API matches SPEC §8.10 and so wiring can be re-used when parallel/long-running modes land (#40/#42)"
+        reason = "kept on the struct so the engine API matches SPEC §8.10 and so wiring can be re-used when the long-running mode lands (#42)"
     )]
     llm_pool: Arc<LlmPool>,
-    /// Sandbox used for shell commands and `write_file` write checks.
     sandbox: Arc<SandboxContext>,
     /// Tool registry. Reserved: built-in tool calls *from the engine*
     /// (e.g. `run_workflow`) will land in #41.
@@ -52,13 +97,23 @@ pub struct WorkflowEngine {
         reason = "kept on the struct so the engine API matches SPEC §8.10 and so the run_workflow tool (#41) can hook in without an API break"
     )]
     tool_registry: Arc<ToolRegistry>,
-    /// Subagent manager used by agent steps.
     subagent_manager: Arc<Mutex<SubagentManager>>,
-    /// Engine-level configuration (timeouts, default model, ...).
     config: WorkflowConfig,
-    /// `tsumugi.toml`-derived configuration as JSON, exposed to
-    /// expressions via the `config.*` scope.
     config_json: Value,
+}
+
+/// Outcome of executing a single step (leaf or control-flow).
+///
+/// `Revise` short-circuits all the way back up to `run` so the engine
+/// can rewind. The carrier is the *outer* target step id; the
+/// rewinder restores the snapshot taken before that step ran.
+#[derive(Debug)]
+pub(crate) enum StepOutcome {
+    /// Step completed; the result has already been written to the
+    /// shared `step_results` map.
+    Completed,
+    /// Step is requesting a workflow-wide rewind to `target`.
+    Revise { target: String },
 }
 
 impl WorkflowEngine {
@@ -96,16 +151,10 @@ impl WorkflowEngine {
     ///
     /// # Cancel safety
     ///
-    /// This future is cancel-safe at await points between steps; if
-    /// dropped mid-step the underlying step handler may finish (e.g.
-    /// the spawned subagent will continue until the manager's
-    /// cancellation token fires). Callers that need to cancel
-    /// promptly should fire the `CancellationToken` they passed to
-    /// `SubagentManager::new` and `SandboxContext`.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "linear step-dispatch loop; splitting into helpers would obscure the per-step state machine"
-    )]
+    /// This future is cancel-safe at await points between top-level
+    /// steps. Spawned `parallel` children honour an internal
+    /// `CancellationToken`; firing the token mid-dispatch will return
+    /// promptly with a [`WorkflowError::StepFailed`].
     pub async fn run(
         &self,
         workflow: &WorkflowDef,
@@ -121,117 +170,79 @@ impl WorkflowEngine {
         // ethos for agent contexts and gives deterministic re-runs.
         let env: BTreeMap<String, String> = std::env::vars().collect();
 
-        let mut steps_results: BTreeMap<String, StepResult> = BTreeMap::new();
+        // Cap agent concurrency at the configured ceiling. Permits are
+        // acquired by agent leaf-step handlers; shell/write_file
+        // leaves bypass the semaphore (per SPEC §8.4).
+        let agent_semaphore = Arc::new(tokio::sync::Semaphore::new(
+            self.config
+                .max_parallel_agents
+                .try_into()
+                .unwrap_or(1)
+                .max(1),
+        ));
 
-        for step in &workflow.steps {
+        let ctx = EngineCtx {
+            sandbox: Arc::clone(&self.sandbox),
+            subagent_manager: Arc::clone(&self.subagent_manager),
+            config: self.config.clone(),
+            config_json: self.config_json.clone(),
+            env: Arc::new(env),
+            inputs: Arc::new(inputs_value),
+            progress_tx,
+            agent_semaphore,
+        };
+
+        let mut step_results: BTreeMap<String, StepResult> = BTreeMap::new();
+        // `snapshots[step_id]` holds the `step_results` map *as it was
+        // immediately before* `step_id` started executing. On a
+        // `revise` decision we restore this map and re-enter dispatch
+        // at that step.
+        let mut snapshots: BTreeMap<String, BTreeMap<String, StepResult>> = BTreeMap::new();
+
+        // Main loop with revise-induced rewind support. We track the
+        // index in workflow.steps so a revise can reset it; a defensive
+        // `rewind_budget` prevents pathological human-loops.
+        let total_steps = workflow.steps.len();
+        let mut idx: usize = 0;
+        let mut rewind_budget: u32 = 64;
+        while idx < total_steps {
+            let step = &workflow.steps[idx];
             let step_id = step.id().to_owned();
-            let step_type = step.step_type();
+            // Snapshot before execution.
+            snapshots.insert(step_id.clone(), step_results.clone());
 
-            // Evaluate `when` clause, if any.
-            if let Some(expr_src) = step.when() {
-                let ctx =
-                    expr::ExprContext::new(&inputs_value, &steps_results, &self.config_json, &env);
-                let cond =
-                    expr::eval_bool(expr_src, &ctx).map_err(|e| WorkflowError::StepFailed {
-                        step_id: step_id.clone(),
-                        message: format!("when-expression error: {e}"),
-                    })?;
-                if !cond {
-                    tracing::debug!(step_id, "skipping step: when=false");
-                    continue;
-                }
-            }
+            let outcome = dispatch_step(&ctx, step, &mut step_results).await?;
 
-            // Best-effort: a closed receiver is not fatal.
-            let _ = progress_tx
-                .send(WorkflowProgress::StepStarted {
-                    step_id: step_id.clone(),
-                    step_type,
-                })
-                .await;
-
-            let ctx =
-                expr::ExprContext::new(&inputs_value, &steps_results, &self.config_json, &env);
-
-            let exec_result = match step {
-                StepDef::Agent {
-                    id: _,
-                    subagent,
-                    prompt,
-                    model,
-                    when: _,
-                    inject_files,
-                } => {
-                    steps::agent::execute(steps::agent::AgentStepArgs {
-                        subagent_manager: &self.subagent_manager,
-                        sandbox: &self.sandbox,
-                        step_id: &step_id,
-                        subagent_name: subagent,
-                        prompt_template: prompt,
-                        model: model.as_deref(),
-                        inject_files,
-                        ctx: &ctx,
-                    })
-                    .await
-                }
-                StepDef::Shell {
-                    id: _,
-                    command,
-                    timeout,
-                    when: _,
-                } => {
-                    steps::shell::execute(
-                        &self.sandbox,
-                        self.config.default_shell_timeout,
-                        command,
-                        *timeout,
-                        &ctx,
-                    )
-                    .await
-                }
-                StepDef::WriteFile {
-                    id: _,
-                    path,
-                    content,
-                } => steps::write_file::execute(&self.sandbox, path, content, &ctx).await,
-            };
-
-            // Re-tag every error returned by a step handler with the
-            // current `step_id` so the returned `WorkflowError` and
-            // the `StepFailed` progress event always agree on which
-            // step failed. Previously only `StepFailed` was re-tagged
-            // for shell steps; sandbox / IO / write-file errors leaked
-            // through without an id, diverging from the progress
-            // event. The wrap is uniform across step types.
-            let exec_result = exec_result.map_err(|e| match e {
-                WorkflowError::StepFailed { message, .. } => WorkflowError::StepFailed {
-                    step_id: step_id.clone(),
-                    message,
-                },
-                other => WorkflowError::StepFailed {
-                    step_id: step_id.clone(),
-                    message: other.to_string(),
-                },
-            });
-
-            match exec_result {
-                Ok(result) => {
-                    let _ = progress_tx
-                        .send(WorkflowProgress::StepCompleted {
+            match outcome {
+                StepOutcome::Completed => idx += 1,
+                StepOutcome::Revise { target } => {
+                    if rewind_budget == 0 {
+                        return Err(WorkflowError::StepFailed {
                             step_id: step_id.clone(),
-                            result: result.clone(),
-                        })
-                        .await;
-                    steps_results.insert(step_id, result);
-                }
-                Err(err) => {
-                    let _ = progress_tx
-                        .send(WorkflowProgress::StepFailed {
-                            step_id: step_id.clone(),
-                            error: err.to_string(),
-                        })
-                        .await;
-                    return Err(err);
+                            message: "revise rewind budget exhausted (>64 rewinds in one run)"
+                                .to_owned(),
+                        });
+                    }
+                    rewind_budget -= 1;
+                    let Some(target_idx) = workflow.steps.iter().position(|s| s.id() == target)
+                    else {
+                        return Err(WorkflowError::StepFailed {
+                            step_id,
+                            message: format!(
+                                "revise target '{target}' is not a top-level step in this workflow"
+                            ),
+                        });
+                    };
+                    let Some(snap) = snapshots.get(&target).cloned() else {
+                        return Err(WorkflowError::StepFailed {
+                            step_id,
+                            message: format!(
+                                "no snapshot recorded for revise target '{target}' (target must have run already)"
+                            ),
+                        });
+                    };
+                    step_results = snap;
+                    idx = target_idx;
                 }
             }
         }
@@ -239,21 +250,194 @@ impl WorkflowEngine {
         // Render outputs.
         let mut output_values: BTreeMap<String, String> = BTreeMap::new();
         for (name, template) in &workflow.outputs {
-            let ctx =
-                expr::ExprContext::new(&inputs_value, &steps_results, &self.config_json, &env);
-            let rendered = expr::eval_string(template, &ctx)?;
+            let inner_ctx =
+                expr::ExprContext::new(&ctx.inputs, &step_results, &ctx.config_json, &ctx.env);
+            let rendered = expr::eval_string(template, &inner_ctx)?;
             output_values.insert(name.clone(), rendered);
         }
         let outputs = WorkflowOutputs {
             values: output_values,
         };
-        let _ = progress_tx
+        let _ = ctx
+            .progress_tx
             .send(WorkflowProgress::WorkflowCompleted {
                 outputs: outputs.clone(),
             })
             .await;
 
         Ok(outputs)
+    }
+}
+
+/// Dispatch a single step (leaf or control-flow) into the appropriate
+/// handler. Updates `step_results` in place on success.
+///
+/// Returns a boxed `Send` future so recursive control-flow paths
+/// (loop / branch / parallel / group) can `Box::pin` the recursion
+/// without the compiler losing track of the `Send` bound across
+/// `tokio::spawn` boundaries.
+pub(crate) fn dispatch_step<'a>(
+    ctx: &'a EngineCtx,
+    step: &'a StepDef,
+    step_results: &'a mut BTreeMap<String, StepResult>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<StepOutcome>> + Send + 'a>> {
+    Box::pin(dispatch_step_inner(ctx, step, step_results))
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear per-variant dispatch; splitting would scatter the leaf-step matrix across helpers and obscure the StepOutcome flow"
+)]
+async fn dispatch_step_inner(
+    ctx: &EngineCtx,
+    step: &StepDef,
+    step_results: &mut BTreeMap<String, StepResult>,
+) -> Result<StepOutcome> {
+    let step_id = step.id().to_owned();
+    let step_type = step.step_type();
+
+    // Evaluate `when` clause for leaf steps that support it.
+    if let Some(expr_src) = step.when() {
+        let eval_ctx =
+            expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env);
+        let cond = expr::eval_bool(expr_src, &eval_ctx).map_err(|e| WorkflowError::StepFailed {
+            step_id: step_id.clone(),
+            message: format!("when-expression error: {e}"),
+        })?;
+        if !cond {
+            tracing::debug!(step_id, "skipping step: when=false");
+            return Ok(StepOutcome::Completed);
+        }
+    }
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::StepStarted {
+            step_id: step_id.clone(),
+            step_type,
+        })
+        .await;
+
+    let exec_result = match step {
+        StepDef::Agent {
+            id: _,
+            subagent,
+            prompt,
+            model,
+            when: _,
+            inject_files,
+        } => {
+            // Acquire agent permit; held only for the duration of this
+            // call. We must not hold the permit across recursive
+            // control-flow boundaries, so an agent leaf is the only
+            // place that takes one. Closing the semaphore is not
+            // expected here, so `acquire().await` returning an error
+            // would only happen if the engine itself dropped it — we
+            // map that to a clear `StepFailed`.
+            let permit = ctx
+                .agent_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|_| WorkflowError::StepFailed {
+                    step_id: step_id.clone(),
+                    message: "agent semaphore was closed".to_owned(),
+                })?;
+            let eval_ctx =
+                expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env);
+            let result = steps::agent::execute(steps::agent::AgentStepArgs {
+                subagent_manager: &ctx.subagent_manager,
+                sandbox: &ctx.sandbox,
+                step_id: &step_id,
+                subagent_name: subagent,
+                prompt_template: prompt,
+                model: model.as_deref(),
+                inject_files,
+                ctx: &eval_ctx,
+            })
+            .await;
+            drop(permit);
+            result
+        }
+        StepDef::Shell {
+            id: _,
+            command,
+            timeout,
+            when: _,
+        } => {
+            let eval_ctx =
+                expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env);
+            steps::shell::execute(
+                &ctx.sandbox,
+                ctx.config.default_shell_timeout,
+                command,
+                *timeout,
+                &eval_ctx,
+            )
+            .await
+        }
+        StepDef::WriteFile {
+            id: _,
+            path,
+            content,
+        } => {
+            let eval_ctx =
+                expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env);
+            steps::write_file::execute(&ctx.sandbox, path, content, &eval_ctx).await
+        }
+        StepDef::Loop { .. } => {
+            return steps::loop_step::execute(ctx, step, step_results).await;
+        }
+        StepDef::Branch { .. } => {
+            return steps::branch::execute(ctx, step, step_results).await;
+        }
+        StepDef::Parallel { .. } => {
+            return steps::parallel::execute(ctx, step, step_results).await;
+        }
+        StepDef::Group { .. } => {
+            return steps::group::execute(ctx, step, step_results).await;
+        }
+        StepDef::Human { .. } => {
+            return steps::human::execute(ctx, step, step_results).await;
+        }
+    };
+
+    // Re-tag every error returned by a leaf-step handler with the
+    // current `step_id` so the returned `WorkflowError` and the
+    // `StepFailed` progress event always agree.
+    let exec_result = exec_result.map_err(|e| match e {
+        WorkflowError::StepFailed { message, .. } => WorkflowError::StepFailed {
+            step_id: step_id.clone(),
+            message,
+        },
+        other => WorkflowError::StepFailed {
+            step_id: step_id.clone(),
+            message: other.to_string(),
+        },
+    });
+
+    match exec_result {
+        Ok(result) => {
+            let _ = ctx
+                .progress_tx
+                .send(WorkflowProgress::StepCompleted {
+                    step_id: step_id.clone(),
+                    result: result.clone(),
+                })
+                .await;
+            step_results.insert(step_id, result);
+            Ok(StepOutcome::Completed)
+        }
+        Err(err) => {
+            let _ = ctx
+                .progress_tx
+                .send(WorkflowProgress::StepFailed {
+                    step_id: step_id.clone(),
+                    error: err.to_string(),
+                })
+                .await;
+            Err(err)
+        }
     }
 }
 

--- a/crates/tmg-workflow/src/lib.rs
+++ b/crates/tmg-workflow/src/lib.rs
@@ -10,16 +10,17 @@
 //!   (priority-ordered, deduplicated by id).
 //! - [`expr`]: minimal `${{ ... }}` template / boolean / value
 //!   evaluator scoped over `inputs`, `steps`, `config`, and `env`.
-//! - [`engine::WorkflowEngine`]: sequential executor for the
-//!   `agent`, `shell`, and `write_file` step types.
+//! - [`engine::WorkflowEngine`]: workflow executor with full
+//!   control-flow dispatch (`agent`, `shell`, `write_file`, `loop`,
+//!   `branch`, `parallel`, `group`, `human`).
 //! - [`progress`]: progress events emitted during execution.
 //!
 //! ## Out of scope (this iteration)
 //!
-//! Control-flow steps (`loop`, `branch`, `parallel`, `group`, `human`)
-//! and the `run_workflow` tool are tracked separately in issues #40 and
-//! #41. The `WorkflowMode::LongRunning` placeholder parses correctly
-//! but executes identically to `Normal` until issue #42 lands.
+//! The `run_workflow` tool is tracked separately in issue #41. The
+//! `WorkflowMode::LongRunning` placeholder parses correctly but
+//! executes identically to `Normal` until issue #42 lands. TUI
+//! integration for `human` steps is tracked in issue #46.
 
 pub mod config;
 pub mod def;
@@ -33,11 +34,12 @@ pub(crate) mod steps;
 
 pub use config::WorkflowConfig;
 pub use def::{
-    InputDef, StepDef, StepResult, WorkflowDef, WorkflowMeta, WorkflowMode, WorkflowOutputs,
+    FailurePolicy, InputDef, StepDef, StepResult, WorkflowDef, WorkflowMeta, WorkflowMode,
+    WorkflowOutputs,
 };
 pub use discovery::discover_workflows;
 pub use engine::WorkflowEngine;
 pub use error::{Result, WorkflowError};
 pub use expr::{ExprContext, eval_bool, eval_string, eval_value};
 pub use parse::{parse_workflow_file, parse_workflow_str};
-pub use progress::WorkflowProgress;
+pub use progress::{HumanResponder, HumanResponse, HumanResponseKind, WorkflowProgress};

--- a/crates/tmg-workflow/src/parse.rs
+++ b/crates/tmg-workflow/src/parse.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use serde::Deserialize;
 
-use crate::def::{InputDef, StepDef, WorkflowDef, WorkflowMode};
+use crate::def::{FailurePolicy, InputDef, StepDef, WorkflowDef, WorkflowMode};
 use crate::error::{Result, WorkflowError};
 
 /// Identifier pattern enforced for workflow ids and step ids.
@@ -54,7 +54,7 @@ struct RawWorkflow {
     #[serde(default)]
     inputs: BTreeMap<String, RawInput>,
     #[serde(default)]
-    steps: Vec<RawStep>,
+    steps: Vec<RawStepOrRef>,
     #[serde(default)]
     outputs: BTreeMap<String, String>,
 }
@@ -75,6 +75,30 @@ struct RawInput {
 
 fn default_input_type() -> String {
     "string".to_owned()
+}
+
+/// A step entry — either a fully-specified step (with `id` + `type`)
+/// or a `ref:` to a previously-defined step (only meaningful inside a
+/// `loop`'s `steps:` block).
+///
+/// `Step` is boxed because [`RawStep`] is large and the unboxed
+/// variant size dominates the enum. Boxing keeps the parser allocation
+/// pattern stable when the supported step set grows.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawStepOrRef {
+    /// `{ ref: previous_step_id }` shorthand. Resolved at parse time
+    /// by cloning the referenced [`StepDef`] into the loop body.
+    Ref(RawStepRef),
+    /// Standard step definition.
+    Step(Box<RawStep>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawStepRef {
+    /// The id of a previously-declared step to clone in.
+    r#ref: String,
 }
 
 /// Permissive serde mirror for a step.
@@ -114,6 +138,48 @@ struct RawStep {
     path: Option<String>,
     #[serde(default)]
     content: Option<String>,
+
+    // Loop-only
+    #[serde(default)]
+    max_iterations: Option<u32>,
+    #[serde(default)]
+    until: Option<String>,
+    #[serde(default)]
+    steps: Option<Vec<RawStepOrRef>>,
+
+    // Branch-only
+    #[serde(default)]
+    conditions: Option<Vec<RawBranchCondition>>,
+    #[serde(default)]
+    default: Option<Vec<RawStepOrRef>>,
+
+    // Group-only
+    #[serde(default)]
+    on_failure: Option<String>,
+    #[serde(default)]
+    max_retries: Option<u32>,
+
+    // Human-only — kept inline to avoid a separate `with:` wrapper.
+    // SPEC §8.4 nests human-step fields under `with:` in the YAML, but
+    // since `flatten` here would conflict with `deny_unknown_fields`
+    // we accept them at the top level and document that.
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    show: Option<String>,
+    #[serde(default)]
+    options: Option<Vec<String>>,
+    #[serde(default)]
+    revise_target: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawBranchCondition {
+    /// `${{ ... }}` boolean expression (without surrounding braces).
+    when: String,
+    /// Steps to execute when `when` is truthy.
+    steps: Vec<RawStepOrRef>,
 }
 
 /// A timeout, accepted as either a number-of-seconds or a humantime-style
@@ -213,29 +279,24 @@ fn finalize_workflow(raw: RawWorkflow, path: &Path) -> Result<WorkflowDef> {
         );
     }
 
-    // Convert steps with id-uniqueness check.
+    // Convert top-level steps with id-uniqueness and `ref:`-availability checks.
+    //
+    // `registry` tracks every step id seen so far at the top level so a
+    // `loop` body can `ref:` them. Nested ids do *not* leak into the
+    // registry (a loop's inner steps are loop-scoped).
+    let mut registry: BTreeMap<String, StepDef> = BTreeMap::new();
     let mut seen_ids: BTreeSet<String> = BTreeSet::new();
     let mut steps: Vec<StepDef> = Vec::with_capacity(raw.steps.len());
-    for raw_step in raw.steps {
-        if raw_step.id.is_empty() {
+    for entry in raw.steps {
+        let RawStepOrRef::Step(raw_step) = entry else {
             return Err(WorkflowError::invalid_workflow(
                 &path_display,
-                "step ids must not be empty",
+                "top-level `ref:` is not allowed; `ref:` may only appear inside a `loop` step's `steps:` block",
             ));
-        }
-        if !is_valid_id(&raw_step.id) {
-            return Err(WorkflowError::invalid_workflow(
-                &path_display,
-                format!("step id '{}' must match {ID_PATTERN}", raw_step.id),
-            ));
-        }
-        if !seen_ids.insert(raw_step.id.clone()) {
-            return Err(WorkflowError::invalid_workflow(
-                &path_display,
-                format!("duplicate step id '{}'", raw_step.id),
-            ));
-        }
-        steps.push(convert_step(raw_step, &path_display)?);
+        };
+        let step = convert_step(*raw_step, &path_display, &mut seen_ids, &registry)?;
+        registry.insert(step.id().to_owned(), step.clone());
+        steps.push(step);
     }
 
     Ok(WorkflowDef {
@@ -252,7 +313,31 @@ fn finalize_workflow(raw: RawWorkflow, path: &Path) -> Result<WorkflowDef> {
     clippy::too_many_lines,
     reason = "linear per-step-type validation; splitting would scatter the supported-fields matrix across helpers"
 )]
-fn convert_step(raw: RawStep, path_display: &str) -> Result<StepDef> {
+fn convert_step(
+    raw: RawStep,
+    path_display: &str,
+    seen_ids: &mut BTreeSet<String>,
+    registry: &BTreeMap<String, StepDef>,
+) -> Result<StepDef> {
+    if raw.id.is_empty() {
+        return Err(WorkflowError::invalid_workflow(
+            path_display,
+            "step ids must not be empty",
+        ));
+    }
+    if !is_valid_id(&raw.id) {
+        return Err(WorkflowError::invalid_workflow(
+            path_display,
+            format!("step id '{}' must match {ID_PATTERN}", raw.id),
+        ));
+    }
+    if !seen_ids.insert(raw.id.clone()) {
+        return Err(WorkflowError::invalid_workflow(
+            path_display,
+            format!("duplicate step id '{}'", raw.id),
+        ));
+    }
+
     let RawStep {
         id,
         step_type,
@@ -265,6 +350,17 @@ fn convert_step(raw: RawStep, path_display: &str) -> Result<StepDef> {
         timeout,
         path,
         content,
+        max_iterations,
+        until,
+        steps: nested_steps,
+        conditions,
+        default,
+        on_failure,
+        max_retries,
+        message,
+        show,
+        options,
+        revise_target,
     } = raw;
 
     match step_type.as_str() {
@@ -294,6 +390,22 @@ fn convert_step(raw: RawStep, path_display: &str) -> Result<StepDef> {
                     format!("agent step '{id}' must not set write_file fields ('path'/'content')"),
                 ));
             }
+            forbid_control_flow_fields(
+                &id,
+                "agent",
+                path_display,
+                max_iterations,
+                &until,
+                &nested_steps,
+                &conditions,
+                &default,
+                &on_failure,
+                max_retries,
+                &message,
+                &show,
+                &options,
+                &revise_target,
+            )?;
 
             Ok(StepDef::Agent {
                 id,
@@ -323,6 +435,22 @@ fn convert_step(raw: RawStep, path_display: &str) -> Result<StepDef> {
                     format!("shell step '{id}' must not set write_file fields"),
                 ));
             }
+            forbid_control_flow_fields(
+                &id,
+                "shell",
+                path_display,
+                max_iterations,
+                &until,
+                &nested_steps,
+                &conditions,
+                &default,
+                &on_failure,
+                max_retries,
+                &message,
+                &show,
+                &options,
+                &revise_target,
+            )?;
             let timeout = match timeout {
                 Some(t) => Some(t.into_duration(&id)?),
                 None => None,
@@ -359,6 +487,22 @@ fn convert_step(raw: RawStep, path_display: &str) -> Result<StepDef> {
                     format!("write_file step '{id}' must not set agent or shell fields"),
                 ));
             }
+            forbid_control_flow_fields(
+                &id,
+                "write_file",
+                path_display,
+                max_iterations,
+                &until,
+                &nested_steps,
+                &conditions,
+                &default,
+                &on_failure,
+                max_retries,
+                &message,
+                &show,
+                &options,
+                &revise_target,
+            )?;
             if when.is_some() {
                 // SPEC §8.4 currently scopes `when` to agent/shell;
                 // reject explicitly so tooling does not assume it works.
@@ -371,13 +515,268 @@ fn convert_step(raw: RawStep, path_display: &str) -> Result<StepDef> {
             }
             Ok(StepDef::WriteFile { id, path, content })
         }
+        "loop" => {
+            let max_iterations = max_iterations.ok_or_else(|| {
+                WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("loop step '{id}' is missing required field 'max_iterations'"),
+                )
+            })?;
+            if max_iterations == 0 {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("loop step '{id}' max_iterations must be >= 1"),
+                ));
+            }
+            let until = until.ok_or_else(|| {
+                WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("loop step '{id}' is missing required field 'until'"),
+                )
+            })?;
+            let raw_steps = nested_steps.ok_or_else(|| {
+                WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("loop step '{id}' is missing required field 'steps'"),
+                )
+            })?;
+            if when.is_some() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("loop step '{id}' does not currently support 'when'"),
+                ));
+            }
+            // Inner steps are scoped to this loop. We use a *fresh*
+            // seen-set so a child can re-use a top-level id by `ref:`,
+            // but still detect duplicate inline ids inside the loop.
+            let mut inner_seen: BTreeSet<String> = BTreeSet::new();
+            let inner = resolve_steps(raw_steps, path_display, &mut inner_seen, registry)?;
+            Ok(StepDef::Loop {
+                id,
+                max_iterations,
+                until,
+                steps: inner,
+            })
+        }
+        "branch" => {
+            let raw_conditions = conditions.ok_or_else(|| {
+                WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("branch step '{id}' is missing required field 'conditions'"),
+                )
+            })?;
+            if raw_conditions.is_empty() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("branch step '{id}' must declare at least one condition"),
+                ));
+            }
+            let mut converted = Vec::with_capacity(raw_conditions.len());
+            for cond in raw_conditions {
+                let mut inner_seen: BTreeSet<String> = BTreeSet::new();
+                let body = resolve_steps(cond.steps, path_display, &mut inner_seen, registry)?;
+                converted.push((cond.when, body));
+            }
+            let default_steps = match default {
+                Some(raw) => {
+                    let mut inner_seen: BTreeSet<String> = BTreeSet::new();
+                    Some(resolve_steps(raw, path_display, &mut inner_seen, registry)?)
+                }
+                None => None,
+            };
+            Ok(StepDef::Branch {
+                id,
+                conditions: converted,
+                default: default_steps,
+            })
+        }
+        "parallel" => {
+            let raw_steps = nested_steps.ok_or_else(|| {
+                WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("parallel step '{id}' is missing required field 'steps'"),
+                )
+            })?;
+            if raw_steps.is_empty() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("parallel step '{id}' must declare at least one inner step"),
+                ));
+            }
+            let mut inner_seen: BTreeSet<String> = BTreeSet::new();
+            let inner = resolve_steps(raw_steps, path_display, &mut inner_seen, registry)?;
+            Ok(StepDef::Parallel { id, steps: inner })
+        }
+        "group" => {
+            let raw_steps = nested_steps.ok_or_else(|| {
+                WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("group step '{id}' is missing required field 'steps'"),
+                )
+            })?;
+            let policy = match on_failure.as_deref() {
+                None | Some("abort") => FailurePolicy::Abort,
+                Some("retry") => FailurePolicy::Retry,
+                Some("continue") => FailurePolicy::Continue,
+                Some(other) => {
+                    return Err(WorkflowError::invalid_workflow(
+                        path_display,
+                        format!(
+                            "group step '{id}' has unknown on_failure '{other}' (allowed: abort, retry, continue)"
+                        ),
+                    ));
+                }
+            };
+            let max_retries_value = max_retries.unwrap_or(0);
+            if matches!(policy, FailurePolicy::Retry) && max_retries_value == 0 {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!(
+                        "group step '{id}' has on_failure: retry but max_retries is 0 (must be >= 1)"
+                    ),
+                ));
+            }
+            let mut inner_seen: BTreeSet<String> = BTreeSet::new();
+            let inner = resolve_steps(raw_steps, path_display, &mut inner_seen, registry)?;
+            Ok(StepDef::Group {
+                id,
+                on_failure: policy,
+                max_retries: max_retries_value,
+                steps: inner,
+            })
+        }
+        "human" => {
+            let message = message.ok_or_else(|| {
+                WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("human step '{id}' is missing required field 'message'"),
+                )
+            })?;
+            let options =
+                options.unwrap_or_else(|| vec!["approve".to_owned(), "reject".to_owned()]);
+            // If `revise` is in `options`, the `revise_target` must be set.
+            if options.iter().any(|o| o == "revise") && revise_target.is_none() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!(
+                        "human step '{id}' lists 'revise' in options but is missing 'revise_target'"
+                    ),
+                ));
+            }
+            Ok(StepDef::Human {
+                id,
+                message,
+                show,
+                options,
+                revise_target,
+            })
+        }
         other => Err(WorkflowError::invalid_workflow(
             path_display,
             format!(
-                "unknown step type '{other}' for step '{id}' (supported: agent, shell, write_file; loop/branch/parallel/group/human are out of scope — see issue #40)"
+                "unknown step type '{other}' for step '{id}' (supported: agent, shell, write_file, loop, branch, parallel, group, human)"
             ),
         )),
     }
+}
+
+/// Resolve a `Vec<RawStepOrRef>` (typically a control-flow body) into
+/// a `Vec<StepDef>`. `ref:` entries are looked up in `registry` and
+/// cloned in. Inline entries are validated against `inner_seen`.
+fn resolve_steps(
+    raw: Vec<RawStepOrRef>,
+    path_display: &str,
+    inner_seen: &mut BTreeSet<String>,
+    registry: &BTreeMap<String, StepDef>,
+) -> Result<Vec<StepDef>> {
+    let mut out = Vec::with_capacity(raw.len());
+    for entry in raw {
+        match entry {
+            RawStepOrRef::Ref(r) => {
+                let Some(found) = registry.get(&r.r#ref) else {
+                    return Err(WorkflowError::invalid_workflow(
+                        path_display,
+                        format!(
+                            "ref: '{}' does not match any previously-defined step id",
+                            r.r#ref
+                        ),
+                    ));
+                };
+                // Cloning a leaf step is fine; a `ref:` to a control-flow
+                // step is rejected because re-running a loop / human /
+                // group inline raises ambiguity around id-disambiguation
+                // and snapshot ownership. Flag it now with a clear error.
+                match found {
+                    StepDef::Agent { .. } | StepDef::Shell { .. } | StepDef::WriteFile { .. } => {
+                        out.push(found.clone());
+                    }
+                    other => {
+                        return Err(WorkflowError::invalid_workflow(
+                            path_display,
+                            format!(
+                                "ref: '{}' resolves to a {} step; only agent/shell/write_file steps may be ref'd",
+                                r.r#ref,
+                                other.step_type()
+                            ),
+                        ));
+                    }
+                }
+            }
+            RawStepOrRef::Step(raw_step) => {
+                // Nested control-flow does not pollute the parent's
+                // step registry — fresh seen-set, but preserve the
+                // outer registry so `ref:` still resolves.
+                let step = convert_step(*raw_step, path_display, inner_seen, registry)?;
+                out.push(step);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Reject control-flow-only fields on leaf step types.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "validation needs every field; grouping into a struct would just shuffle the arguments"
+)]
+#[expect(
+    clippy::ref_option,
+    reason = "callers already hold the Option; passing &Option<T> avoids cloning the inner Vec/String"
+)]
+fn forbid_control_flow_fields(
+    id: &str,
+    step_type: &str,
+    path_display: &str,
+    max_iterations: Option<u32>,
+    until: &Option<String>,
+    nested_steps: &Option<Vec<RawStepOrRef>>,
+    conditions: &Option<Vec<RawBranchCondition>>,
+    default: &Option<Vec<RawStepOrRef>>,
+    on_failure: &Option<String>,
+    max_retries: Option<u32>,
+    message: &Option<String>,
+    show: &Option<String>,
+    options: &Option<Vec<String>>,
+    revise_target: &Option<String>,
+) -> Result<()> {
+    if max_iterations.is_some()
+        || until.is_some()
+        || nested_steps.is_some()
+        || conditions.is_some()
+        || default.is_some()
+        || on_failure.is_some()
+        || max_retries.is_some()
+        || message.is_some()
+        || show.is_some()
+        || options.is_some()
+        || revise_target.is_some()
+    {
+        return Err(WorkflowError::invalid_workflow(
+            path_display,
+            format!("{step_type} step '{id}' must not set control-flow fields"),
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -508,15 +907,15 @@ steps:
 id: bad
 steps:
   - id: s
-    type: parallel
+    type: mystery
     command: "true"
 "#;
         let err = parse_workflow_str(yaml, p()).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("unknown step type"), "{msg}");
-        // Mention the supported set + #40 reference.
+        // Mention the supported set.
         assert!(msg.contains("agent"));
-        assert!(msg.contains("issue #40"));
+        assert!(msg.contains("loop"));
     }
 
     #[test]
@@ -612,5 +1011,212 @@ steps: []
 ";
         let wf = parse_workflow_str(yaml, p()).unwrap();
         assert_eq!(wf.mode, WorkflowMode::LongRunning);
+    }
+
+    /// SPEC §8.4 `review_loop` sample: top-level steps + a loop body
+    /// that uses `ref:` to reuse previous shell steps.
+    #[test]
+    fn parses_spec_review_loop_sample() {
+        let yaml = r#"
+id: review_loop
+steps:
+  - id: verify
+    type: shell
+    command: "cargo test --workspace"
+  - id: fix_errors
+    type: shell
+    command: "echo fix"
+  - id: loop_step
+    type: loop
+    max_iterations: 3
+    until: "steps.verify.exit_code == 0"
+    steps:
+      - ref: verify
+      - ref: fix_errors
+"#;
+        let wf = parse_workflow_str(yaml, p()).unwrap();
+        assert_eq!(wf.steps.len(), 3);
+        match &wf.steps[2] {
+            StepDef::Loop {
+                id,
+                max_iterations,
+                until,
+                steps,
+            } => {
+                assert_eq!(id, "loop_step");
+                assert_eq!(*max_iterations, 3);
+                assert_eq!(until, "steps.verify.exit_code == 0");
+                assert_eq!(steps.len(), 2);
+                assert_eq!(steps[0].id(), "verify");
+                assert_eq!(steps[1].id(), "fix_errors");
+            }
+            other => panic!("expected Loop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_ref_to_unknown_id_fails() {
+        let yaml = r#"
+id: bad_ref
+steps:
+  - id: l
+    type: loop
+    max_iterations: 1
+    until: "true"
+    steps:
+      - ref: not_defined
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(err.to_string().contains("does not match"), "{}", err);
+    }
+
+    #[test]
+    fn parses_branch_with_default() {
+        let yaml = r#"
+id: bx
+steps:
+  - id: choose
+    type: branch
+    conditions:
+      - when: "inputs.flag == 1"
+        steps:
+          - id: a
+            type: shell
+            command: "echo a"
+      - when: "inputs.flag == 2"
+        steps:
+          - id: b
+            type: shell
+            command: "echo b"
+    default:
+      - id: c
+        type: shell
+        command: "echo c"
+"#;
+        let wf = parse_workflow_str(yaml, p()).unwrap();
+        match &wf.steps[0] {
+            StepDef::Branch {
+                conditions,
+                default,
+                ..
+            } => {
+                assert_eq!(conditions.len(), 2);
+                assert!(default.is_some());
+            }
+            _ => panic!("expected branch"),
+        }
+    }
+
+    #[test]
+    fn parses_parallel() {
+        let yaml = r#"
+id: par
+steps:
+  - id: p
+    type: parallel
+    steps:
+      - id: a
+        type: shell
+        command: "echo a"
+      - id: b
+        type: shell
+        command: "echo b"
+"#;
+        let wf = parse_workflow_str(yaml, p()).unwrap();
+        match &wf.steps[0] {
+            StepDef::Parallel { steps, .. } => assert_eq!(steps.len(), 2),
+            _ => panic!("expected parallel"),
+        }
+    }
+
+    #[test]
+    fn parses_group_retry_with_max_retries() {
+        let yaml = r#"
+id: g
+steps:
+  - id: grp
+    type: group
+    on_failure: retry
+    max_retries: 3
+    steps:
+      - id: s
+        type: shell
+        command: "true"
+"#;
+        let wf = parse_workflow_str(yaml, p()).unwrap();
+        match &wf.steps[0] {
+            StepDef::Group {
+                on_failure,
+                max_retries,
+                ..
+            } => {
+                assert_eq!(*on_failure, FailurePolicy::Retry);
+                assert_eq!(*max_retries, 3);
+            }
+            _ => panic!("expected group"),
+        }
+    }
+
+    #[test]
+    fn group_retry_without_max_retries_fails() {
+        let yaml = r#"
+id: g
+steps:
+  - id: grp
+    type: group
+    on_failure: retry
+    steps:
+      - id: s
+        type: shell
+        command: "true"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(err.to_string().contains("max_retries"), "{err}");
+    }
+
+    #[test]
+    fn parses_human_step_with_revise() {
+        let yaml = r#"
+id: hh
+steps:
+  - id: design
+    type: agent
+    subagent: worker
+    prompt: "design"
+  - id: review
+    type: human
+    message: "review the design"
+    show: "${{ steps.design.output }}"
+    options: [approve, reject, revise]
+    revise_target: design
+"#;
+        let wf = parse_workflow_str(yaml, p()).unwrap();
+        match &wf.steps[1] {
+            StepDef::Human {
+                message,
+                options,
+                revise_target,
+                ..
+            } => {
+                assert_eq!(message, "review the design");
+                assert_eq!(options.len(), 3);
+                assert_eq!(revise_target.as_deref(), Some("design"));
+            }
+            _ => panic!("expected human"),
+        }
+    }
+
+    #[test]
+    fn human_with_revise_but_no_target_fails() {
+        let yaml = r#"
+id: bad_human
+steps:
+  - id: r
+    type: human
+    message: "decide"
+    options: [approve, revise]
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(err.to_string().contains("revise_target"), "{err}");
     }
 }

--- a/crates/tmg-workflow/src/parse.rs
+++ b/crates/tmg-workflow/src/parse.rs
@@ -571,6 +571,12 @@ fn convert_step(
                     format!("branch step '{id}' must declare at least one condition"),
                 ));
             }
+            if when.is_some() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("branch step '{id}' does not currently support 'when'"),
+                ));
+            }
             let mut converted = Vec::with_capacity(raw_conditions.len());
             for cond in raw_conditions {
                 let mut inner_seen: BTreeSet<String> = BTreeSet::new();
@@ -601,6 +607,12 @@ fn convert_step(
                 return Err(WorkflowError::invalid_workflow(
                     path_display,
                     format!("parallel step '{id}' must declare at least one inner step"),
+                ));
+            }
+            if when.is_some() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("parallel step '{id}' does not currently support 'when'"),
                 ));
             }
             let mut inner_seen: BTreeSet<String> = BTreeSet::new();
@@ -636,6 +648,12 @@ fn convert_step(
                     ),
                 ));
             }
+            if when.is_some() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("group step '{id}' does not currently support 'when'"),
+                ));
+            }
             let mut inner_seen: BTreeSet<String> = BTreeSet::new();
             let inner = resolve_steps(raw_steps, path_display, &mut inner_seen, registry)?;
             Ok(StepDef::Group {
@@ -661,6 +679,39 @@ fn convert_step(
                     format!(
                         "human step '{id}' lists 'revise' in options but is missing 'revise_target'"
                     ),
+                ));
+            }
+            // `revise_target`, when set, must reference a top-level
+            // step id declared *above* this human step. Nested ids (in
+            // groups, loops, parallels, branches) are not supported as
+            // rewind targets because the engine's snapshot map only
+            // tracks top-level steps. Rejecting this at parse time
+            // prevents a class of UI bugs that would surface only at
+            // run time. The human step's own id (already inserted in
+            // `seen_ids` above) is also rejected — a self-revise would
+            // never terminate.
+            if let Some(target) = &revise_target {
+                if target == &id {
+                    return Err(WorkflowError::invalid_workflow(
+                        path_display,
+                        format!(
+                            "human step '{id}' has revise_target pointing at itself; pick a step declared above this human step"
+                        ),
+                    ));
+                }
+                if !seen_ids.contains(target) {
+                    return Err(WorkflowError::invalid_workflow(
+                        path_display,
+                        format!(
+                            "human step '{id}' has revise_target '{target}' which is not a top-level step declared before this human step (nested ids in group/loop/parallel/branch are not supported as revise targets)"
+                        ),
+                    ));
+                }
+            }
+            if when.is_some() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!("human step '{id}' does not currently support 'when'"),
                 ));
             }
             Ok(StepDef::Human {
@@ -1218,5 +1269,193 @@ steps:
 "#;
         let err = parse_workflow_str(yaml, p()).unwrap_err();
         assert!(err.to_string().contains("revise_target"), "{err}");
+    }
+
+    /// Fix #3: `revise_target` referencing a step nested inside a
+    /// group/loop/branch must be rejected at parse time, since the
+    /// engine snapshot map only tracks top-level steps.
+    #[test]
+    fn human_revise_target_nested_in_group_fails() {
+        let yaml = r#"
+id: bad_revise_nested
+steps:
+  - id: g
+    type: group
+    on_failure: abort
+    steps:
+      - id: inner
+        type: shell
+        command: "echo hi"
+  - id: r
+    type: human
+    message: "review"
+    options: [approve, revise]
+    revise_target: inner
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("revise_target") && msg.contains("top-level"),
+            "expected top-level message, got: {msg}"
+        );
+    }
+
+    /// Fix #3: `revise_target` referencing an undeclared id must be
+    /// rejected at parse time.
+    #[test]
+    fn human_revise_target_undeclared_fails() {
+        let yaml = r#"
+id: bad_revise_undeclared
+steps:
+  - id: design
+    type: shell
+    command: "echo design"
+  - id: r
+    type: human
+    message: "review"
+    options: [approve, revise]
+    revise_target: phantom
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("revise_target") && msg.contains("phantom"),
+            "expected phantom-not-declared message, got: {msg}"
+        );
+    }
+
+    /// Fix #3: `revise_target` referencing a top-level id declared
+    /// *above* the human step must succeed.
+    #[test]
+    fn human_revise_target_top_level_above_succeeds() {
+        let yaml = r#"
+id: ok_revise
+steps:
+  - id: design
+    type: shell
+    command: "echo design"
+  - id: r
+    type: human
+    message: "review"
+    options: [approve, revise]
+    revise_target: design
+"#;
+        let wf = parse_workflow_str(yaml, p()).unwrap();
+        match &wf.steps[1] {
+            StepDef::Human { revise_target, .. } => {
+                assert_eq!(revise_target.as_deref(), Some("design"));
+            }
+            _ => panic!("expected human"),
+        }
+    }
+
+    /// Fix #3: a self-referential `revise_target` should be rejected
+    /// since rewinding to the human step itself is meaningless.
+    #[test]
+    fn human_revise_target_self_fails() {
+        let yaml = r#"
+id: bad_self
+steps:
+  - id: r
+    type: human
+    message: "review"
+    options: [approve, revise]
+    revise_target: r
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(
+            err.to_string().contains("itself"),
+            "expected self-reference message, got: {err}"
+        );
+    }
+
+    /// Fix #4: `when:` on control-flow steps should be rejected
+    /// explicitly until we plumb evaluation through every variant.
+    #[test]
+    fn rejects_when_on_branch() {
+        let yaml = r#"
+id: br_when
+steps:
+  - id: b
+    type: branch
+    when: "true"
+    conditions:
+      - when: "true"
+        steps:
+          - id: a
+            type: shell
+            command: "true"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not currently support 'when'"),
+            "{err}"
+        );
+    }
+
+    /// Fix #4: `when:` on a parallel step should be rejected.
+    #[test]
+    fn rejects_when_on_parallel() {
+        let yaml = r#"
+id: par_when
+steps:
+  - id: p
+    type: parallel
+    when: "true"
+    steps:
+      - id: a
+        type: shell
+        command: "true"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not currently support 'when'"),
+            "{err}"
+        );
+    }
+
+    /// Fix #4: `when:` on a group step should be rejected.
+    #[test]
+    fn rejects_when_on_group() {
+        let yaml = r#"
+id: g_when
+steps:
+  - id: g
+    type: group
+    on_failure: abort
+    when: "true"
+    steps:
+      - id: a
+        type: shell
+        command: "true"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not currently support 'when'"),
+            "{err}"
+        );
+    }
+
+    /// Fix #4: `when:` on a human step should be rejected.
+    #[test]
+    fn rejects_when_on_human() {
+        let yaml = r#"
+id: h_when
+steps:
+  - id: r
+    type: human
+    message: "decide"
+    options: [approve, reject]
+    when: "true"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not currently support 'when'"),
+            "{err}"
+        );
     }
 }

--- a/crates/tmg-workflow/src/progress.rs
+++ b/crates/tmg-workflow/src/progress.rs
@@ -2,11 +2,26 @@
 //!
 //! `WorkflowProgress` is the canonical message type emitted on the
 //! channel passed to [`crate::engine::WorkflowEngine::run`]. The TUI
-//! layer (issue #41) will consume this stream to render live progress.
+//! layer (issue #46) will consume this stream to render live progress.
+
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, oneshot};
 
 use crate::def::{StepResult, WorkflowOutputs};
 
 /// Progress event emitted by the workflow engine.
+///
+/// ## Cloning trade-off for `HumanInputRequired`
+///
+/// The `response_tx` carried by [`WorkflowProgress::HumanInputRequired`]
+/// is wrapped in `Arc<Mutex<Option<oneshot::Sender<HumanResponse>>>>`.
+/// This is a deliberate trade-off so the entire enum can keep
+/// `derive(Clone)` (TUI / CLI consumers may broadcast events to
+/// multiple sinks). The downside is that the responder must `take()`
+/// the inner `Sender` before sending; double-take returns `None`,
+/// which the engine treats as "no responder will reply" and
+/// short-circuits with a `StepFailed`.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum WorkflowProgress {
@@ -14,7 +29,8 @@ pub enum WorkflowProgress {
     StepStarted {
         /// Step id.
         step_id: String,
-        /// Step type label (`"agent"`, `"shell"`, `"write_file"`).
+        /// Step type label (`"agent"`, `"shell"`, `"write_file"`,
+        /// `"loop"`, `"branch"`, `"parallel"`, `"group"`, `"human"`).
         step_type: &'static str,
     },
     /// A streaming chunk of stdout / agent text.
@@ -34,16 +50,109 @@ pub enum WorkflowProgress {
         /// Result captured from the step.
         result: StepResult,
     },
-    /// A step failed; the engine aborts the run after emitting this.
+    /// A step failed; the engine aborts the run after emitting this
+    /// (unless wrapped in a `Group` with `on_failure: continue`).
     StepFailed {
         /// Step id.
         step_id: String,
         /// Error message.
         error: String,
     },
+    /// A loop iteration just finished (or is about to begin) — emitted
+    /// at the start of every iteration so consumers can render
+    /// progress bars without inferring from inner step events.
+    LoopIteration {
+        /// The loop step's id.
+        step_id: String,
+        /// 1-based iteration counter.
+        iteration: u32,
+        /// Configured `max_iterations`.
+        max: u32,
+    },
+    /// The engine is paused on a `human` step waiting for a response.
+    ///
+    /// The receiver should call
+    /// `response_tx.lock().await.take()` to extract the one-shot
+    /// sender, then `send(HumanResponse { ... })`. Double-take returns
+    /// `None`; the engine treats that as a missing response and fails
+    /// the step.
+    HumanInputRequired {
+        /// The `human` step's id.
+        step_id: String,
+        /// Prompt to display.
+        message: String,
+        /// Allowed response keywords.
+        options: Vec<String>,
+        /// Optional rendered `show:` payload.
+        show: Option<String>,
+        /// One-shot reply channel (see type docs for the
+        /// take-once contract).
+        response_tx: HumanResponder,
+    },
     /// The workflow finished and produced its final outputs.
     WorkflowCompleted {
         /// Final outputs (each declared output rendered as a string).
         outputs: WorkflowOutputs,
     },
+}
+
+/// Take-once `oneshot::Sender` for human-input replies.
+///
+/// Wrapped in `Arc<Mutex<Option<...>>>` so [`WorkflowProgress`] can
+/// derive `Clone` while still respecting the underlying single-shot
+/// channel semantics.
+pub type HumanResponder = Arc<Mutex<Option<oneshot::Sender<HumanResponse>>>>;
+
+/// Decision returned by a UI in response to
+/// [`WorkflowProgress::HumanInputRequired`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HumanResponse {
+    /// The high-level decision.
+    pub kind: HumanResponseKind,
+    /// Required only when `kind == HumanResponseKind::Revise`. The
+    /// engine validates that this matches the human step's
+    /// `revise_target` (when set) or one of the previously-executed
+    /// step ids.
+    pub target: Option<String>,
+}
+
+impl HumanResponse {
+    /// Convenience constructor for an `approve` response.
+    #[must_use]
+    pub fn approve() -> Self {
+        Self {
+            kind: HumanResponseKind::Approve,
+            target: None,
+        }
+    }
+
+    /// Convenience constructor for a `reject` response.
+    #[must_use]
+    pub fn reject() -> Self {
+        Self {
+            kind: HumanResponseKind::Reject,
+            target: None,
+        }
+    }
+
+    /// Convenience constructor for a `revise` response targeting `step_id`.
+    #[must_use]
+    pub fn revise(step_id: impl Into<String>) -> Self {
+        Self {
+            kind: HumanResponseKind::Revise,
+            target: Some(step_id.into()),
+        }
+    }
+}
+
+/// Kinds of decisions a human responder may return.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HumanResponseKind {
+    /// Continue past the human step.
+    Approve,
+    /// Abort the workflow.
+    Reject,
+    /// Rewind to (and re-execute from) `target`.
+    Revise,
 }

--- a/crates/tmg-workflow/src/steps/branch.rs
+++ b/crates/tmg-workflow/src/steps/branch.rs
@@ -1,0 +1,100 @@
+//! `branch` step handler (SPEC §8.4).
+//!
+//! Evaluates each `(when, steps)` pair in order; the first pair whose
+//! `when` is truthy has its `steps` executed. If none match, the
+//! `default` body runs (when present); otherwise the branch is a
+//! no-op. The branch's own `StepResult` records which arm fired.
+
+use std::collections::BTreeMap;
+
+use serde_json::json;
+
+use crate::def::{StepDef, StepResult};
+use crate::engine::{EngineCtx, StepOutcome, dispatch_step};
+use crate::error::{Result, WorkflowError};
+use crate::expr;
+use crate::progress::WorkflowProgress;
+
+pub(crate) async fn execute(
+    ctx: &EngineCtx,
+    step: &StepDef,
+    step_results: &mut BTreeMap<String, StepResult>,
+) -> Result<StepOutcome> {
+    let StepDef::Branch {
+        id,
+        conditions,
+        default,
+    } = step
+    else {
+        return Err(WorkflowError::StepFailed {
+            step_id: step.id().to_owned(),
+            message: "internal error: branch::execute called with non-branch step".to_owned(),
+        });
+    };
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::StepStarted {
+            step_id: id.clone(),
+            step_type: "branch",
+        })
+        .await;
+
+    let mut chosen_arm: Option<usize> = None;
+
+    for (idx, (when_expr, _)) in conditions.iter().enumerate() {
+        let inner_ctx =
+            expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env);
+        let cond =
+            expr::eval_bool(when_expr, &inner_ctx).map_err(|e| WorkflowError::StepFailed {
+                step_id: id.clone(),
+                message: format!("when-expression error in branch arm {idx}: {e}"),
+            })?;
+        if cond {
+            chosen_arm = Some(idx);
+            break;
+        }
+    }
+
+    let body: Option<&Vec<StepDef>> = match chosen_arm {
+        Some(idx) => Some(&conditions[idx].1),
+        None => default.as_ref(),
+    };
+
+    let arm_label: String = match (chosen_arm, default) {
+        (Some(idx), _) => format!("arm_{idx}"),
+        (None, Some(_)) => "default".to_owned(),
+        (None, None) => "noop".to_owned(),
+    };
+
+    if let Some(steps) = body {
+        for inner in steps {
+            let outcome = dispatch_step(ctx, inner, step_results).await?;
+            if let StepOutcome::Revise { target } = outcome {
+                return Ok(StepOutcome::Revise { target });
+            }
+        }
+    }
+
+    let result = StepResult {
+        output: json!({
+            "matched": arm_label,
+            "matched_index": chosen_arm,
+        }),
+        exit_code: 0,
+        stdout: String::new(),
+        stderr: String::new(),
+        changed_files: Vec::new(),
+    };
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::StepCompleted {
+            step_id: id.clone(),
+            result: result.clone(),
+        })
+        .await;
+    step_results.insert(id.clone(), result);
+
+    Ok(StepOutcome::Completed)
+}

--- a/crates/tmg-workflow/src/steps/branch.rs
+++ b/crates/tmg-workflow/src/steps/branch.rs
@@ -32,13 +32,9 @@ pub(crate) async fn execute(
         });
     };
 
-    let _ = ctx
-        .progress_tx
-        .send(WorkflowProgress::StepStarted {
-            step_id: id.clone(),
-            step_type: "branch",
-        })
-        .await;
+    // NOTE: `StepStarted` is emitted by `engine::dispatch_step_inner`
+    // for every step before delegating to the per-type handler;
+    // emitting it again here would deliver duplicates.
 
     let mut chosen_arm: Option<usize> = None;
 
@@ -69,7 +65,23 @@ pub(crate) async fn execute(
 
     if let Some(steps) = body {
         for inner in steps {
-            let outcome = dispatch_step(ctx, inner, step_results).await?;
+            // On failure, the inner leaf has already emitted its own
+            // `StepFailed`; we additionally emit a `StepFailed` for
+            // the *branch* so a consumer can render the branch as
+            // failed and not just the leaf.
+            let outcome = match dispatch_step(ctx, inner, step_results).await {
+                Ok(outcome) => outcome,
+                Err(err) => {
+                    let _ = ctx
+                        .progress_tx
+                        .send(WorkflowProgress::StepFailed {
+                            step_id: id.clone(),
+                            error: err.to_string(),
+                        })
+                        .await;
+                    return Err(err);
+                }
+            };
             if let StepOutcome::Revise { target } = outcome {
                 return Ok(StepOutcome::Revise { target });
             }

--- a/crates/tmg-workflow/src/steps/group.rs
+++ b/crates/tmg-workflow/src/steps/group.rs
@@ -27,10 +27,6 @@ use crate::engine::{EngineCtx, StepOutcome, dispatch_step};
 use crate::error::{Result, WorkflowError};
 use crate::progress::WorkflowProgress;
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "linear retry/abort/continue dispatch; splitting would scatter the per-policy match arms across helpers"
-)]
 pub(crate) async fn execute(
     ctx: &EngineCtx,
     step: &StepDef,
@@ -49,13 +45,9 @@ pub(crate) async fn execute(
         });
     };
 
-    let _ = ctx
-        .progress_tx
-        .send(WorkflowProgress::StepStarted {
-            step_id: id.clone(),
-            step_type: "group",
-        })
-        .await;
+    // NOTE: `StepStarted` is emitted by `engine::dispatch_step_inner`
+    // for every step before delegating to the per-type handler;
+    // emitting it again here would deliver duplicates.
 
     let pre_snapshot = step_results.clone();
 

--- a/crates/tmg-workflow/src/steps/group.rs
+++ b/crates/tmg-workflow/src/steps/group.rs
@@ -1,0 +1,155 @@
+//! `group` step handler (SPEC §8.4).
+//!
+//! Bundles multiple steps under one of three failure policies:
+//!
+//! - [`FailurePolicy::Abort`] (default): an inner failure propagates.
+//! - [`FailurePolicy::Retry`]: re-run the *entire* group on inner
+//!   failure, up to `max_retries` times.
+//! - [`FailurePolicy::Continue`]: log the failure, mark the group's
+//!   own `StepResult` as `failed`, and continue past the group.
+//!
+//! ## Retry semantics
+//!
+//! When retrying, the engine *restores* `step_results` to the
+//! pre-group snapshot before each attempt. Without this, a partially
+//! successful first attempt would leave inner-step results in place
+//! that subsequent attempts could observe via `${{ steps.* }}` and
+//! derive incorrect decisions from. The snapshot is captured locally
+//! in this handler — the engine-level `snapshots` map is reserved for
+//! revise rewinds across `human` boundaries.
+
+use std::collections::BTreeMap;
+
+use serde_json::json;
+
+use crate::def::{FailurePolicy, StepDef, StepResult};
+use crate::engine::{EngineCtx, StepOutcome, dispatch_step};
+use crate::error::{Result, WorkflowError};
+use crate::progress::WorkflowProgress;
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear retry/abort/continue dispatch; splitting would scatter the per-policy match arms across helpers"
+)]
+pub(crate) async fn execute(
+    ctx: &EngineCtx,
+    step: &StepDef,
+    step_results: &mut BTreeMap<String, StepResult>,
+) -> Result<StepOutcome> {
+    let StepDef::Group {
+        id,
+        on_failure,
+        max_retries,
+        steps: body,
+    } = step
+    else {
+        return Err(WorkflowError::StepFailed {
+            step_id: step.id().to_owned(),
+            message: "internal error: group::execute called with non-group step".to_owned(),
+        });
+    };
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::StepStarted {
+            step_id: id.clone(),
+            step_type: "group",
+        })
+        .await;
+
+    let pre_snapshot = step_results.clone();
+
+    let mut attempts: u32 = 0;
+    let max_attempts = match on_failure {
+        FailurePolicy::Retry => max_retries.saturating_add(1),
+        FailurePolicy::Abort | FailurePolicy::Continue => 1,
+    };
+
+    let mut last_error: Option<WorkflowError> = None;
+
+    'outer: while attempts < max_attempts {
+        attempts += 1;
+        // Restore pre-snapshot before each attempt (no-op on attempt 1).
+        if attempts > 1 {
+            *step_results = pre_snapshot.clone();
+        }
+
+        for inner in body {
+            match dispatch_step(ctx, inner, step_results).await {
+                Ok(StepOutcome::Completed) => {}
+                Ok(StepOutcome::Revise { target }) => {
+                    return Ok(StepOutcome::Revise { target });
+                }
+                Err(err) => {
+                    tracing::debug!(group = id, attempt = attempts, %err, "group inner step failed");
+                    last_error = Some(err);
+                    continue 'outer;
+                }
+            }
+        }
+        // All inner steps passed — exit early.
+        last_error = None;
+        break;
+    }
+
+    match (last_error, on_failure) {
+        (None, _) => {
+            let result = StepResult {
+                output: json!({"attempts": attempts, "ok": true}),
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+                changed_files: Vec::new(),
+            };
+            let _ = ctx
+                .progress_tx
+                .send(WorkflowProgress::StepCompleted {
+                    step_id: id.clone(),
+                    result: result.clone(),
+                })
+                .await;
+            step_results.insert(id.clone(), result);
+            Ok(StepOutcome::Completed)
+        }
+        (Some(err), FailurePolicy::Continue) => {
+            tracing::warn!(group = id, %err, "group failed under on_failure: continue");
+            // Restore the pre-group snapshot so subsequent steps don't
+            // observe a half-applied failed group.
+            *step_results = pre_snapshot;
+            let result = StepResult {
+                output: json!({
+                    "attempts": attempts,
+                    "ok": false,
+                    "error": err.to_string(),
+                }),
+                exit_code: 1,
+                stdout: String::new(),
+                stderr: err.to_string(),
+                changed_files: Vec::new(),
+            };
+            // Emit a `StepCompleted` (not `StepFailed`) — the *group*
+            // succeeded by absorbing the failure, even though its
+            // inner work did not. Callers that want to discriminate
+            // can read `result.exit_code`.
+            let _ = ctx
+                .progress_tx
+                .send(WorkflowProgress::StepCompleted {
+                    step_id: id.clone(),
+                    result: result.clone(),
+                })
+                .await;
+            step_results.insert(id.clone(), result);
+            Ok(StepOutcome::Completed)
+        }
+        (Some(err), FailurePolicy::Abort | FailurePolicy::Retry) => {
+            let _ = ctx
+                .progress_tx
+                .send(WorkflowProgress::StepFailed {
+                    step_id: id.clone(),
+                    error: err.to_string(),
+                })
+                .await;
+            Err(err)
+        }
+    }
+}

--- a/crates/tmg-workflow/src/steps/human.rs
+++ b/crates/tmg-workflow/src/steps/human.rs
@@ -52,13 +52,9 @@ pub(crate) async fn execute(
         });
     };
 
-    let _ = ctx
-        .progress_tx
-        .send(WorkflowProgress::StepStarted {
-            step_id: id.clone(),
-            step_type: "human",
-        })
-        .await;
+    // NOTE: `StepStarted` is emitted by `engine::dispatch_step_inner`
+    // for every step before delegating to the per-type handler;
+    // emitting it again here would deliver duplicates.
 
     // Render the prompt and `show:` payload eagerly so the receiver
     // sees the substituted values, not the raw template.
@@ -84,11 +80,33 @@ pub(crate) async fn execute(
         .await;
 
     // Await the response. `recv` errors when the sender is dropped
-    // without a value — surface that as a clear `StepFailed`.
-    let response = rx.await.map_err(|_| WorkflowError::StepFailed {
-        step_id: id.clone(),
-        message: "human input channel was dropped before a response arrived".to_owned(),
-    })?;
+    // without a value — surface that as a clear `StepFailed`. We also
+    // honour the engine-level cancellation token so a workflow
+    // never blocks forever when the UI consumer goes away without
+    // responding.
+    let response = tokio::select! {
+        biased;
+        () = ctx.cancel.cancelled() => {
+            let err = WorkflowError::StepFailed {
+                step_id: id.clone(),
+                message: "human step cancelled".to_owned(),
+            };
+            let _ = ctx
+                .progress_tx
+                .send(WorkflowProgress::StepFailed {
+                    step_id: id.clone(),
+                    error: err.to_string(),
+                })
+                .await;
+            return Err(err);
+        }
+        recv = rx => {
+            recv.map_err(|_| WorkflowError::StepFailed {
+                step_id: id.clone(),
+                message: "human input channel was dropped before a response arrived".to_owned(),
+            })?
+        }
+    };
 
     match response.kind {
         HumanResponseKind::Approve => {

--- a/crates/tmg-workflow/src/steps/human.rs
+++ b/crates/tmg-workflow/src/steps/human.rs
@@ -1,0 +1,159 @@
+//! `human` step handler (SPEC §8.4).
+//!
+//! Emits [`WorkflowProgress::HumanInputRequired`] with a one-shot
+//! responder, awaits the [`HumanResponse`], and translates the
+//! response into the appropriate [`StepOutcome`]:
+//!
+//! - `approve` -> `Completed` (workflow continues past this step).
+//! - `reject` -> bubble up a [`WorkflowError::StepFailed`] so the
+//!   engine aborts.
+//! - `revise` -> [`StepOutcome::Revise`] carrying the target step id;
+//!   the engine rewinds to the snapshot captured before that step.
+//!
+//! ## TUI integration
+//!
+//! The TUI / CLI consumer is responsible for `take()`-ing the
+//! [`oneshot::Sender`] from the wrapped responder and `send`-ing a
+//! [`HumanResponse`]. Tests in this crate drive the responder
+//! directly (no TUI dependency).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use serde_json::json;
+use tokio::sync::{Mutex, oneshot};
+
+use crate::def::{StepDef, StepResult};
+use crate::engine::{EngineCtx, StepOutcome};
+use crate::error::{Result, WorkflowError};
+use crate::expr;
+use crate::progress::{HumanResponseKind, WorkflowProgress};
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear approve/reject/revise dispatch; splitting would scatter the per-decision branches"
+)]
+pub(crate) async fn execute(
+    ctx: &EngineCtx,
+    step: &StepDef,
+    step_results: &mut BTreeMap<String, StepResult>,
+) -> Result<StepOutcome> {
+    let StepDef::Human {
+        id,
+        message,
+        show,
+        options,
+        revise_target,
+    } = step
+    else {
+        return Err(WorkflowError::StepFailed {
+            step_id: step.id().to_owned(),
+            message: "internal error: human::execute called with non-human step".to_owned(),
+        });
+    };
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::StepStarted {
+            step_id: id.clone(),
+            step_type: "human",
+        })
+        .await;
+
+    // Render the prompt and `show:` payload eagerly so the receiver
+    // sees the substituted values, not the raw template.
+    let inner_ctx = expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env);
+    let rendered_message = expr::eval_string(message, &inner_ctx)?;
+    let rendered_show = match show {
+        Some(template) => Some(expr::eval_string(template, &inner_ctx)?),
+        None => None,
+    };
+
+    let (tx, rx) = oneshot::channel::<crate::progress::HumanResponse>();
+    let responder = Arc::new(Mutex::new(Some(tx)));
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::HumanInputRequired {
+            step_id: id.clone(),
+            message: rendered_message,
+            options: options.clone(),
+            show: rendered_show,
+            response_tx: Arc::clone(&responder),
+        })
+        .await;
+
+    // Await the response. `recv` errors when the sender is dropped
+    // without a value — surface that as a clear `StepFailed`.
+    let response = rx.await.map_err(|_| WorkflowError::StepFailed {
+        step_id: id.clone(),
+        message: "human input channel was dropped before a response arrived".to_owned(),
+    })?;
+
+    match response.kind {
+        HumanResponseKind::Approve => {
+            let result = StepResult {
+                output: json!({"decision": "approve"}),
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+                changed_files: Vec::new(),
+            };
+            let _ = ctx
+                .progress_tx
+                .send(WorkflowProgress::StepCompleted {
+                    step_id: id.clone(),
+                    result: result.clone(),
+                })
+                .await;
+            step_results.insert(id.clone(), result);
+            Ok(StepOutcome::Completed)
+        }
+        HumanResponseKind::Reject => {
+            let err = WorkflowError::StepFailed {
+                step_id: id.clone(),
+                message: "human reviewer rejected the workflow".to_owned(),
+            };
+            let _ = ctx
+                .progress_tx
+                .send(WorkflowProgress::StepFailed {
+                    step_id: id.clone(),
+                    error: err.to_string(),
+                })
+                .await;
+            Err(err)
+        }
+        HumanResponseKind::Revise => {
+            // Resolve the target. Prefer the response's explicit target,
+            // falling back to the human step's declared `revise_target`.
+            let target = response
+                .target
+                .clone()
+                .or_else(|| revise_target.clone())
+                .ok_or_else(|| WorkflowError::StepFailed {
+                    step_id: id.clone(),
+                    message: "human response 'revise' supplied no target and the human step has no revise_target"
+                        .to_owned(),
+                })?;
+            // Optional sanity: if the human step *does* declare a
+            // revise_target, restrict the response to that single id.
+            // Without this a UI bug could rewind to an unintended step.
+            if let Some(declared) = revise_target {
+                if response.target.is_some() && response.target.as_ref() != Some(declared) {
+                    return Err(WorkflowError::StepFailed {
+                        step_id: id.clone(),
+                        message: format!(
+                            "revise target '{}' does not match declared revise_target '{declared}'",
+                            response.target.as_deref().unwrap_or("<none>")
+                        ),
+                    });
+                }
+            }
+            // Note: we intentionally do NOT insert a `StepCompleted` /
+            // step_results entry for this human step on `revise` —
+            // the engine will re-enter the workflow from `target` and
+            // the human step itself will be re-run later.
+            Ok(StepOutcome::Revise { target })
+        }
+    }
+}

--- a/crates/tmg-workflow/src/steps/loop_step.rs
+++ b/crates/tmg-workflow/src/steps/loop_step.rs
@@ -51,13 +51,10 @@ pub(crate) async fn execute(
         });
     };
 
-    let _ = ctx
-        .progress_tx
-        .send(WorkflowProgress::StepStarted {
-            step_id: id.clone(),
-            step_type: "loop",
-        })
-        .await;
+    // NOTE: `StepStarted` is emitted for *every* step (including
+    // control-flow steps) by `engine::dispatch_step_inner` before this
+    // handler is invoked. Emitting again here would surface as a
+    // duplicate event to consumers. See engine.rs.
 
     let mut completed = 0u32;
     let mut hit_until = false;
@@ -85,8 +82,23 @@ pub(crate) async fn execute(
             // Dispatch the iteration-tagged step. Its result is stored
             // under the tagged id; we then mirror it under the bare
             // id (without the suffix) so the loop's `until:` can refer
-            // to it naturally.
-            let outcome = dispatch_step(ctx, &tagged, step_results).await?;
+            // to it naturally. On failure, the inner leaf has already
+            // emitted its own `StepFailed`; we additionally emit a
+            // `StepFailed` for the *loop* so a TUI consumer can show
+            // the loop as failed and not just the leaf.
+            let outcome = match dispatch_step(ctx, &tagged, step_results).await {
+                Ok(outcome) => outcome,
+                Err(err) => {
+                    let _ = ctx
+                        .progress_tx
+                        .send(WorkflowProgress::StepFailed {
+                            step_id: id.clone(),
+                            error: err.to_string(),
+                        })
+                        .await;
+                    return Err(err);
+                }
+            };
             // Loop bodies don't propagate Revise through to the engine
             // — a `human` inside a loop body that asks for revise
             // tries to rewind to a target outside the loop, which we
@@ -107,6 +119,12 @@ pub(crate) async fn execute(
             // already write their own ids into `step_results` and the
             // parser forbids `ref:`-ing them, so they cannot reach
             // this branch in practice. Guard defensively anyway.
+            //
+            // When the tagged id was *not* written this iteration
+            // (e.g. the inner leaf was skipped via `when=false`), we
+            // remove the bare id rather than preserving iteration
+            // N-1's value. Otherwise `until:` (which reads the bare
+            // id) would observe stale data and could exit early.
             if matches!(
                 inner,
                 StepDef::Agent { .. } | StepDef::Shell { .. } | StepDef::WriteFile { .. }
@@ -115,6 +133,8 @@ pub(crate) async fn execute(
                 let tagged_id = format!("{bare_id}{suffix}");
                 if let Some(latest) = step_results.get(&tagged_id).cloned() {
                     step_results.insert(bare_id.to_owned(), latest);
+                } else {
+                    step_results.remove(bare_id);
                 }
             }
         }

--- a/crates/tmg-workflow/src/steps/loop_step.rs
+++ b/crates/tmg-workflow/src/steps/loop_step.rs
@@ -1,0 +1,158 @@
+//! `loop` step handler (SPEC §8.4).
+//!
+//! Iterates the inner step list up to `max_iterations` times,
+//! evaluating `until` after each iteration and exiting when it
+//! becomes truthy. Inner step ids are *re-tagged* per iteration
+//! (`id[1]`, `id[2]`, ...) so each iteration's [`StepResult`] is
+//! independently addressable in `steps.<inner>[N]`-style lookups via
+//! the `[]` indexing syntax.
+//!
+//! ## Re-tagging convention
+//!
+//! Given an inner step `verify`, iteration 1 stores its result under
+//! `verify[1]`, iteration 2 under `verify[2]`, etc. The most recent
+//! iteration's result is *also* stored under the bare id `verify` so
+//! the loop's own `until:` expression can refer to
+//! `steps.verify.exit_code` without iteration arithmetic. The mirror
+//! is overwritten each iteration; only the most recent is preserved.
+//!
+//! ## Result shape
+//!
+//! - On `until` success: `output = {"max_iterations_reached": false,
+//!   "iterations": N}` where N is the 1-based iteration count.
+//! - On `max_iterations` reached without `until` succeeding: `output =
+//!   {"max_iterations_reached": true, "iterations": max_iterations}`.
+
+use std::collections::BTreeMap;
+
+use serde_json::json;
+
+use crate::def::{StepDef, StepResult};
+use crate::engine::{EngineCtx, StepOutcome, dispatch_step};
+use crate::error::{Result, WorkflowError};
+use crate::expr;
+use crate::progress::WorkflowProgress;
+
+pub(crate) async fn execute(
+    ctx: &EngineCtx,
+    step: &StepDef,
+    step_results: &mut BTreeMap<String, StepResult>,
+) -> Result<StepOutcome> {
+    let StepDef::Loop {
+        id,
+        max_iterations,
+        until,
+        steps: body,
+    } = step
+    else {
+        return Err(WorkflowError::StepFailed {
+            step_id: step.id().to_owned(),
+            message: "internal error: loop_step::execute called with non-loop step".to_owned(),
+        });
+    };
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::StepStarted {
+            step_id: id.clone(),
+            step_type: "loop",
+        })
+        .await;
+
+    let mut completed = 0u32;
+    let mut hit_until = false;
+
+    for iteration in 1..=*max_iterations {
+        let _ = ctx
+            .progress_tx
+            .send(WorkflowProgress::LoopIteration {
+                step_id: id.clone(),
+                iteration,
+                max: *max_iterations,
+            })
+            .await;
+
+        for inner in body {
+            // Clone + re-tag the inner step so its id reads `id[N]`.
+            // We append `[N]` rather than mutating in place because
+            // `StepDef::Branch`/`Loop`/etc. recursive children must
+            // also be re-tagged consistently. `retag_ids` walks the
+            // tree.
+            let mut tagged = inner.clone();
+            let suffix = format!("[{iteration}]");
+            tagged.retag_ids(&|orig| format!("{orig}{suffix}"));
+
+            // Dispatch the iteration-tagged step. Its result is stored
+            // under the tagged id; we then mirror it under the bare
+            // id (without the suffix) so the loop's `until:` can refer
+            // to it naturally.
+            let outcome = dispatch_step(ctx, &tagged, step_results).await?;
+            // Loop bodies don't propagate Revise through to the engine
+            // — a `human` inside a loop body that asks for revise
+            // tries to rewind to a target outside the loop, which we
+            // bubble up unchanged.
+            if let StepOutcome::Revise { target } = outcome {
+                let _ = ctx
+                    .progress_tx
+                    .send(WorkflowProgress::StepFailed {
+                        step_id: id.clone(),
+                        error: format!("loop interrupted by revise -> {target}"),
+                    })
+                    .await;
+                return Ok(StepOutcome::Revise { target });
+            }
+
+            // Mirror the latest iteration result under the bare id.
+            // We only mirror leaf steps — control-flow children
+            // already write their own ids into `step_results` and the
+            // parser forbids `ref:`-ing them, so they cannot reach
+            // this branch in practice. Guard defensively anyway.
+            if matches!(
+                inner,
+                StepDef::Agent { .. } | StepDef::Shell { .. } | StepDef::WriteFile { .. }
+            ) {
+                let bare_id = inner.id();
+                let tagged_id = format!("{bare_id}{suffix}");
+                if let Some(latest) = step_results.get(&tagged_id).cloned() {
+                    step_results.insert(bare_id.to_owned(), latest);
+                }
+            }
+        }
+
+        completed = iteration;
+
+        // Evaluate `until` after the iteration body.
+        let inner_ctx =
+            expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env);
+        let cond = expr::eval_bool(until, &inner_ctx).map_err(|e| WorkflowError::StepFailed {
+            step_id: id.clone(),
+            message: format!("until-expression error: {e}"),
+        })?;
+        if cond {
+            hit_until = true;
+            break;
+        }
+    }
+
+    let result = StepResult {
+        output: json!({
+            "max_iterations_reached": !hit_until,
+            "iterations": completed,
+        }),
+        exit_code: i32::from(!hit_until),
+        stdout: String::new(),
+        stderr: String::new(),
+        changed_files: Vec::new(),
+    };
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::StepCompleted {
+            step_id: id.clone(),
+            result: result.clone(),
+        })
+        .await;
+    step_results.insert(id.clone(), result);
+
+    Ok(StepOutcome::Completed)
+}

--- a/crates/tmg-workflow/src/steps/mod.rs
+++ b/crates/tmg-workflow/src/steps/mod.rs
@@ -1,10 +1,19 @@
 //! Step handlers for the workflow engine.
 //!
-//! Each submodule implements one step type. Handlers receive a borrow
-//! of the engine's resources plus the resolved [`crate::expr::ExprContext`]
-//! and return a [`crate::def::StepResult`].
+//! Each submodule implements one step type. Leaf handlers receive a
+//! borrow of the engine's resources plus the resolved
+//! [`crate::expr::ExprContext`] and return a [`crate::def::StepResult`].
+//! Control-flow handlers ([`branch`], [`group`], [`loop_step`],
+//! [`parallel`], [`human`]) accept the [`crate::engine::EngineCtx`] and
+//! the shared `step_results` map and dispatch their children back into
+//! [`crate::engine::dispatch_step`].
 
 pub(crate) mod agent;
+pub(crate) mod branch;
+pub(crate) mod group;
+pub(crate) mod human;
+pub(crate) mod loop_step;
+pub(crate) mod parallel;
 pub(crate) mod path_util;
 pub(crate) mod shell;
 pub(crate) mod write_file;

--- a/crates/tmg-workflow/src/steps/parallel.rs
+++ b/crates/tmg-workflow/src/steps/parallel.rs
@@ -31,7 +31,6 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use serde_json::json;
-use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
@@ -61,13 +60,9 @@ pub(crate) async fn execute(
         });
     };
 
-    let _ = ctx
-        .progress_tx
-        .send(WorkflowProgress::StepStarted {
-            step_id: id.clone(),
-            step_type: "parallel",
-        })
-        .await;
+    // NOTE: `StepStarted` is emitted by `engine::dispatch_step_inner`
+    // for every step before delegating to the per-type handler;
+    // emitting it again here would deliver duplicates.
 
     let cancel = CancellationToken::new();
     let mut joinset: JoinSet<ChildJoin> = JoinSet::new();
@@ -84,9 +79,11 @@ pub(crate) async fn execute(
         let child_id = child.id().to_owned();
         joinset.spawn(async move {
             // Each child gets a private mutable map seeded from the
-            // baseline. Mutex lets us pass `&mut` into dispatch_step
-            // without lifetime contortions.
-            let local = Mutex::new((*baseline_clone).clone());
+            // baseline. Owned by the spawned task so we can pass
+            // `&mut local` straight into `dispatch_step` without a
+            // lock — no lock is needed because no other task touches
+            // this map.
+            let mut local = (*baseline_clone).clone();
             let result = tokio::select! {
                 biased;
                 () = cancel_clone.cancelled() => {
@@ -95,20 +92,18 @@ pub(crate) async fn execute(
                         message: "cancelled by sibling failure".to_owned(),
                     })
                 }
-                outcome = async {
-                    let mut guard = local.lock().await;
-                    dispatch_step(&ctx_clone, &child_clone, &mut guard).await
-                } => {
+                outcome = dispatch_step(&ctx_clone, &child_clone, &mut local) => {
                     outcome.map(|_| ())
                 }
             };
-            let map = local.into_inner();
-            (child_id, result.map(|()| map))
+            (child_id, result.map(|()| local))
         });
     }
 
     // Drain the join set, collecting per-child maps. On first failure
-    // fire the cancellation token and propagate.
+    // fire the cancellation token and explicitly `shutdown().await` the
+    // join set so remaining children are aborted promptly (rather than
+    // waiting for them to observe the cancel token).
     let mut child_maps: Vec<(String, BTreeMap<String, StepResult>)> =
         Vec::with_capacity(body.len());
     let mut first_error: Option<WorkflowError> = None;
@@ -119,6 +114,7 @@ pub(crate) async fn execute(
                 if first_error.is_none() {
                     first_error = Some(err);
                     cancel.cancel();
+                    joinset.shutdown().await;
                 }
                 tracing::debug!(child_id, "parallel child failed; siblings cancelled");
             }
@@ -129,6 +125,7 @@ pub(crate) async fn execute(
                         message: format!("parallel child task panicked: {join_err}"),
                     });
                     cancel.cancel();
+                    joinset.shutdown().await;
                 }
             }
         }

--- a/crates/tmg-workflow/src/steps/parallel.rs
+++ b/crates/tmg-workflow/src/steps/parallel.rs
@@ -1,0 +1,176 @@
+//! `parallel` step handler (SPEC §8.4).
+//!
+//! Dispatches each child step concurrently via `tokio::spawn`. The
+//! engine-wide [`tokio::sync::Semaphore`] (sized by
+//! `[workflow] max_parallel_agents`) caps **agent** leaves only —
+//! shell / `write_file` children run uncapped, matching the SPEC
+//! ("agent ステップだけがカウント対象").
+//!
+//! ## Child isolation
+//!
+//! Each spawned task gets a fresh `BTreeMap<String, StepResult>` seeded
+//! from the parent's snapshot at dispatch time. After all children
+//! complete (or one fails) the produced results are merged back into
+//! the parent map. This avoids needing a `Mutex` around `step_results`
+//! for the duration of a parallel block — children that produce
+//! disjoint id sets see no interference. If two children produce the
+//! same id, the later one (by `JoinSet` completion order) wins; in
+//! practice the parser's id-uniqueness check makes that case
+//! impossible.
+//!
+//! ## Cancellation
+//!
+//! A private [`tokio_util::sync::CancellationToken`] is fired on the
+//! first child failure. Spawned step handlers do not currently observe
+//! this token directly (the LLM and shell layers manage their own
+//! tokens), so cancellation is best-effort: in-flight blocking work
+//! continues until its natural completion. We still abort outstanding
+//! `JoinSet` tasks so the *workflow* observes prompt failure.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use serde_json::json;
+use tokio::sync::Mutex;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+use crate::def::{StepDef, StepResult};
+use crate::engine::{EngineCtx, StepOutcome, dispatch_step};
+use crate::error::{Result, WorkflowError};
+use crate::progress::WorkflowProgress;
+
+/// Outcome carried back from a single child task: the child's id and
+/// either the new step-results snapshot it produced, or the failure
+/// it raised. Aliased here because clippy flags the bare tuple as
+/// `type_complexity` once it's nested in `JoinSet<...>`.
+type ChildJoin = (
+    String,
+    std::result::Result<BTreeMap<String, StepResult>, WorkflowError>,
+);
+
+pub(crate) async fn execute(
+    ctx: &EngineCtx,
+    step: &StepDef,
+    step_results: &mut BTreeMap<String, StepResult>,
+) -> Result<StepOutcome> {
+    let StepDef::Parallel { id, steps: body } = step else {
+        return Err(WorkflowError::StepFailed {
+            step_id: step.id().to_owned(),
+            message: "internal error: parallel::execute called with non-parallel step".to_owned(),
+        });
+    };
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::StepStarted {
+            step_id: id.clone(),
+            step_type: "parallel",
+        })
+        .await;
+
+    let cancel = CancellationToken::new();
+    let mut joinset: JoinSet<ChildJoin> = JoinSet::new();
+
+    // Snapshot the parent's results so each child sees the same
+    // baseline. We wrap in `Arc` to share cheaply across tasks.
+    let baseline = Arc::new(step_results.clone());
+
+    for child in body {
+        let ctx_clone = ctx.clone();
+        let child_clone = child.clone();
+        let cancel_clone = cancel.clone();
+        let baseline_clone = Arc::clone(&baseline);
+        let child_id = child.id().to_owned();
+        joinset.spawn(async move {
+            // Each child gets a private mutable map seeded from the
+            // baseline. Mutex lets us pass `&mut` into dispatch_step
+            // without lifetime contortions.
+            let local = Mutex::new((*baseline_clone).clone());
+            let result = tokio::select! {
+                biased;
+                () = cancel_clone.cancelled() => {
+                    Err(WorkflowError::StepFailed {
+                        step_id: child_id.clone(),
+                        message: "cancelled by sibling failure".to_owned(),
+                    })
+                }
+                outcome = async {
+                    let mut guard = local.lock().await;
+                    dispatch_step(&ctx_clone, &child_clone, &mut guard).await
+                } => {
+                    outcome.map(|_| ())
+                }
+            };
+            let map = local.into_inner();
+            (child_id, result.map(|()| map))
+        });
+    }
+
+    // Drain the join set, collecting per-child maps. On first failure
+    // fire the cancellation token and propagate.
+    let mut child_maps: Vec<(String, BTreeMap<String, StepResult>)> =
+        Vec::with_capacity(body.len());
+    let mut first_error: Option<WorkflowError> = None;
+    while let Some(joined) = joinset.join_next().await {
+        match joined {
+            Ok((child_id, Ok(map))) => child_maps.push((child_id, map)),
+            Ok((child_id, Err(err))) => {
+                if first_error.is_none() {
+                    first_error = Some(err);
+                    cancel.cancel();
+                }
+                tracing::debug!(child_id, "parallel child failed; siblings cancelled");
+            }
+            Err(join_err) => {
+                if first_error.is_none() {
+                    first_error = Some(WorkflowError::StepFailed {
+                        step_id: id.clone(),
+                        message: format!("parallel child task panicked: {join_err}"),
+                    });
+                    cancel.cancel();
+                }
+            }
+        }
+    }
+
+    if let Some(err) = first_error {
+        let _ = ctx
+            .progress_tx
+            .send(WorkflowProgress::StepFailed {
+                step_id: id.clone(),
+                error: err.to_string(),
+            })
+            .await;
+        return Err(err);
+    }
+
+    // Merge children's new entries back into the parent. Each child's
+    // map already includes the baseline; we only copy entries the
+    // child added (or modified). The parser's id-uniqueness rule
+    // rules out genuine merge collisions.
+    for (_child_id, map) in child_maps {
+        for (k, v) in map {
+            step_results.insert(k, v);
+        }
+    }
+
+    let result = StepResult {
+        output: json!({"children": body.len()}),
+        exit_code: 0,
+        stdout: String::new(),
+        stderr: String::new(),
+        changed_files: Vec::new(),
+    };
+
+    let _ = ctx
+        .progress_tx
+        .send(WorkflowProgress::StepCompleted {
+            step_id: id.clone(),
+            result: result.clone(),
+        })
+        .await;
+    step_results.insert(id.clone(), result);
+
+    Ok(StepOutcome::Completed)
+}

--- a/crates/tmg-workflow/tests/control_flow.rs
+++ b/crates/tmg-workflow/tests/control_flow.rs
@@ -1,0 +1,693 @@
+//! Integration tests for the control-flow step set added in issue #40
+//! (`loop`, `branch`, `parallel`, `group`, `human`).
+//!
+//! These exercise the engine end-to-end via `shell` + `write_file`
+//! leaves so they don't depend on a live LLM. The agent path is
+//! validated separately in `agent_isolation.rs`.
+
+#![expect(clippy::unwrap_used, reason = "test assertions")]
+#![expect(clippy::expect_used, reason = "test assertions")]
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, mpsc};
+use tokio_util::sync::CancellationToken;
+
+use tmg_agents::SubagentManager;
+use tmg_llm::{LlmPool, PoolConfig};
+use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
+use tmg_tools::ToolRegistry;
+use tmg_workflow::{
+    HumanResponse, WorkflowConfig, WorkflowEngine, WorkflowProgress, parse_workflow_str,
+};
+
+/// Build the engine + a temp workspace + matching sandbox for tests.
+fn build_engine(workspace: &Path, max_parallel_agents: u32) -> WorkflowEngine {
+    let llm_pool =
+        Arc::new(LlmPool::new(&PoolConfig::single("http://localhost:9999"), "test-model").unwrap());
+    // Canonicalize the workspace path so the sandbox's write-check
+    // (which canonicalizes target paths) sees a matching prefix. On
+    // macOS `/var/folders/...` is a symlink to `/private/var/...`,
+    // and a re-write of the same file fails the prefix check
+    // otherwise.
+    let workspace_canonical =
+        std::fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
+    let sandbox = Arc::new(SandboxContext::new(
+        SandboxConfig::new(&workspace_canonical).with_mode(SandboxMode::WorkspaceWrite),
+    ));
+    let tool_registry = Arc::new(ToolRegistry::new());
+
+    let llm_client_cfg = tmg_llm::LlmClientConfig::new("http://localhost:9999", "test-model");
+    let llm_client = tmg_llm::LlmClient::new(llm_client_cfg).unwrap();
+    let cancel = CancellationToken::new();
+    let manager = SubagentManager::new(llm_client, cancel, "http://localhost:9999", "test-model");
+    let subagent_manager = Arc::new(Mutex::new(manager));
+
+    let config = WorkflowConfig {
+        max_parallel_agents,
+        ..WorkflowConfig::default()
+    };
+    WorkflowEngine::new(
+        llm_pool,
+        sandbox,
+        tool_registry,
+        subagent_manager,
+        config,
+        serde_json::Value::Null,
+    )
+}
+
+fn drain<T>(rx: &mut mpsc::Receiver<T>) -> Vec<T> {
+    let mut out = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        out.push(ev);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------
+// Loop
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn loop_until_succeeds_after_third_iteration() {
+    // Use a counter file in the workspace; each iteration appends a
+    // line, and `until` becomes true once the counter file contains
+    // the magic third line. Since the engine evaluates `until` over
+    // the most recent iteration's `steps.<id>.exit_code`, we use shell
+    // exit codes directly: iter1/iter2 -> exit 1, iter3 -> exit 0.
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+
+    let counter = tmp.path().join("counter");
+    std::fs::write(&counter, "0").unwrap();
+    let counter_path = counter.to_string_lossy().to_string();
+
+    let yaml = format!(
+        r#"
+id: loop_succeeds
+steps:
+  - id: l
+    type: loop
+    max_iterations: 5
+    until: "steps.bump.exit_code == 0"
+    steps:
+      - id: bump
+        type: shell
+        command: |
+          n=$(cat {counter_path})
+          n=$((n+1))
+          echo $n > {counter_path}
+          if [ $n -ge 3 ]; then exit 0; else exit 1; fi
+"#
+    );
+    let wf = parse_workflow_str(&yaml, "<inline>").unwrap();
+    let (tx, mut rx) = mpsc::channel(64);
+
+    engine.run(&wf, BTreeMap::new(), tx).await.unwrap();
+
+    let events = drain(&mut rx);
+    let iters = events
+        .iter()
+        .filter(|e| matches!(e, WorkflowProgress::LoopIteration { .. }))
+        .count();
+    assert_eq!(iters, 3, "expected exactly three iterations");
+
+    // Ensure the loop step's StepResult reports no max_iterations_reached.
+    let final_loop_result = events
+        .iter()
+        .find_map(|e| match e {
+            WorkflowProgress::StepCompleted { step_id, result } if step_id == "l" => Some(result),
+            _ => None,
+        })
+        .expect("loop step completion event");
+    assert_eq!(
+        final_loop_result.output["max_iterations_reached"],
+        serde_json::json!(false)
+    );
+    assert_eq!(final_loop_result.output["iterations"], serde_json::json!(3));
+}
+
+#[tokio::test]
+async fn loop_max_iterations_reached_branch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: loop_caps
+steps:
+  - id: l
+    type: loop
+    max_iterations: 2
+    until: "false"
+    steps:
+      - id: noop
+        type: shell
+        command: "true"
+outputs:
+  hit_cap: "${{ steps.l.output.max_iterations_reached }}"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, mut rx) = mpsc::channel(32);
+    let outputs = engine.run(&wf, BTreeMap::new(), tx).await.unwrap();
+    let events = drain(&mut rx);
+    let iters = events
+        .iter()
+        .filter(|e| matches!(e, WorkflowProgress::LoopIteration { .. }))
+        .count();
+    assert_eq!(iters, 2);
+    assert_eq!(
+        outputs.values.get("hit_cap").map(String::as_str),
+        Some("true")
+    );
+}
+
+#[tokio::test]
+async fn loop_ref_substitution_runs_referenced_step() {
+    // A `ref:` to a previously-defined shell step should clone the
+    // step into the loop body and run it with iteration suffixes.
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: loop_ref
+steps:
+  - id: ping
+    type: shell
+    command: "echo pong"
+  - id: l
+    type: loop
+    max_iterations: 2
+    until: "false"
+    steps:
+      - ref: ping
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, mut rx) = mpsc::channel(32);
+    engine.run(&wf, BTreeMap::new(), tx).await.unwrap();
+
+    let events = drain(&mut rx);
+    // Each iteration tags the inner ping step as `ping[1]`, `ping[2]`.
+    let mut tagged: Vec<String> = events
+        .iter()
+        .filter_map(|e| match e {
+            WorkflowProgress::StepStarted { step_id, .. } if step_id.starts_with("ping[") => {
+                Some(step_id.clone())
+            }
+            _ => None,
+        })
+        .collect();
+    tagged.sort();
+    assert_eq!(tagged, vec!["ping[1]".to_owned(), "ping[2]".to_owned()]);
+}
+
+// ---------------------------------------------------------------------
+// Branch
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn branch_first_match_wins() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: br
+inputs:
+  flag:
+    type: integer
+    default: 2
+steps:
+  - id: choose
+    type: branch
+    conditions:
+      - when: "inputs.flag == 1"
+        steps:
+          - id: a
+            type: write_file
+            path: "a.txt"
+            content: "A"
+      - when: "inputs.flag == 2"
+        steps:
+          - id: b
+            type: write_file
+            path: "b.txt"
+            content: "B"
+      - when: "true"
+        steps:
+          - id: c
+            type: write_file
+            path: "c.txt"
+            content: "C"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, _rx) = mpsc::channel(32);
+    engine.run(&wf, BTreeMap::new(), tx).await.unwrap();
+    assert!(!tmp.path().join("a.txt").exists());
+    assert!(tmp.path().join("b.txt").exists());
+    assert!(!tmp.path().join("c.txt").exists());
+}
+
+#[tokio::test]
+async fn branch_default_runs_when_no_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: brd
+steps:
+  - id: choose
+    type: branch
+    conditions:
+      - when: "false"
+        steps:
+          - id: a
+            type: write_file
+            path: "a.txt"
+            content: "A"
+    default:
+      - id: d
+        type: write_file
+        path: "d.txt"
+        content: "D"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, _rx) = mpsc::channel(32);
+    engine.run(&wf, BTreeMap::new(), tx).await.unwrap();
+    assert!(!tmp.path().join("a.txt").exists());
+    assert!(tmp.path().join("d.txt").exists());
+}
+
+#[tokio::test]
+async fn branch_no_default_is_noop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: brn
+steps:
+  - id: choose
+    type: branch
+    conditions:
+      - when: "false"
+        steps:
+          - id: a
+            type: write_file
+            path: "a.txt"
+            content: "A"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, _rx) = mpsc::channel(32);
+    engine.run(&wf, BTreeMap::new(), tx).await.unwrap();
+    assert!(!tmp.path().join("a.txt").exists());
+}
+
+// ---------------------------------------------------------------------
+// Parallel
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn parallel_shell_children_run_concurrently() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 1); // agent cap doesn't matter for shell
+    let yaml = r#"
+id: parsh
+steps:
+  - id: p
+    type: parallel
+    steps:
+      - id: a
+        type: write_file
+        path: "a.txt"
+        content: "A"
+      - id: b
+        type: write_file
+        path: "b.txt"
+        content: "B"
+      - id: c
+        type: write_file
+        path: "c.txt"
+        content: "C"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, _rx) = mpsc::channel(64);
+    engine.run(&wf, BTreeMap::new(), tx).await.unwrap();
+    assert!(tmp.path().join("a.txt").exists());
+    assert!(tmp.path().join("b.txt").exists());
+    assert!(tmp.path().join("c.txt").exists());
+}
+
+#[tokio::test]
+async fn parallel_failing_child_cancels_siblings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    // One child writes a file, the other exits non-zero. The shell
+    // step's exit_code is recorded but does not raise StepFailed —
+    // shell failures don't error the workflow. To force a hard
+    // failure we use `write_file` with a bad path traversal.
+    let yaml = r#"
+id: par_fail
+steps:
+  - id: p
+    type: parallel
+    steps:
+      - id: ok
+        type: write_file
+        path: "ok.txt"
+        content: "ok"
+      - id: bad
+        type: write_file
+        path: "../escape.txt"
+        content: "boom"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, _rx) = mpsc::channel(64);
+    let result = engine.run(&wf, BTreeMap::new(), tx).await;
+    assert!(result.is_err(), "parallel must surface child failure");
+}
+
+// ---------------------------------------------------------------------
+// Group
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn group_abort_propagates_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: g_abort
+steps:
+  - id: g
+    type: group
+    on_failure: abort
+    steps:
+      - id: bad
+        type: write_file
+        path: "../escape.txt"
+        content: "boom"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, _rx) = mpsc::channel(32);
+    let res = engine.run(&wf, BTreeMap::new(), tx).await;
+    assert!(res.is_err());
+}
+
+#[tokio::test]
+async fn group_continue_logs_failure_and_proceeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: g_cont
+steps:
+  - id: g
+    type: group
+    on_failure: continue
+    steps:
+      - id: bad
+        type: write_file
+        path: "../escape.txt"
+        content: "boom"
+  - id: after
+    type: write_file
+    path: "after.txt"
+    content: "OK"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, _rx) = mpsc::channel(32);
+    let res = engine.run(&wf, BTreeMap::new(), tx).await;
+    assert!(res.is_ok(), "continue must not abort");
+    assert!(tmp.path().join("after.txt").exists());
+}
+
+#[tokio::test]
+async fn group_retry_succeeds_after_failures() {
+    // The retry test needs a *deterministic* failure that goes away
+    // after N attempts. We use:
+    //   step `tick`   — increments a counter file (always succeeds).
+    //   step `gate`   — write_file whose templated path is `..`
+    //                   (sandbox-rejected) until the counter reaches
+    //                   the threshold, after which it points to a
+    //                   workspace-relative file.
+    //
+    // The engine restores `step_results` to the pre-group snapshot
+    // before each retry, but the *filesystem* counter persists across
+    // attempts, so the retry condition makes monotonic progress.
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = std::fs::canonicalize(tmp.path()).unwrap();
+    let engine = build_engine(&workspace, 2);
+    let counter = workspace.join("retry_counter");
+    let path_marker = workspace.join("path.txt");
+    std::fs::write(&counter, "0").unwrap();
+    let counter_path = counter.to_string_lossy().to_string();
+    let path_marker_str = path_marker.to_string_lossy().to_string();
+    let yaml = format!(
+        r#"
+id: g_retry
+steps:
+  - id: g
+    type: group
+    on_failure: retry
+    max_retries: 5
+    steps:
+      - id: tick
+        type: shell
+        command: |
+          n=$(cat {counter_path})
+          n=$((n+1))
+          echo $n > {counter_path}
+          if [ $n -ge 3 ]; then echo good > {path_marker_str}; else echo "../escape" > {path_marker_str}; fi
+      - id: route
+        type: shell
+        command: "cat {path_marker_str}"
+      - id: maybe_fail
+        type: write_file
+        path: "${{{{ steps.route.stdout }}}}.txt"
+        content: ""
+"#
+    );
+    // route.stdout has a trailing newline so the path becomes
+    // "good\n.txt" or "../escape\n.txt". The "../escape" prefix is
+    // rejected by the path-traversal check; the "good" case writes
+    // "good\n.txt" which succeeds (newline is a valid path char on
+    // Unix). Counter increments to 3 to break the retry loop.
+    let wf = parse_workflow_str(&yaml, "<inline>").unwrap();
+    let (tx, _rx) = mpsc::channel(64);
+    let res = engine.run(&wf, BTreeMap::new(), tx).await;
+    assert!(
+        res.is_ok(),
+        "group retry should eventually succeed; got {res:?}"
+    );
+    // Counter must have been bumped at least to the success threshold.
+    let final_n: i32 = std::fs::read_to_string(&counter)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert!(final_n >= 3, "counter advanced to {final_n}, expected >= 3");
+}
+
+// ---------------------------------------------------------------------
+// Human
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn human_approve_continues_workflow() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: h_approve
+steps:
+  - id: prep
+    type: write_file
+    path: "before.txt"
+    content: "before"
+  - id: r
+    type: human
+    message: "ok?"
+    options: [approve, reject]
+  - id: after
+    type: write_file
+    path: "after.txt"
+    content: "after"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, mut rx) = mpsc::channel(64);
+
+    let run_handle = tokio::spawn({
+        let inputs = BTreeMap::new();
+        let wf = wf.clone();
+        async move { engine.run(&wf, inputs, tx).await }
+    });
+
+    // Drain progress events until we see the HumanInputRequired.
+    while let Some(ev) = rx.recv().await {
+        if let WorkflowProgress::HumanInputRequired { response_tx, .. } = ev {
+            let sender = response_tx.lock().await.take().unwrap();
+            sender.send(HumanResponse::approve()).unwrap();
+            break;
+        }
+    }
+
+    // Drain the rest in the background (otherwise the engine blocks
+    // on the channel) by spawning a no-op consumer.
+    let _drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+    run_handle.await.unwrap().unwrap();
+
+    assert!(tmp.path().join("before.txt").exists());
+    assert!(tmp.path().join("after.txt").exists());
+}
+
+#[tokio::test]
+async fn human_reject_aborts_workflow() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: h_reject
+steps:
+  - id: r
+    type: human
+    message: "decide"
+    options: [approve, reject]
+  - id: never
+    type: write_file
+    path: "never.txt"
+    content: "x"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, mut rx) = mpsc::channel(64);
+
+    let run_handle = tokio::spawn({
+        let wf = wf.clone();
+        async move { engine.run(&wf, BTreeMap::new(), tx).await }
+    });
+
+    while let Some(ev) = rx.recv().await {
+        if let WorkflowProgress::HumanInputRequired { response_tx, .. } = ev {
+            let sender = response_tx.lock().await.take().unwrap();
+            sender.send(HumanResponse::reject()).unwrap();
+            break;
+        }
+    }
+    let _drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+    let res = run_handle.await.unwrap();
+    assert!(res.is_err(), "reject must abort the workflow");
+    assert!(!tmp.path().join("never.txt").exists());
+}
+
+#[tokio::test]
+async fn human_revise_rewinds_to_target() {
+    // The classic "design -> review (revise) -> design re-runs" flow.
+    // We use write_file as a stand-in for the design agent. After the
+    // first revise, the design step must run again, so the workspace
+    // ends up with `design.txt` rewritten. To make the revise
+    // *terminate* we send `revise` once and `approve` the second
+    // time.
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let yaml = r#"
+id: h_revise
+inputs:
+  iteration:
+    type: integer
+    default: 1
+steps:
+  - id: design
+    type: write_file
+    path: "design.txt"
+    content: "designed"
+  - id: r
+    type: human
+    message: "review the design"
+    options: [approve, revise]
+    revise_target: design
+  - id: ship
+    type: write_file
+    path: "ship.txt"
+    content: "shipped"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, mut rx) = mpsc::channel(128);
+
+    let run_handle = tokio::spawn({
+        let wf = wf.clone();
+        async move { engine.run(&wf, BTreeMap::new(), tx).await }
+    });
+
+    let mut seen_revise = false;
+    let mut human_seen = 0u32;
+    while let Some(ev) = rx.recv().await {
+        if let WorkflowProgress::HumanInputRequired { response_tx, .. } = ev {
+            human_seen += 1;
+            let sender = response_tx.lock().await.take().unwrap();
+            if seen_revise {
+                sender.send(HumanResponse::approve()).unwrap();
+                break;
+            }
+            seen_revise = true;
+            sender.send(HumanResponse::revise("design")).unwrap();
+        }
+    }
+    let _drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+    run_handle.await.unwrap().unwrap();
+
+    assert_eq!(
+        human_seen, 2,
+        "the human step should fire twice — once before revise, once before approve"
+    );
+    assert!(tmp.path().join("design.txt").exists());
+    assert!(tmp.path().join("ship.txt").exists());
+}
+
+// ---------------------------------------------------------------------
+// SPEC §8.4 review_loop YAML — end-to-end parse + run with shell mocks
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn spec_review_loop_yaml_parses_and_runs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let counter = tmp.path().join("verify_counter");
+    std::fs::write(&counter, "0").unwrap();
+    let counter_path = counter.to_string_lossy().to_string();
+    // Approximation of the SPEC §8.4 sample: top-level `verify` and
+    // `fix_errors` are real shell steps; the loop body refs them.
+    let yaml = format!(
+        r#"
+id: review_loop
+description: "Verify -> fix -> verify cycle"
+steps:
+  - id: verify
+    type: shell
+    command: |
+      n=$(cat {counter_path})
+      n=$((n+1))
+      echo $n > {counter_path}
+      if [ $n -ge 2 ]; then exit 0; else exit 1; fi
+  - id: fix_errors
+    type: shell
+    command: "echo applying fixes"
+  - id: review
+    type: loop
+    max_iterations: 3
+    until: "steps.verify.exit_code == 0"
+    steps:
+      - ref: verify
+      - ref: fix_errors
+"#
+    );
+    let wf = parse_workflow_str(&yaml, "<inline>").unwrap();
+    let (tx, mut rx) = mpsc::channel(64);
+    engine.run(&wf, BTreeMap::new(), tx).await.unwrap();
+
+    let events = drain(&mut rx);
+    let iters = events
+        .iter()
+        .filter(|e| matches!(e, WorkflowProgress::LoopIteration { .. }))
+        .count();
+    // Counter starts at 0; first attempt outside the loop -> 1, then
+    // first loop iter -> 2 (verify exits 0), so we expect exactly one
+    // LoopIteration event.
+    assert!(iters >= 1);
+    let counter_final: i32 = std::fs::read_to_string(&counter)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert!(counter_final >= 2, "verify ran at least twice");
+}

--- a/crates/tmg-workflow/tests/control_flow.rs
+++ b/crates/tmg-workflow/tests/control_flow.rs
@@ -680,14 +680,184 @@ steps:
         .iter()
         .filter(|e| matches!(e, WorkflowProgress::LoopIteration { .. }))
         .count();
-    // Counter starts at 0; first attempt outside the loop -> 1, then
-    // first loop iter -> 2 (verify exits 0), so we expect exactly one
-    // LoopIteration event.
-    assert!(iters >= 1);
+    // Counter starts at 0; first attempt outside the loop -> 1
+    // (verify exits 1), then first loop iter -> 2 (verify exits 0),
+    // so we expect exactly one LoopIteration event.
+    assert_eq!(iters, 1);
     let counter_final: i32 = std::fs::read_to_string(&counter)
         .unwrap()
         .trim()
         .parse()
         .unwrap();
-    assert!(counter_final >= 2, "verify ran at least twice");
+    assert_eq!(counter_final, 2, "verify ran exactly twice");
+}
+
+// ---------------------------------------------------------------------
+// Regression tests for PR #64 review fixes
+// ---------------------------------------------------------------------
+
+/// Fix #1: every step (leaf or control-flow) must produce exactly one
+/// `StepStarted` event. Pre-fix, control-flow handlers double-emitted.
+#[tokio::test]
+async fn each_step_emits_exactly_one_step_started_event() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    // Workflow exercises every control-flow variant + a leaf so we
+    // catch a regression in any handler.
+    let yaml = r#"
+id: one_started_per_step
+steps:
+  - id: g
+    type: group
+    on_failure: abort
+    steps:
+      - id: in_group
+        type: write_file
+        path: "g.txt"
+        content: "g"
+  - id: br
+    type: branch
+    conditions:
+      - when: "true"
+        steps:
+          - id: in_branch
+            type: write_file
+            path: "br.txt"
+            content: "br"
+  - id: par
+    type: parallel
+    steps:
+      - id: in_par
+        type: write_file
+        path: "par.txt"
+        content: "par"
+  - id: lp
+    type: loop
+    max_iterations: 1
+    until: "true"
+    steps:
+      - id: in_loop
+        type: write_file
+        path: "lp.txt"
+        content: "lp"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let (tx, mut rx) = mpsc::channel(64);
+    engine.run(&wf, BTreeMap::new(), tx).await.unwrap();
+    let events = drain(&mut rx);
+
+    let mut counts: BTreeMap<String, u32> = BTreeMap::new();
+    for ev in &events {
+        if let WorkflowProgress::StepStarted { step_id, .. } = ev {
+            *counts.entry(step_id.clone()).or_default() += 1;
+        }
+    }
+    for (id, n) in &counts {
+        assert_eq!(
+            *n, 1,
+            "step '{id}' emitted {n} StepStarted events; expected exactly 1"
+        );
+    }
+    // Sanity: every control-flow step we declared above is in there.
+    for expected in [
+        "g",
+        "br",
+        "par",
+        "lp",
+        "in_group",
+        "in_branch",
+        "in_par",
+        "in_loop[1]",
+    ] {
+        assert!(
+            counts.contains_key(expected),
+            "missing StepStarted for '{expected}' (got: {counts:?})"
+        );
+    }
+}
+
+/// Fix #5: when iteration N skips its inner leaf via `when=false`, the
+/// loop must NOT preserve iteration N-1's value under the bare id.
+/// Otherwise `until:` (which reads the bare id) would observe stale
+/// data and could exit early on a stale truthy result.
+///
+/// Strategy:
+/// - The loop's `until` is `steps.bump.exit_code == 0`.
+/// - `guard` (always-running shell) toggles each iteration based on a
+///   counter file: iter 1 exits 0; iter 2 exits 1 (so bump skips).
+/// - `bump`'s `when: steps.guard.exit_code == 0` controls whether the
+///   inner step runs.
+///
+/// Pre-fix behavior: iter 1 sets `bump` (bare-id mirror) to a
+/// successful exit code (0). Iter 2 skips bump but the bare-id mirror
+/// stays as iter 1's result. After iter 2 the loop's
+/// `until="steps.bump.exit_code == 0"` is **true** because of the
+/// stale mirror, so the loop exits early at iter 2 with `until` hit.
+///
+/// Post-fix: at the end of iter 2 we *clear* the bare-id mirror
+/// because no `bump[2]` was written. `until="steps.bump.exit_code == 0"`
+/// then errors-out (`steps.bump` missing), which surfaces as a
+/// `WorkflowError::StepFailed` with `until-expression error:` in the
+/// message. This is the visible signal we assert.
+///
+/// (A nicer post-fix UX would be to treat a missing id as falsy; we
+/// keep the existing strict semantics here to avoid silently masking
+/// typos. The test pins the actual current behaviour.)
+#[tokio::test]
+async fn loop_skipped_inner_clears_bare_id_mirror() {
+    let tmp = tempfile::tempdir().unwrap();
+    let engine = build_engine(tmp.path(), 2);
+    let counter = tmp.path().join("loop_skip_counter");
+    std::fs::write(&counter, "0").unwrap();
+    let counter_path = counter.to_string_lossy().to_string();
+    // The `until` requires BOTH bump.exit_code == 0 AND
+    // guard.exit_code != 0. Iter 1: guard exit 0 -> until false.
+    // Iter 2: guard exit 1, bump skipped. Pre-fix: stale bare-id
+    // mirror keeps bump.exit_code == 0, until evaluates true and the
+    // loop exits cleanly. Post-fix: mirror is cleared, until errors,
+    // and the engine returns Err.
+    let yaml = format!(
+        r#"
+id: skip_clears_mirror
+steps:
+  - id: lp
+    type: loop
+    max_iterations: 3
+    until: "steps.bump.exit_code == 0 && steps.guard.exit_code != 0"
+    steps:
+      - id: guard
+        type: shell
+        command: |
+          n=$(cat {counter_path})
+          n=$((n+1))
+          echo $n > {counter_path}
+          if [ $n -ge 2 ]; then exit 1; else exit 0; fi
+      - id: bump
+        type: shell
+        when: "steps.guard.exit_code == 0"
+        command: "true"
+"#
+    );
+    let wf = parse_workflow_str(&yaml, "<inline>").unwrap();
+    let (tx, mut rx) = mpsc::channel(64);
+    let res = engine.run(&wf, BTreeMap::new(), tx).await;
+    let _ = drain(&mut rx);
+
+    // Pre-fix: iter 1 runs guard (exit 0) and bump (exit 0). bare-id
+    // mirror has bump.exit_code=0. until evaluates: 0==0 (true) &&
+    // 0!=0 (false) -> false. Iter 2: guard exits 1; bump skipped.
+    // Pre-fix bare-id mirror still says exit_code=0. until: 0==0
+    // (true) && 1!=0 (true) -> true. Loop exits at iter 2 with `Ok`.
+    //
+    // Post-fix: iter 2 clears the bump bare-id mirror. until errors
+    // because `steps.bump` is missing. The loop returns Err.
+    //
+    // We assert post-fix behaviour: the run errored with an
+    // until-expression error mentioning bump.
+    let err = res.expect_err("post-fix #5: until must error on missing bump after skipped iter 2");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("until-expression") && msg.contains("bump"),
+        "expected an until-expression error referencing 'bump', got: {msg}"
+    );
 }


### PR DESCRIPTION
## Summary

Implements SPEC §8.4 control-flow steps on top of the WorkflowEngine introduced in #39, completing the StepDef matrix so workflows like `implement.yaml` and `review_loop.yaml` can be expressed declaratively.

- **StepDef** gains five `#[non_exhaustive]` variants — `Loop`, `Branch`, `Parallel`, `Group`, `Human` — plus a `FailurePolicy { Abort, Retry, Continue }` enum for groups.
- **WorkflowEngine** dispatches recursively (`dispatch_step` returns a `Pin<Box<dyn Future + Send>>` so spawned children stay `Send`-bounded). A snapshot map captures `step_results` before each top-level step so a `human` reviewer's `revise` decision can rewind to an earlier step.
- **Loop** re-tags inner step ids per iteration as `id[N]` and mirrors the most recent under the bare id so `until: ${{ steps.verify.exit_code == 0 }}` reads naturally. Reaching `max_iterations` records `{"max_iterations_reached": true}`.
- **Branch** evaluates each `(when, steps)` pair in declaration order; first truthy wins, otherwise `default` runs (or no-op).
- **Parallel** uses a `JoinSet` plus a private `CancellationToken` to fan out children and cancel siblings on first failure. An `Arc<Semaphore>` of size `[workflow] max_parallel_agents` caps concurrent agent leaves only — `shell` / `write_file` children stay uncapped per SPEC ("agent ステップだけがカウント対象").
- **Group** implements `abort` / `retry` / `continue`. `retry` restores the pre-group `step_results` snapshot before each attempt so observers don't see partial state. `continue` emits `StepCompleted` with `exit_code = 1`.
- **Human** sends `WorkflowProgress::HumanInputRequired { response_tx: Arc<Mutex<Option<oneshot::Sender>>> }` and awaits a `HumanResponse { kind, target }`. The wrapping keeps `WorkflowProgress` `Clone`-able; the take-once contract is documented inline. `revise` returns `StepOutcome::Revise { target }` which the engine translates into a snapshot-restore + dispatch-index reset (rewind budget: 64/run).
- **Parser** supports the new step types plus the `ref:` shorthand for cloning a previously-defined leaf step into a loop body. Top-level `ref:` is rejected; control-flow `ref:` targets are rejected with a clear error.

Modified crates: `tmg-workflow` only. No public-API breaking changes — both enums are `#[non_exhaustive]` and the new types are additive.

## Acceptance criteria

- [x] `loop` exits on `until` and on `max_iterations`
- [x] `branch` first-match wins / default fallback / no-default no-op
- [x] `parallel` errors cancel siblings; agents are capped by semaphore
- [x] `group` retry / continue / abort
- [x] `human` approve / reject / revise (with rewind)
- [x] SPEC §8.4 `review_loop` YAML parses + runs end-to-end
- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (all tests pass; 15 new control-flow tests)

## Test plan

- [x] `cargo test -p tmg-workflow` — 67 unit tests + 15 control-flow integration tests + existing 9 integration tests, all green.
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo build --workspace` clean.

### Runtime Verification

- LLM server: available
- One-shot mode: SKIP — this PR adds workflow-engine library code only; the binary does not yet expose a `run_workflow` tool (gated under #41) and the `--prompt` path does not exercise `WorkflowEngine`. Runtime behavior is fully covered by the 15 new integration tests.
- TUI mode: SKIP — same reason as above.

## Trade-offs documented in code

- `Pin<Box<dyn Future + Send>>` return on `dispatch_step` is a recursion+`Send` workaround for `tokio::spawn` boundaries (engine.rs).
- `Arc<Mutex<Option<oneshot::Sender>>>` for `HumanResponder` keeps `WorkflowProgress: Clone` (progress.rs).
- Snapshot map memory cost is documented in engine.rs; a 64-rewind budget guards against pathological human-loops.
- `parallel` cancellation is best-effort (LLM/shell layers manage their own tokens); we still abort the `JoinSet` so the workflow observes prompt failure (parallel.rs).
- `ref:` is restricted to leaf steps inside loops; control-flow `ref:` is rejected at parse time to avoid id-disambiguation ambiguity (parse.rs).

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)