### PR TITLE
tmg-workflow: long_running mode + init / iterate / bootstrap (#42)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tmg-agents",
+ "tmg-harness",
  "tmg-llm",
  "tmg-sandbox",
  "tmg-tools",

--- a/crates/tmg-workflow/Cargo.toml
+++ b/crates/tmg-workflow/Cargo.toml
@@ -10,6 +10,7 @@ tmg-llm = { workspace = true }
 tmg-tools = { workspace = true }
 tmg-agents = { workspace = true }
 tmg-sandbox = { workspace = true }
+tmg-harness = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/tmg-workflow/src/def.rs
+++ b/crates/tmg-workflow/src/def.rs
@@ -354,7 +354,14 @@ impl StepDef {
 }
 
 /// A fully-validated workflow definition.
+///
+/// Marked `#[non_exhaustive]` because future SPEC additions are
+/// expected to grow optional fields (e.g. per-workflow telemetry tags).
+/// External crates must use [`WorkflowDef::new`] (and the builder
+/// methods) instead of struct literals so growing the struct is not a
+/// breaking change.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct WorkflowDef {
     /// Unique workflow identifier (snake_case-ish).
     pub id: String,
@@ -384,6 +391,77 @@ pub struct WorkflowDef {
     /// [`IteratePhase::steps`], and evaluates [`IteratePhase::until`]
     /// to decide whether to stop.
     pub iterate: Option<IteratePhase>,
+}
+
+impl WorkflowDef {
+    /// Build a new [`WorkflowDef`] with default fields.
+    ///
+    /// All optional fields (`description`, `mode`, `inputs`, `steps`,
+    /// `outputs`, `init`, `iterate`) start empty. Use the builder
+    /// methods or direct field assignment (within the crate) to
+    /// populate them.
+    #[must_use]
+    pub fn new(id: String) -> Self {
+        Self {
+            id,
+            description: None,
+            mode: WorkflowMode::Normal,
+            inputs: BTreeMap::new(),
+            steps: Vec::new(),
+            outputs: BTreeMap::new(),
+            init: None,
+            iterate: None,
+        }
+    }
+
+    /// Set the workflow's [`WorkflowMode`].
+    #[must_use]
+    pub fn with_mode(mut self, mode: WorkflowMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Set the workflow description.
+    #[must_use]
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the workflow's input declarations.
+    #[must_use]
+    pub fn with_inputs(mut self, inputs: BTreeMap<String, InputDef>) -> Self {
+        self.inputs = inputs;
+        self
+    }
+
+    /// Set the workflow's top-level steps.
+    #[must_use]
+    pub fn with_steps(mut self, steps: Vec<StepDef>) -> Self {
+        self.steps = steps;
+        self
+    }
+
+    /// Set the workflow's output templates.
+    #[must_use]
+    pub fn with_outputs(mut self, outputs: BTreeMap<String, String>) -> Self {
+        self.outputs = outputs;
+        self
+    }
+
+    /// Attach an `init:` phase.
+    #[must_use]
+    pub fn with_init(mut self, init: InitPhase) -> Self {
+        self.init = Some(init);
+        self
+    }
+
+    /// Attach an `iterate:` phase.
+    #[must_use]
+    pub fn with_iterate(mut self, iterate: IteratePhase) -> Self {
+        self.iterate = Some(iterate);
+        self
+    }
 }
 
 /// `init:` phase configuration for a `mode: long_running` workflow.

--- a/crates/tmg-workflow/src/def.rs
+++ b/crates/tmg-workflow/src/def.rs
@@ -368,6 +368,93 @@ pub struct WorkflowDef {
     pub steps: Vec<StepDef>,
     /// Output expressions (each value is a `${{ ... }}` template).
     pub outputs: BTreeMap<String, String>,
+    /// Optional `init` phase (only valid for `mode: long_running`).
+    ///
+    /// SPEC §8.12: the `init` phase runs once per long-running run on
+    /// the first attach. It typically invokes the `initializer` builtin
+    /// subagent through an `agent` step to produce `features.json` /
+    /// `init.sh` / `progress.md`. After [`InitPhase::steps`] complete,
+    /// the executor flips the run to harnessed scope.
+    pub init: Option<InitPhase>,
+    /// Optional `iterate` phase (required for `mode: long_running`).
+    ///
+    /// SPEC §8.12: the `iterate` phase is the per-session loop. Each
+    /// iteration begins a new harnessed session, resolves the
+    /// [`IteratePhase::bootstrap`] items into a context block, runs
+    /// [`IteratePhase::steps`], and evaluates [`IteratePhase::until`]
+    /// to decide whether to stop.
+    pub iterate: Option<IteratePhase>,
+}
+
+/// `init:` phase configuration for a `mode: long_running` workflow.
+///
+/// Runs once per run, on the first attach (i.e. when the run is still
+/// ad-hoc). The phase typically produces `features.json` / `init.sh` /
+/// `progress.md` via the `initializer` builtin subagent and then the
+/// executor escalates the run to harnessed scope.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct InitPhase {
+    /// Optional named artifact paths exposed to expressions as
+    /// `${{ artifacts.<name> }}`. The path is rendered as a string when
+    /// referenced from a template.
+    ///
+    /// Example: `progress_file: ".tsumugi/runs/<id>/progress.md"`.
+    pub artifacts: BTreeMap<String, PathBuf>,
+    /// Steps to execute during initialisation.
+    ///
+    /// Step types are the standard set
+    /// (`agent` / `shell` / `write_file` / `loop` / `branch` /
+    /// `parallel` / `group` / `human`).
+    pub steps: Vec<StepDef>,
+}
+
+/// `iterate:` phase configuration for a `mode: long_running` workflow.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct IteratePhase {
+    /// Bootstrap items resolved at the start of each session and
+    /// concatenated into the iterate step context.
+    ///
+    /// See [`BootstrapItem`] for the supported entry kinds.
+    pub bootstrap: Vec<BootstrapItem>,
+    /// Steps to execute every session.
+    pub steps: Vec<StepDef>,
+    /// `${{ ... }}` boolean expression evaluated after every session;
+    /// when truthy the executor stops with [`crate::long_running::RunStatus::Completed`].
+    pub until: String,
+    /// Maximum number of sessions before the executor stops with
+    /// [`crate::long_running::RunStatus::Exhausted`]. Must be `>= 1`.
+    pub max_sessions: u32,
+    /// Wall-clock budget for one session. When exceeded, the executor
+    /// fires [`tmg_harness::SessionEndTrigger::Timeout`] via the
+    /// existing watchdog path and continues with the next iteration.
+    pub session_timeout: Duration,
+}
+
+/// One entry in a `bootstrap:` list.
+///
+/// Parsed from the YAML shorthand:
+///
+/// ```yaml
+/// bootstrap:
+///   - run: "ls -la"            # BootstrapItem::Run
+///   - read: "src/lib.rs"       # BootstrapItem::Read
+///   - smoke_test:              # BootstrapItem::SmokeTest
+///       id: smoke
+///       type: shell
+///       command: "cargo test --lib"
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum BootstrapItem {
+    /// Run a shell command via the sandbox; capture stdout.
+    Run(String),
+    /// Read a file (path may use `${{ artifacts.* }}` references).
+    Read(String),
+    /// Execute a single step (typically a shell smoke test) and capture
+    /// its stdout/stderr summary.
+    SmokeTest(Box<StepDef>),
 }
 
 /// Result of executing a single step.

--- a/crates/tmg-workflow/src/engine.rs
+++ b/crates/tmg-workflow/src/engine.rs
@@ -55,9 +55,10 @@ use tmg_tools::ToolRegistry;
 use crate::config::WorkflowConfig;
 use crate::def::{InputDef, StepDef, StepResult, WorkflowDef, WorkflowOutputs};
 use crate::error::{Result, WorkflowError};
-use crate::expr;
+use crate::expr::{self, ArtifactResolver};
 use crate::progress::WorkflowProgress;
 use crate::steps;
+use std::path::PathBuf;
 
 /// Shared index of discovered workflows, keyed by id.
 ///
@@ -111,6 +112,56 @@ pub(crate) struct EngineCtx {
     /// nested `WorkflowEngine::run` call to prevent runaway recursion
     /// when a pipeline misconfigures stage references.
     pub(crate) workflow_depth: u32,
+    /// Optional named artifact paths exposed to expressions as
+    /// `${{ artifacts.<name> }}`. Populated only by long-running
+    /// workflows when the executor calls
+    /// [`WorkflowEngine::run_with_extras`].
+    pub(crate) artifacts: Option<Arc<BTreeMap<String, PathBuf>>>,
+    /// Optional [`ArtifactResolver`] used by the
+    /// `${{ artifact.<name>.<method> }}` form. Populated only by
+    /// long-running workflows when the executor calls
+    /// [`WorkflowEngine::run_with_extras`].
+    pub(crate) artifact_resolver: Option<Arc<dyn ArtifactResolver>>,
+}
+
+/// Build a fully-populated [`expr::ExprContext`] from `ctx`,
+/// `step_results`, and a `stages_snapshot` borrowed from the caller.
+///
+/// Centralises the optional `artifacts` / `artifact_resolver` plumbing
+/// so every step handler picks up the long-running scopes uniformly.
+/// Callers must hold `stages_snapshot` for the lifetime of the
+/// returned context.
+pub(crate) fn build_eval_ctx<'a>(
+    ctx: &'a EngineCtx,
+    step_results: &'a BTreeMap<String, StepResult>,
+    stages_snapshot: &'a BTreeMap<String, WorkflowOutputs>,
+) -> expr::ExprContext<'a> {
+    let mut eval_ctx =
+        expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
+            .with_stages(stages_snapshot);
+    if let Some(art) = ctx.artifacts.as_ref() {
+        eval_ctx = eval_ctx.with_artifacts(art.as_ref());
+    }
+    if let Some(res) = ctx.artifact_resolver.as_ref() {
+        eval_ctx = eval_ctx.with_artifact_resolver(res.as_ref());
+    }
+    eval_ctx
+}
+
+/// Optional extension knobs for a long-running workflow phase.
+///
+/// Long-running mode (`mode: long_running`) needs to thread the run's
+/// artifact paths and a live `artifact.*` resolver into iterate-phase
+/// step handlers so step expressions can reference
+/// `${{ artifacts.progress_file }}` / `${{ artifact.features.passing_count }}`.
+/// Plain workflows leave both fields `None` and see the historical
+/// scope set.
+#[derive(Default)]
+pub struct EngineExtras {
+    /// Artifact-name -> path map exposed via `${{ artifacts.<name> }}`.
+    pub artifacts: Option<Arc<BTreeMap<String, PathBuf>>>,
+    /// Optional resolver for `${{ artifact.<name>.<method> }}`.
+    pub artifact_resolver: Option<Arc<dyn ArtifactResolver>>,
 }
 
 /// Workflow executor.
@@ -218,6 +269,11 @@ pub(crate) async fn run_nested_workflow(
         // borrow rather than a clone.
         stages: Arc::new(RwLock::new(BTreeMap::new())),
         workflow_depth: parent_ctx.workflow_depth + 1,
+        // Inherit long-running scopes so a nested pipeline-style stage
+        // sees the same `${{ artifacts.* }}` / `${{ artifact.* }}` view
+        // its parent saw.
+        artifacts: parent_ctx.artifacts.clone(),
+        artifact_resolver: parent_ctx.artifact_resolver.clone(),
     };
 
     let mut step_results: BTreeMap<String, StepResult> = BTreeMap::new();
@@ -271,13 +327,7 @@ pub(crate) async fn run_nested_workflow(
     let stages_snapshot = nested_ctx.stages.read().await.clone();
     let mut output_values: BTreeMap<String, String> = BTreeMap::new();
     for (name, template) in &workflow.outputs {
-        let inner_ctx = expr::ExprContext::new(
-            &nested_ctx.inputs,
-            &step_results,
-            &nested_ctx.config_json,
-            &nested_ctx.env,
-        )
-        .with_stages(&stages_snapshot);
+        let inner_ctx = build_eval_ctx(&nested_ctx, &step_results, &stages_snapshot);
         let rendered = expr::eval_string(template, &inner_ctx)?;
         output_values.insert(name.clone(), rendered);
     }
@@ -337,6 +387,17 @@ impl WorkflowEngine {
         self.workflow_index.clone()
     }
 
+    /// Return a cheaply-cloned handle to the [`SandboxContext`] this
+    /// engine was built with.
+    ///
+    /// Long-running mode reuses this so its own bootstrap shell
+    /// commands run under the same Landlock / timeout / OOM-score
+    /// policy the engine applies to `shell` steps.
+    #[must_use]
+    pub fn sandbox(&self) -> Arc<SandboxContext> {
+        Arc::clone(&self.sandbox)
+    }
+
     /// Run the given workflow with the given input map.
     ///
     /// The supplied `progress_tx` receives one [`WorkflowProgress`]
@@ -378,6 +439,32 @@ impl WorkflowEngine {
         progress_tx: mpsc::Sender<WorkflowProgress>,
         cancel: CancellationToken,
     ) -> Result<WorkflowOutputs> {
+        self.run_with_extras(
+            workflow,
+            inputs,
+            progress_tx,
+            cancel,
+            EngineExtras::default(),
+        )
+        .await
+    }
+
+    /// Like [`Self::run_with_cancel`] but additionally accepts an
+    /// [`EngineExtras`] bundle so long-running workflows can inject
+    /// their per-run artifact map and `artifact.*` resolver.
+    ///
+    /// This is the entry point used by [`crate::LongRunningExecutor`]
+    /// when running iterate-phase steps so any step expression
+    /// referencing `${{ artifacts.<name> }}` or
+    /// `${{ artifact.<name>.<method> }}` resolves correctly.
+    pub async fn run_with_extras(
+        &self,
+        workflow: &WorkflowDef,
+        inputs: BTreeMap<String, Value>,
+        progress_tx: mpsc::Sender<WorkflowProgress>,
+        cancel: CancellationToken,
+        extras: EngineExtras,
+    ) -> Result<WorkflowOutputs> {
         // Resolve inputs (apply defaults / required check).
         let resolved_inputs = resolve_inputs(&workflow.inputs, inputs)?;
         let inputs_value = Value::Object(resolved_inputs);
@@ -411,6 +498,8 @@ impl WorkflowEngine {
             workflow_index: self.workflow_index.clone(),
             stages: Arc::new(RwLock::new(BTreeMap::new())),
             workflow_depth: 0,
+            artifacts: extras.artifacts,
+            artifact_resolver: extras.artifact_resolver,
         };
 
         let mut step_results: BTreeMap<String, StepResult> = BTreeMap::new();
@@ -489,9 +578,7 @@ impl WorkflowEngine {
         let stages_snapshot = ctx.stages.read().await.clone();
         let mut output_values: BTreeMap<String, String> = BTreeMap::new();
         for (name, template) in &workflow.outputs {
-            let inner_ctx =
-                expr::ExprContext::new(&ctx.inputs, &step_results, &ctx.config_json, &ctx.env)
-                    .with_stages(&stages_snapshot);
+            let inner_ctx = build_eval_ctx(&ctx, &step_results, &stages_snapshot);
             let rendered = expr::eval_string(template, &inner_ctx)?;
             output_values.insert(name.clone(), rendered);
         }
@@ -539,9 +626,7 @@ async fn dispatch_step_inner(
     // Evaluate `when` clause for leaf steps that support it.
     if let Some(expr_src) = step.when() {
         let stages_snapshot = ctx.stages.read().await.clone();
-        let eval_ctx =
-            expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
-                .with_stages(&stages_snapshot);
+        let eval_ctx = build_eval_ctx(ctx, step_results, &stages_snapshot);
         let cond = expr::eval_bool(expr_src, &eval_ctx).map_err(|e| WorkflowError::StepFailed {
             step_id: step_id.clone(),
             message: format!("when-expression error: {e}"),
@@ -586,9 +671,7 @@ async fn dispatch_step_inner(
                     message: "agent semaphore was closed".to_owned(),
                 })?;
             let stages_snapshot = ctx.stages.read().await.clone();
-            let eval_ctx =
-                expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
-                    .with_stages(&stages_snapshot);
+            let eval_ctx = build_eval_ctx(ctx, step_results, &stages_snapshot);
             let result = steps::agent::execute(steps::agent::AgentStepArgs {
                 subagent_manager: &ctx.subagent_manager,
                 sandbox: &ctx.sandbox,
@@ -610,9 +693,7 @@ async fn dispatch_step_inner(
             when: _,
         } => {
             let stages_snapshot = ctx.stages.read().await.clone();
-            let eval_ctx =
-                expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
-                    .with_stages(&stages_snapshot);
+            let eval_ctx = build_eval_ctx(ctx, step_results, &stages_snapshot);
             steps::shell::execute(
                 &ctx.sandbox,
                 ctx.config.default_shell_timeout,
@@ -628,9 +709,7 @@ async fn dispatch_step_inner(
             content,
         } => {
             let stages_snapshot = ctx.stages.read().await.clone();
-            let eval_ctx =
-                expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
-                    .with_stages(&stages_snapshot);
+            let eval_ctx = build_eval_ctx(ctx, step_results, &stages_snapshot);
             steps::write_file::execute(&ctx.sandbox, path, content, &eval_ctx).await
         }
         StepDef::Loop { .. } => {

--- a/crates/tmg-workflow/src/expr.rs
+++ b/crates/tmg-workflow/src/expr.rs
@@ -55,11 +55,30 @@
 //!   scope keys ("unknown identifier 'foo' in 'inputs'").
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use serde_json::Value;
 
 use crate::def::{StepResult, WorkflowOutputs};
 use crate::error::{Result, WorkflowError};
+
+/// Resolves the special `${{ artifact.<name>.<method> }}` expression
+/// scope.
+///
+/// `tail` is the dotted suffix after the leading `artifact.` (for
+/// example, the expression `${{ artifact.features.all_passing }}`
+/// arrives here as `"features.all_passing"`). Implementations dispatch
+/// on the head and return a JSON value (typically a bool / number /
+/// string) suitable for use in `${{ ... }}` substitution and `until:`
+/// boolean evaluation.
+///
+/// The trait is `Send + Sync` so the [`ExprContext`] holding a
+/// reference to the resolver can be shared across the workflow
+/// engine's recursive dispatch.
+pub trait ArtifactResolver: Send + Sync {
+    /// Resolve `tail` (dotted, no leading `artifact.`) into a value.
+    fn resolve(&self, tail: &str) -> Result<Value>;
+}
 
 /// Compute a 1-based `(line, col)` for a byte offset into `src`.
 ///
@@ -84,14 +103,25 @@ fn line_col(src: &str, pos: usize) -> (usize, usize) {
     (line, col)
 }
 
-/// The four+ scopes available to expressions.
+/// The scopes available to expressions.
 ///
-/// `stages` is an optional fifth scope used by declarative-pipeline
-/// (`stages:`) workflows added in issue #41. It carries the per-stage
-/// [`WorkflowOutputs`] map keyed by stage id; pipelines can reference
-/// `${{ stages.<id>.outputs.<key> }}` between stages. Plain workflows
-/// (no `stages:`) leave it as `None`, which matches the historical
-/// scope set (`inputs`, `steps`, `config`, `env`) exactly.
+/// In addition to the four standard scopes (`inputs`, `steps`,
+/// `config`, `env`), additional optional scopes can be attached:
+///
+/// - `stages`: an optional pipeline scope used by declarative-pipeline
+///   (`stages:`) workflows added in issue #41. It carries the per-stage
+///   [`WorkflowOutputs`] map keyed by stage id; pipelines can reference
+///   `${{ stages.<id>.outputs.<key> }}` between stages. Plain workflows
+///   (no `stages:`) leave it as `None`.
+/// - `artifacts`: a `BTreeMap<String, PathBuf>` exposed to expressions
+///   as `${{ artifacts.<name> }}` (returns the path string).
+/// - `artifact_resolver`: an [`ArtifactResolver`] that dispatches the
+///   special `${{ artifact.<name>.<method> }}` form against a live
+///   data source — typically the harnessed run's `features.json`.
+///
+/// All three optional fields default to `None`. Workflows that don't
+/// opt into these scopes see a clear "unknown top-level identifier"
+/// error if they try to reference them.
 pub struct ExprContext<'a> {
     /// Workflow inputs as a JSON object.
     pub inputs: &'a Value,
@@ -105,15 +135,21 @@ pub struct ExprContext<'a> {
     /// outer workflow has `stages:` and is dispatching a `workflow`
     /// step). `None` outside that context.
     pub stages: Option<&'a BTreeMap<String, WorkflowOutputs>>,
+    /// Optional named artifact paths (`artifacts.<name>` -> path
+    /// string).
+    pub artifacts: Option<&'a BTreeMap<String, PathBuf>>,
+    /// Optional resolver for the `artifact.<name>.<method>` scope.
+    pub artifact_resolver: Option<&'a dyn ArtifactResolver>,
 }
 
 impl<'a> ExprContext<'a> {
-    /// Construct a new context.
+    /// Construct a new context with the four standard scopes.
     ///
-    /// The `stages` scope is left empty (`None`) — equivalent to the
-    /// historical four-scope context used by single-workflow runs. Use
-    /// [`Self::with_stages`] to attach a stages map for pipeline
-    /// dispatch.
+    /// All optional scopes (`stages`, `artifacts`, `artifact_resolver`)
+    /// are left empty. Use [`with_stages`](Self::with_stages),
+    /// [`with_artifacts`](Self::with_artifacts), and
+    /// [`with_artifact_resolver`](Self::with_artifact_resolver) to opt
+    /// into the additional scopes.
     #[must_use]
     pub fn new(
         inputs: &'a Value,
@@ -127,6 +163,8 @@ impl<'a> ExprContext<'a> {
             config,
             env,
             stages: None,
+            artifacts: None,
+            artifact_resolver: None,
         }
     }
 
@@ -136,6 +174,26 @@ impl<'a> ExprContext<'a> {
     #[must_use]
     pub fn with_stages(mut self, stages: &'a BTreeMap<String, WorkflowOutputs>) -> Self {
         self.stages = Some(stages);
+        self
+    }
+
+    /// Attach an `artifacts` map to this context.
+    ///
+    /// Returns `self` for builder-style chaining. The map is borrowed
+    /// for the context's lifetime.
+    #[must_use]
+    pub fn with_artifacts(mut self, artifacts: &'a BTreeMap<String, PathBuf>) -> Self {
+        self.artifacts = Some(artifacts);
+        self
+    }
+
+    /// Attach an [`ArtifactResolver`] to this context.
+    ///
+    /// Returns `self` for builder-style chaining. The resolver is
+    /// borrowed for the context's lifetime.
+    #[must_use]
+    pub fn with_artifact_resolver(mut self, resolver: &'a dyn ArtifactResolver) -> Self {
+        self.artifact_resolver = Some(resolver);
         self
     }
 }
@@ -718,14 +776,96 @@ fn resolve_path(segs: &[PathSeg], ctx: &ExprContext) -> Result<Value> {
             // when the engine attached a stages map (pipeline dispatch).
             return resolve_stages_path(&segs[1..], ctx);
         }
+        "artifacts" => {
+            return resolve_artifacts_path(&segs[1..], ctx);
+        }
+        "artifact" => {
+            return resolve_artifact_method(&segs[1..], ctx);
+        }
         other => {
             return Err(WorkflowError::expression(format!(
-                "unknown top-level identifier '{other}' (allowed: inputs, steps, stages, config, env)"
+                "unknown top-level identifier '{other}' (allowed: inputs, steps, stages, config, env, artifacts, artifact)"
             )));
         }
     };
 
     walk_path(&head, &segs[1..], scope)
+}
+
+/// Resolve `artifacts.<name>` to the configured path string.
+///
+/// Returns a clear error when no `artifacts` map was attached (i.e.
+/// the caller is not in a long-running workflow context) so the
+/// workflow author sees a useful message instead of a silent `null`.
+fn resolve_artifacts_path(rest: &[PathSeg], ctx: &ExprContext) -> Result<Value> {
+    let Some(artifacts) = ctx.artifacts else {
+        return Err(WorkflowError::expression(
+            "the 'artifacts' scope is only available inside a long_running workflow's iterate phase",
+        ));
+    };
+    let Some(first) = rest.first() else {
+        // Bare `artifacts` reference — return all entries as an object
+        // for completeness (cheap; the map is small).
+        let mut obj = serde_json::Map::new();
+        for (name, path) in artifacts {
+            obj.insert(
+                name.clone(),
+                Value::String(path.to_string_lossy().into_owned()),
+            );
+        }
+        return Ok(Value::Object(obj));
+    };
+    let name = match first {
+        PathSeg::Ident(s) | PathSeg::Index(s) => s,
+    };
+    let Some(path) = artifacts.get(name) else {
+        return Err(WorkflowError::expression(format!(
+            "unknown artifact '{name}' in 'artifacts' (declared names: {names})",
+            names = artifacts.keys().cloned().collect::<Vec<_>>().join(", "),
+        )));
+    };
+    let value = Value::String(path.to_string_lossy().into_owned());
+    walk_path(&value, &rest[1..], &format!("artifacts.{name}"))
+}
+
+/// Resolve `artifact.<name>.<method>` by dispatching to the attached
+/// [`ArtifactResolver`].
+///
+/// The full dotted suffix (e.g. `features.all_passing`) is passed to
+/// the resolver verbatim. Any remaining path segments after the
+/// resolver returns are walked normally so callers can still drill
+/// into a returned object (e.g. `artifact.features.all_passing` ->
+/// bool, `artifact.features.summary.entries[0]` -> object).
+fn resolve_artifact_method(rest: &[PathSeg], ctx: &ExprContext) -> Result<Value> {
+    let Some(resolver) = ctx.artifact_resolver else {
+        return Err(WorkflowError::expression(
+            "the 'artifact' scope is only available inside a long_running workflow's iterate phase",
+        ));
+    };
+    if rest.is_empty() {
+        return Err(WorkflowError::expression(
+            "expected 'artifact.<name>.<method>' (e.g. 'artifact.features.all_passing')",
+        ));
+    }
+    // Consume *all* leading identifier segments as the resolver tail.
+    // `[ "features", "all_passing" ]` -> `"features.all_passing"`. Any
+    // further segments after that — typically empty — are left for
+    // `walk_path` to handle in case the resolver returns a structured
+    // value the caller wants to drill into.
+    //
+    // Concretely we feed the resolver the whole tail; callers that
+    // want a "stop walking after method" semantic can return a scalar
+    // and `walk_path` becomes a no-op.
+    let tail_parts: Vec<&str> = rest
+        .iter()
+        .map(|seg| match seg {
+            PathSeg::Ident(s) | PathSeg::Index(s) => s.as_str(),
+        })
+        .collect();
+    let tail = tail_parts.join(".");
+    let value = resolver.resolve(&tail)?;
+    // No further walking — the resolver already received the full tail.
+    Ok(value)
 }
 
 fn resolve_steps_path(rest: &[PathSeg], ctx: &ExprContext) -> Result<Value> {
@@ -1256,5 +1396,80 @@ mod tests {
         let src = "ab\ncd\nefg";
         let (line, col) = line_col(src, 7);
         assert_eq!((line, col), (3, 2));
+    }
+
+    #[test]
+    fn artifacts_scope_returns_path_string() {
+        let inputs = Value::Null;
+        let s = BTreeMap::new();
+        let c = Value::Null;
+        let e = BTreeMap::new();
+        let mut artifacts = BTreeMap::new();
+        artifacts.insert(
+            "progress_file".to_owned(),
+            PathBuf::from("/run/progress.md"),
+        );
+        let ctx = ExprContext::new(&inputs, &s, &c, &e).with_artifacts(&artifacts);
+        let v = eval_value("artifacts.progress_file", &ctx).unwrap();
+        assert_eq!(v, json!("/run/progress.md"));
+    }
+
+    #[test]
+    fn artifacts_scope_unknown_name_errors() {
+        let inputs = Value::Null;
+        let s = BTreeMap::new();
+        let c = Value::Null;
+        let e = BTreeMap::new();
+        let mut artifacts = BTreeMap::new();
+        artifacts.insert("known".to_owned(), PathBuf::from("/p"));
+        let ctx = ExprContext::new(&inputs, &s, &c, &e).with_artifacts(&artifacts);
+        let err = eval_value("artifacts.unknown", &ctx).unwrap_err();
+        assert!(err.to_string().contains("unknown artifact 'unknown'"));
+    }
+
+    #[test]
+    fn artifacts_scope_without_attached_errors() {
+        let (i, s, c, e) = ctx_with_inputs(Value::Null);
+        let ctx = make_ctx(&i, &s, &c, &e);
+        let err = eval_value("artifacts.foo", &ctx).unwrap_err();
+        assert!(err.to_string().contains("only available inside"));
+    }
+
+    /// A test resolver that maps a fixed table.
+    struct TestResolver;
+    impl ArtifactResolver for TestResolver {
+        fn resolve(&self, tail: &str) -> Result<Value> {
+            match tail {
+                "features.all_passing" => Ok(json!(true)),
+                "features.passing_count" => Ok(json!(7)),
+                other => Err(WorkflowError::expression(format!("unknown {other}"))),
+            }
+        }
+    }
+
+    #[test]
+    fn artifact_method_dispatches_to_resolver() {
+        let inputs = Value::Null;
+        let s = BTreeMap::new();
+        let c = Value::Null;
+        let e = BTreeMap::new();
+        let resolver = TestResolver;
+        let ctx = ExprContext::new(&inputs, &s, &c, &e).with_artifact_resolver(&resolver);
+        assert_eq!(
+            eval_value("artifact.features.all_passing", &ctx).unwrap(),
+            json!(true),
+        );
+        assert_eq!(
+            eval_value("artifact.features.passing_count", &ctx).unwrap(),
+            json!(7),
+        );
+    }
+
+    #[test]
+    fn artifact_scope_without_resolver_errors() {
+        let (i, s, c, e) = ctx_with_inputs(Value::Null);
+        let ctx = make_ctx(&i, &s, &c, &e);
+        let err = eval_value("artifact.features.all_passing", &ctx).unwrap_err();
+        assert!(err.to_string().contains("only available inside"));
     }
 }

--- a/crates/tmg-workflow/src/lib.rs
+++ b/crates/tmg-workflow/src/lib.rs
@@ -36,11 +36,11 @@ pub mod tools;
 
 pub use config::WorkflowConfig;
 pub use def::{
-    BootstrapItem, FailurePolicy, InitPhase, InputDef, IteratePhase, LoopSpec, StepDef,
-    StepResult, WorkflowDef, WorkflowMeta, WorkflowMode, WorkflowOutputs,
+    BootstrapItem, FailurePolicy, InitPhase, InputDef, IteratePhase, LoopSpec, StepDef, StepResult,
+    WorkflowDef, WorkflowMeta, WorkflowMode, WorkflowOutputs,
 };
 pub use discovery::discover_workflows;
-pub use engine::{WorkflowEngine, WorkflowIndex};
+pub use engine::{EngineExtras, WorkflowEngine, WorkflowIndex};
 pub use error::{Result, WorkflowError};
 pub use expr::{ArtifactResolver, ExprContext, eval_bool, eval_string, eval_value};
 pub use long_running::{LongRunningExecutor, RunStatus};

--- a/crates/tmg-workflow/src/lib.rs
+++ b/crates/tmg-workflow/src/lib.rs
@@ -28,6 +28,7 @@ pub mod discovery;
 pub mod engine;
 pub mod error;
 pub mod expr;
+pub mod long_running;
 pub mod parse;
 pub mod progress;
 pub(crate) mod steps;
@@ -35,13 +36,14 @@ pub mod tools;
 
 pub use config::WorkflowConfig;
 pub use def::{
-    FailurePolicy, InputDef, LoopSpec, StepDef, StepResult, WorkflowDef, WorkflowMeta,
-    WorkflowMode, WorkflowOutputs,
+    BootstrapItem, FailurePolicy, InitPhase, InputDef, IteratePhase, LoopSpec, StepDef,
+    StepResult, WorkflowDef, WorkflowMeta, WorkflowMode, WorkflowOutputs,
 };
 pub use discovery::discover_workflows;
 pub use engine::{WorkflowEngine, WorkflowIndex};
 pub use error::{Result, WorkflowError};
-pub use expr::{ExprContext, eval_bool, eval_string, eval_value};
+pub use expr::{ArtifactResolver, ExprContext, eval_bool, eval_string, eval_value};
+pub use long_running::{LongRunningExecutor, RunStatus};
 pub use parse::{parse_workflow_file, parse_workflow_str};
 pub use progress::{HumanResponder, HumanResponse, HumanResponseKind, WorkflowProgress};
 pub use tools::{

--- a/crates/tmg-workflow/src/long_running.rs
+++ b/crates/tmg-workflow/src/long_running.rs
@@ -1,0 +1,624 @@
+//! Long-running workflow executor (SPEC §8.12 + §9.9).
+//!
+//! Drives the `mode: long_running` workflow lifecycle on top of the
+//! existing [`WorkflowEngine`]:
+//!
+//! 1. **Init phase** — runs once per harnessed run on first attach.
+//!    Typically calls the `initializer` builtin subagent through an
+//!    `agent` step to produce `features.json` / `init.sh` /
+//!    `progress.md`. After the steps complete the executor invokes
+//!    [`tmg_harness::RunRunner::escalate_to_harnessed`] so the run
+//!    flips to harnessed scope and the on-disk artifacts are recorded.
+//!
+//! 2. **Iterate phase** — the per-session loop. Each iteration begins
+//!    a new harnessed session, resolves the `bootstrap` items into a
+//!    context block, runs `iterate.steps`, then evaluates the `until`
+//!    expression. Sessions stop the loop on:
+//!    - `until` truthy → [`RunStatus::Completed`]
+//!    - `session_count >= max_sessions` →
+//!      [`RunStatus::Exhausted { reason: "max_sessions" }`]
+//!    - `session_timeout` exceeded → fires
+//!      [`tmg_harness::SessionEndTrigger::Timeout`] via the existing
+//!      watchdog channel and continues with the next iteration.
+//!
+//! ## Cancellation safety
+//!
+//! Every await point is cancel-safe at the session boundary. The
+//! per-session loop honours the engine's progress channel for visibility
+//! but does not block on a UI consumer; a slow consumer back-pressures
+//! progress events without stalling the loop.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::sync::{Mutex, mpsc};
+
+use tmg_harness::{RunRunner, SessionEndTrigger};
+
+use crate::def::{BootstrapItem, StepDef, StepResult, WorkflowDef, WorkflowMode};
+use crate::engine::WorkflowEngine;
+use crate::error::{Result, WorkflowError};
+use crate::expr::{self, ArtifactResolver, ExprContext};
+use crate::progress::WorkflowProgress;
+
+/// Terminal state of [`LongRunningExecutor::run`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RunStatus {
+    /// `until:` evaluated truthy and the run completed normally.
+    Completed,
+    /// Hit a hard stop (e.g. `max_sessions`) without completing.
+    Exhausted {
+        /// Short tag identifying the stop reason (e.g.
+        /// `"max_sessions"`).
+        reason: String,
+    },
+    /// A step in the iterate phase failed; the carried message is the
+    /// formatted [`WorkflowError`].
+    Failed {
+        /// Error message.
+        error: String,
+    },
+}
+
+/// Stateful executor that drives a `mode: long_running` workflow.
+///
+/// Constructed once per CLI / TUI invocation and given a shared
+/// [`WorkflowEngine`] plus the run's [`RunRunner`].
+pub struct LongRunningExecutor {
+    engine: Arc<WorkflowEngine>,
+    run_runner: Arc<Mutex<RunRunner>>,
+}
+
+impl LongRunningExecutor {
+    /// Build a new executor.
+    #[must_use]
+    pub fn new(engine: Arc<WorkflowEngine>, run_runner: Arc<Mutex<RunRunner>>) -> Self {
+        Self { engine, run_runner }
+    }
+
+    /// Drive the workflow to its terminal [`RunStatus`].
+    ///
+    /// Returns:
+    ///
+    /// - [`RunStatus::Completed`] when the iterate phase's `until`
+    ///   expression evaluates truthy at the end of a session.
+    /// - [`RunStatus::Exhausted`] when `iterate.max_sessions` is
+    ///   reached without `until` ever firing.
+    /// - [`RunStatus::Failed`] when an init or iterate step propagates
+    ///   a [`WorkflowError`] up.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WorkflowError`] only for setup-level problems (the
+    /// workflow is not `mode: long_running`, the `iterate` phase is
+    /// missing, or the harness escalation I/O fails). Step-level
+    /// failures inside the iterate loop are surfaced as
+    /// [`RunStatus::Failed`] so the caller can persist the error to
+    /// `run.toml` without unwinding.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "linear init-then-loop sequence; splitting it into helpers would scatter the session lifecycle across tiny methods"
+    )]
+    pub async fn run(
+        &self,
+        workflow: &WorkflowDef,
+        inputs: BTreeMap<String, Value>,
+    ) -> Result<RunStatus> {
+        if workflow.mode != WorkflowMode::LongRunning {
+            return Err(WorkflowError::invalid_workflow(
+                workflow.id.clone(),
+                "LongRunningExecutor::run requires a `mode: long_running` workflow",
+            ));
+        }
+        let Some(iterate) = workflow.iterate.as_ref() else {
+            return Err(WorkflowError::invalid_workflow(
+                workflow.id.clone(),
+                "long_running workflow has no `iterate:` phase",
+            ));
+        };
+
+        // ---------- Init phase ----------
+        // Run init.steps once when the run is still ad-hoc, then
+        // escalate to harnessed. Idempotency: if the run is already
+        // harnessed (e.g. resumed from a previous attempt) we skip
+        // this entire branch and go straight to the iterate loop.
+        let init_artifacts = workflow
+            .init
+            .as_ref()
+            .map(|init| init.artifacts.clone())
+            .unwrap_or_default();
+
+        let must_init = {
+            let runner = self.run_runner.lock().await;
+            runner.scope().is_ad_hoc()
+        };
+        if must_init {
+            if let Some(init) = workflow.init.as_ref() {
+                let init_inputs = inputs.clone();
+                let init_workflow = synthesize_phase_workflow(
+                    &workflow.id,
+                    "init",
+                    &init.steps,
+                    &workflow.inputs,
+                    &init_artifacts,
+                );
+                if let Err(err) = self.run_phase(&init_workflow, init_inputs).await {
+                    return Ok(RunStatus::Failed {
+                        error: err.to_string(),
+                    });
+                }
+            }
+            // Escalate even when there are no init.steps — the SPEC
+            // §9.9 invariant is that long_running runs are harnessed
+            // by the time the iterate loop begins.
+            self.escalate_run().await?;
+        }
+
+        // ---------- Iterate phase ----------
+        let mut session_idx: u32 = 0;
+        loop {
+            session_idx += 1;
+            if session_idx > iterate.max_sessions {
+                return Ok(RunStatus::Exhausted {
+                    reason: "max_sessions".to_owned(),
+                });
+            }
+
+            // 1. Begin a new harnessed session and arm the watchdog.
+            let (timeout_tx, mut timeout_rx) = mpsc::channel::<SessionEndTrigger>(2);
+            let session_handle = {
+                let mut runner = self.run_runner.lock().await;
+                runner
+                    .begin_session()
+                    .map_err(|e| WorkflowError::StepFailed {
+                        step_id: "iterate".to_owned(),
+                        message: format!("begin_session: {e}"),
+                    })?
+            };
+
+            // 2. Resolve bootstrap items.
+            let bootstrap_block = match self
+                .resolve_bootstrap(&iterate.bootstrap, &init_artifacts, &inputs)
+                .await
+            {
+                Ok(b) => b,
+                Err(err) => {
+                    let mut runner = self.run_runner.lock().await;
+                    let _ = runner.end_session(&session_handle, SessionEndTrigger::UserExit);
+                    return Ok(RunStatus::Failed {
+                        error: format!("bootstrap failed: {err}"),
+                    });
+                }
+            };
+
+            // 3. Execute iterate.steps with the bootstrap block + the
+            //    artifacts map injected as `bootstrap_input`.
+            let mut iterate_inputs = inputs.clone();
+            iterate_inputs.insert(
+                "bootstrap_context".to_owned(),
+                Value::String(bootstrap_block),
+            );
+            iterate_inputs.insert(
+                "session_index".to_owned(),
+                Value::Number(serde_json::Number::from(session_idx)),
+            );
+            let iter_workflow = synthesize_phase_workflow(
+                &workflow.id,
+                "iterate",
+                &iterate.steps,
+                &workflow.inputs,
+                &init_artifacts,
+            );
+
+            // Arm the per-session watchdog. The runner's existing
+            // helper spawns a tokio sleep + try_send task; we still
+            // wrap the engine's `run` in a `tokio::time::timeout` so
+            // an aborted-watchdog path still terminates the loop in
+            // bounded time. The watchdog drives the *trigger
+            // attribution* (so the persisted session record carries
+            // `Timeout`); the local `tokio::time::timeout` drives the
+            // actual unwind.
+            self.arm_watchdog(timeout_tx.clone(), iterate.session_timeout)
+                .await;
+
+            let exec_future =
+                run_engine_drain(Arc::clone(&self.engine), iter_workflow, iterate_inputs);
+
+            let exec_outcome = tokio::time::timeout(iterate.session_timeout, exec_future).await;
+
+            // Drain the watchdog channel non-blockingly to see whether
+            // it fired. If it did, the session ended on a Timeout.
+            let watchdog_fired = matches!(timeout_rx.try_recv(), Ok(SessionEndTrigger::Timeout));
+            let timeout_fired = exec_outcome.is_err() || watchdog_fired;
+            // If the steps returned an error (not a timeout), surface
+            // it as Failed rather than continuing.
+            if let Ok(Err(err)) = exec_outcome {
+                let mut runner = self.run_runner.lock().await;
+                runner.disarm_timeout_watchdog();
+                let _ = runner.end_session(&session_handle, SessionEndTrigger::UserExit);
+                return Ok(RunStatus::Failed {
+                    error: err.to_string(),
+                });
+            }
+
+            // Disarm the watchdog and end the session.
+            {
+                let mut runner = self.run_runner.lock().await;
+                runner.disarm_timeout_watchdog();
+                let trigger = if timeout_fired {
+                    SessionEndTrigger::Timeout
+                } else {
+                    SessionEndTrigger::Completed
+                };
+                runner.end_session(&session_handle, trigger).map_err(|e| {
+                    WorkflowError::StepFailed {
+                        step_id: "iterate".to_owned(),
+                        message: format!("end_session: {e}"),
+                    }
+                })?;
+            }
+
+            // If the session timed out, skip the `until` evaluation
+            // and just begin the next iteration.
+            if timeout_fired {
+                continue;
+            }
+
+            // 4. Evaluate `until` against the run's resolver.
+            let resolver = RunRunnerArtifactResolver {
+                runner: Arc::clone(&self.run_runner),
+            };
+            let inputs_value = Value::Object(map_to_obj(&inputs));
+            let env: BTreeMap<String, String> = std::env::vars().collect();
+            let empty_steps: BTreeMap<String, StepResult> = BTreeMap::new();
+            let until_ctx = ExprContext::new(&inputs_value, &empty_steps, &Value::Null, &env)
+                .with_artifacts(&init_artifacts)
+                .with_artifact_resolver(&resolver);
+            let stop = expr::eval_bool(&iterate.until, &until_ctx).map_err(|e| {
+                WorkflowError::StepFailed {
+                    step_id: "iterate.until".to_owned(),
+                    message: e.to_string(),
+                }
+            })?;
+            if stop {
+                return Ok(RunStatus::Completed);
+            }
+        }
+    }
+
+    /// Escalate the active run from ad-hoc to harnessed scope.
+    ///
+    /// This is the SPEC §9.9 forced upgrade for `mode: long_running`.
+    /// We synthesize an [`tmg_harness::EscalationDecision::Escalate`]
+    /// (no estimated feature count yet — the count populates from
+    /// `features.json` once the initializer has produced it) and feed
+    /// the runner empty `features_json` / `init.sh` text. The runner
+    /// truncates over any existing files via `std::fs::write`, so
+    /// writing empty strings is benign when the init phase already
+    /// produced the real artifacts on its own. (For workflows that
+    /// don't run an initializer step the empty files are sufficient
+    /// to record the harnessed transition; SPEC §9.3 considers the
+    /// scope flip the source of truth.)
+    async fn escalate_run(&self) -> Result<()> {
+        let mut runner = self.run_runner.lock().await;
+        if !runner.scope().is_ad_hoc() {
+            return Ok(());
+        }
+        // Read whatever the init phase wrote (if anything) and feed it
+        // to escalate_to_harnessed. The runner's contract is that the
+        // strings are written verbatim into `features.json` / `init.sh`,
+        // overwriting any existing content. We re-feed the existing
+        // contents so a successful init phase isn't clobbered with
+        // empty bytes.
+        let features_path = runner.features().path().to_path_buf();
+        let init_path = runner.init_script().path().to_path_buf();
+        let features_json = read_or_default(&features_path, "{\"features\":[]}");
+        let init_script = read_or_default(&init_path, "#!/bin/sh\n");
+
+        let decision = tmg_harness::EscalationDecision::Escalate {
+            reason: "mode: long_running forced harnessed scope".to_owned(),
+            estimated_features: None,
+        };
+        runner
+            .escalate_to_harnessed(&features_json, &init_script, &decision)
+            .map_err(|e| WorkflowError::StepFailed {
+                step_id: "init".to_owned(),
+                message: format!("escalate_to_harnessed: {e}"),
+            })?;
+        Ok(())
+    }
+
+    /// Run a single phase (init or iterate) by delegating to the
+    /// engine's standard `run` path.
+    async fn run_phase(
+        &self,
+        phase_workflow: &WorkflowDef,
+        inputs: BTreeMap<String, Value>,
+    ) -> Result<()> {
+        let (tx, mut rx) = mpsc::channel::<WorkflowProgress>(64);
+        // Spawn a drain task so the engine can keep emitting progress
+        // even when no UI is attached.
+        let drain = tokio::spawn(async move {
+            while rx.recv().await.is_some() {
+                // Discard for now; SPEC §8.10 wires this to the TUI.
+            }
+        });
+        let _outputs = self.engine.run(phase_workflow, inputs, tx).await?;
+        drain.abort();
+        Ok(())
+    }
+
+    /// Resolve bootstrap items into a single context block string.
+    async fn resolve_bootstrap(
+        &self,
+        items: &[BootstrapItem],
+        artifacts: &BTreeMap<String, PathBuf>,
+        inputs: &BTreeMap<String, Value>,
+    ) -> Result<String> {
+        if items.is_empty() {
+            return Ok(String::new());
+        }
+        let mut buf = String::new();
+        buf.push_str("[bootstrap]\n");
+        let inputs_value = Value::Object(map_to_obj(inputs));
+        let env: BTreeMap<String, String> = std::env::vars().collect();
+        let empty_steps: BTreeMap<String, StepResult> = BTreeMap::new();
+        let resolver = RunRunnerArtifactResolver {
+            runner: Arc::clone(&self.run_runner),
+        };
+        for item in items {
+            let ctx = ExprContext::new(&inputs_value, &empty_steps, &Value::Null, &env)
+                .with_artifacts(artifacts)
+                .with_artifact_resolver(&resolver);
+            match item {
+                BootstrapItem::Run(cmd_template) => {
+                    let cmd = expr::eval_string(cmd_template, &ctx)?;
+                    let runner = self.run_runner.lock().await;
+                    let workspace = runner.workspace_path_owned();
+                    drop(runner);
+                    let output = run_shell_in(&workspace, &cmd).await?;
+                    let _ = writeln!(buf, "$ {cmd}");
+                    let _ = writeln!(buf, "{}", output.trim_end());
+                }
+                BootstrapItem::Read(path_template) => {
+                    let path_text = expr::eval_string(path_template, &ctx)?;
+                    let target = if Path::new(&path_text).is_absolute() {
+                        PathBuf::from(&path_text)
+                    } else {
+                        let runner = self.run_runner.lock().await;
+                        runner.workspace_path_owned().join(&path_text)
+                    };
+                    match tokio::fs::read_to_string(&target).await {
+                        Ok(text) => {
+                            let _ = writeln!(buf, "# read: {path_text}");
+                            let _ = writeln!(buf, "{text}");
+                        }
+                        Err(e) => {
+                            let _ = writeln!(buf, "# read: {path_text} FAILED: {e}");
+                        }
+                    }
+                }
+                BootstrapItem::SmokeTest(step) => {
+                    let summary = self.run_smoke_test(step, inputs).await?;
+                    let _ = writeln!(buf, "# smoke_test: {summary}");
+                }
+            }
+        }
+        Ok(buf)
+    }
+
+    /// Dispatch a single smoke-test step through a one-shot synthetic
+    /// workflow and return a short summary string.
+    async fn run_smoke_test(
+        &self,
+        step: &StepDef,
+        inputs: &BTreeMap<String, Value>,
+    ) -> Result<String> {
+        let phase = synthesize_phase_workflow(
+            "smoke_test",
+            "smoke_test",
+            std::slice::from_ref(step),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        );
+        let (tx, mut rx) = mpsc::channel::<WorkflowProgress>(32);
+        let id = step.id().to_owned();
+        let drain = tokio::spawn(async move {
+            // Capture a one-line summary from the StepCompleted event.
+            let mut last_exit: Option<i32> = None;
+            while let Some(evt) = rx.recv().await {
+                if let WorkflowProgress::StepCompleted { result, step_id } = evt
+                    && step_id == id
+                {
+                    last_exit = Some(result.exit_code);
+                }
+            }
+            last_exit
+        });
+        let outcome = self.engine.run(&phase, inputs.clone(), tx).await;
+        let exit = drain.await.unwrap_or(None);
+        match outcome {
+            Ok(_) => Ok(format!(
+                "{step_id} exit={exit}",
+                step_id = step.id(),
+                exit = exit.map_or_else(|| "?".to_owned(), |c| c.to_string()),
+            )),
+            Err(e) => Ok(format!("{step_id} ERROR: {e}", step_id = step.id())),
+        }
+    }
+
+    /// Arm the runner's per-session watchdog so a Timeout trigger is
+    /// delivered on `tx` after `duration` elapses.
+    async fn arm_watchdog(&self, tx: mpsc::Sender<SessionEndTrigger>, duration: Duration) {
+        let mut runner = self.run_runner.lock().await;
+        runner.arm_session_timeout_watchdog(duration, tx);
+    }
+}
+
+/// Run the workflow engine and drain the progress channel locally so
+/// the engine stays unblocked even when no UI is attached.
+async fn run_engine_drain(
+    engine: Arc<WorkflowEngine>,
+    workflow: WorkflowDef,
+    inputs: BTreeMap<String, Value>,
+) -> Result<crate::def::WorkflowOutputs> {
+    let (tx, mut rx) = mpsc::channel::<WorkflowProgress>(64);
+    let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+    let outputs = engine.run(&workflow, inputs, tx).await?;
+    drain.abort();
+    Ok(outputs)
+}
+
+/// Synthesize a single-phase [`WorkflowDef`] from `steps` so the
+/// engine's existing `run()` path can drive it.
+fn synthesize_phase_workflow(
+    parent_id: &str,
+    phase: &str,
+    steps: &[StepDef],
+    inputs: &BTreeMap<String, crate::def::InputDef>,
+    _artifacts: &BTreeMap<String, PathBuf>,
+) -> WorkflowDef {
+    WorkflowDef {
+        id: format!("{parent_id}__{phase}"),
+        description: Some(format!("{phase} phase of {parent_id}")),
+        // The synthetic phase workflow runs as a normal workflow under
+        // the engine; long-running orchestration is handled by the
+        // outer LongRunningExecutor.
+        mode: WorkflowMode::Normal,
+        inputs: inputs.clone(),
+        steps: steps.to_vec(),
+        outputs: BTreeMap::new(),
+        init: None,
+        iterate: None,
+    }
+}
+
+/// Bridge a [`tmg_harness::RunRunner`] into the [`ArtifactResolver`]
+/// trait, exposing the run-level data sources to the expression
+/// evaluator.
+///
+/// Currently supported `tail` values:
+///
+/// - `features.all_passing` → bool (vacuously true on an empty list).
+/// - `features.passing_count` → integer.
+///
+/// Unknown tails return a clear error message that lists the known
+/// names. To extend: add another arm in `resolve` and document it
+/// here.
+struct RunRunnerArtifactResolver {
+    runner: Arc<Mutex<RunRunner>>,
+}
+
+impl ArtifactResolver for RunRunnerArtifactResolver {
+    fn resolve(&self, tail: &str) -> Result<Value> {
+        // We need a sync read but the runner sits behind a tokio Mutex.
+        // `try_lock` succeeds in the synchronous expression evaluation
+        // path because the executor releases the mutex before calling
+        // into the evaluator. In the rare contended case we fall back
+        // to a clear error rather than blocking the runtime.
+        let guard = self.runner.try_lock().map_err(|_| {
+            WorkflowError::expression(
+                "could not acquire RunRunner lock for artifact.* resolution; \
+                 the long_running executor releases the lock before evaluating expressions",
+            )
+        })?;
+        match tail {
+            "features.all_passing" => {
+                let v = guard
+                    .features()
+                    .all_passing()
+                    .map_err(|e| WorkflowError::expression(format!("features.all_passing: {e}")))?;
+                Ok(json!(v))
+            }
+            "features.passing_count" => {
+                // Read full features list and count `passes == true`.
+                let parsed = guard.features().read().map_err(|e| {
+                    WorkflowError::expression(format!("features.passing_count: {e}"))
+                })?;
+                let count = parsed.features.iter().filter(|f| f.passes).count();
+                Ok(json!(count))
+            }
+            other => Err(WorkflowError::expression(format!(
+                "unknown artifact resolver method 'artifact.{other}' \
+                 (supported: features.all_passing, features.passing_count)"
+            ))),
+        }
+    }
+}
+
+/// Convert a `BTreeMap<String, Value>` into a `serde_json::Map`
+/// preserving ordering.
+fn map_to_obj(map: &BTreeMap<String, Value>) -> serde_json::Map<String, Value> {
+    map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+}
+
+/// Run a shell command in `workspace` and return combined stdout/stderr.
+async fn run_shell_in(workspace: &Path, cmd: &str) -> Result<String> {
+    let output = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(cmd)
+        .current_dir(workspace)
+        .output()
+        .await
+        .map_err(|e| WorkflowError::io(format!("running bootstrap command '{cmd}'"), e))?;
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !output.stderr.is_empty() {
+        combined.push_str("\n--- stderr ---\n");
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    }
+    Ok(combined)
+}
+
+/// Read a file or fall back to a default literal when the file is
+/// missing / unreadable.
+fn read_or_default(path: &Path, fallback: &str) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|_| fallback.to_owned())
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_status_completed_eq() {
+        assert_eq!(RunStatus::Completed, RunStatus::Completed);
+    }
+
+    #[test]
+    fn run_status_exhausted_carries_reason() {
+        let s = RunStatus::Exhausted {
+            reason: "max_sessions".to_owned(),
+        };
+        if let RunStatus::Exhausted { reason } = s {
+            assert_eq!(reason, "max_sessions");
+        } else {
+            panic!("expected Exhausted");
+        }
+    }
+
+    #[test]
+    fn synthesize_phase_workflow_carries_steps() {
+        let steps = vec![StepDef::Shell {
+            id: "x".to_owned(),
+            command: "true".to_owned(),
+            timeout: None,
+            when: None,
+        }];
+        let wf = synthesize_phase_workflow(
+            "build_app",
+            "init",
+            &steps,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        );
+        assert_eq!(wf.id, "build_app__init");
+        assert_eq!(wf.mode, WorkflowMode::Normal);
+        assert_eq!(wf.steps.len(), 1);
+    }
+}

--- a/crates/tmg-workflow/src/long_running.rs
+++ b/crates/tmg-workflow/src/long_running.rs
@@ -15,8 +15,10 @@
 //!    context block, runs `iterate.steps`, then evaluates the `until`
 //!    expression. Sessions stop the loop on:
 //!    - `until` truthy → [`RunStatus::Completed`]
-//!    - `session_count >= max_sessions` →
-//!      [`RunStatus::Exhausted { reason: "max_sessions" }`]
+//!    - `session_count > max_sessions` (i.e. the *next* index would
+//!      strictly exceed the cap) → [`RunStatus::Exhausted { reason:
+//!      "max_sessions" }`]. With `max_sessions: N` the executor
+//!      consumes exactly `N` sessions before giving up.
 //!    - `session_timeout` exceeded → fires
 //!      [`tmg_harness::SessionEndTrigger::Timeout`] via the existing
 //!      watchdog channel and continues with the next iteration.
@@ -30,17 +32,20 @@
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::{Value, json};
 use tokio::sync::{Mutex, mpsc};
+use tokio_util::sync::CancellationToken;
 
 use tmg_harness::{RunRunner, SessionEndTrigger};
+use tmg_sandbox::SandboxContext;
 
 use crate::def::{BootstrapItem, StepDef, StepResult, WorkflowDef, WorkflowMode};
-use crate::engine::WorkflowEngine;
+use crate::engine::{EngineExtras, WorkflowEngine};
 use crate::error::{Result, WorkflowError};
 use crate::expr::{self, ArtifactResolver, ExprContext};
 use crate::progress::WorkflowProgress;
@@ -147,7 +152,8 @@ impl LongRunningExecutor {
                     &workflow.inputs,
                     &init_artifacts,
                 );
-                if let Err(err) = self.run_phase(&init_workflow, init_inputs).await {
+                let extras = self.build_extras(&init_artifacts);
+                if let Err(err) = self.run_phase(&init_workflow, init_inputs, extras).await {
                     return Ok(RunStatus::Failed {
                         error: err.to_string(),
                     });
@@ -188,11 +194,15 @@ impl LongRunningExecutor {
             {
                 Ok(b) => b,
                 Err(err) => {
+                    let message = format!("bootstrap failed: {err}");
                     let mut runner = self.run_runner.lock().await;
-                    let _ = runner.end_session(&session_handle, SessionEndTrigger::UserExit);
-                    return Ok(RunStatus::Failed {
-                        error: format!("bootstrap failed: {err}"),
-                    });
+                    let _ = runner.end_session(
+                        &session_handle,
+                        SessionEndTrigger::Errored {
+                            message: message.clone(),
+                        },
+                    );
+                    return Ok(RunStatus::Failed { error: message });
                 }
             };
 
@@ -227,29 +237,56 @@ impl LongRunningExecutor {
                 .await;
 
             let exec_future =
-                run_engine_drain(Arc::clone(&self.engine), iter_workflow, iterate_inputs);
+                self.run_iterate_engine(iter_workflow, iterate_inputs, &init_artifacts);
 
             let exec_outcome = tokio::time::timeout(iterate.session_timeout, exec_future).await;
 
-            // Drain the watchdog channel non-blockingly to see whether
-            // it fired. If it did, the session ended on a Timeout.
-            let watchdog_fired = matches!(timeout_rx.try_recv(), Ok(SessionEndTrigger::Timeout));
-            let timeout_fired = exec_outcome.is_err() || watchdog_fired;
-            // If the steps returned an error (not a timeout), surface
-            // it as Failed rather than continuing.
-            if let Ok(Err(err)) = exec_outcome {
-                let mut runner = self.run_runner.lock().await;
-                runner.disarm_timeout_watchdog();
-                let _ = runner.end_session(&session_handle, SessionEndTrigger::UserExit);
-                return Ok(RunStatus::Failed {
-                    error: err.to_string(),
-                });
-            }
-
-            // Disarm the watchdog and end the session.
+            // Disarm the watchdog *before* draining the channel so the
+            // race window (watchdog fires after the engine returned
+            // cleanly but before we noticed) collapses. After this
+            // point the watchdog cannot deliver any more triggers.
             {
                 let mut runner = self.run_runner.lock().await;
                 runner.disarm_timeout_watchdog();
+            }
+
+            // The local `tokio::time::timeout` is the source of truth
+            // for whether the session timed out from the executor's
+            // perspective. The watchdog channel is checked only for
+            // diagnostic purposes — a stray watchdog event delivered
+            // *after* a clean engine completion is logged as a warning
+            // so the operator can spot misbehaving session-timeout
+            // configuration without it polluting the trigger
+            // attribution.
+            let timeout_fired = exec_outcome.is_err();
+            let watchdog_fired = matches!(timeout_rx.try_recv(), Ok(SessionEndTrigger::Timeout));
+            if watchdog_fired && !timeout_fired {
+                tracing::warn!(
+                    session_idx,
+                    "watchdog fired after engine completed cleanly; treating as benign race"
+                );
+            }
+
+            // If the steps returned an error (not a timeout), surface
+            // it as Failed rather than continuing.
+            if let Ok(Err(err)) = exec_outcome {
+                let message = err.to_string();
+                let mut runner = self.run_runner.lock().await;
+                let _ = runner.end_session(
+                    &session_handle,
+                    SessionEndTrigger::Errored {
+                        message: message.clone(),
+                    },
+                );
+                return Ok(RunStatus::Failed { error: message });
+            }
+
+            // End the session. The trigger attribution is `Timeout`
+            // only when the executor's own deadline fired; a stray
+            // watchdog event (handled above) does not promote a clean
+            // completion to a timeout.
+            {
+                let mut runner = self.run_runner.lock().await;
                 let trigger = if timeout_fired {
                     SessionEndTrigger::Timeout
                 } else {
@@ -279,12 +316,14 @@ impl LongRunningExecutor {
             let until_ctx = ExprContext::new(&inputs_value, &empty_steps, &Value::Null, &env)
                 .with_artifacts(&init_artifacts)
                 .with_artifact_resolver(&resolver);
-            let stop = expr::eval_bool(&iterate.until, &until_ctx).map_err(|e| {
-                WorkflowError::StepFailed {
-                    step_id: "iterate.until".to_owned(),
-                    message: e.to_string(),
+            let stop = match expr::eval_bool(&iterate.until, &until_ctx) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Ok(RunStatus::Failed {
+                        error: format!("iterate.until: {e}"),
+                    });
                 }
-            })?;
+            };
             if stop {
                 return Ok(RunStatus::Completed);
             }
@@ -317,8 +356,8 @@ impl LongRunningExecutor {
         // empty bytes.
         let features_path = runner.features().path().to_path_buf();
         let init_path = runner.init_script().path().to_path_buf();
-        let features_json = read_or_default(&features_path, "{\"features\":[]}");
-        let init_script = read_or_default(&init_path, "#!/bin/sh\n");
+        let features_json = read_or_default(&features_path, "{\"features\":[]}")?;
+        let init_script = read_or_default(&init_path, "#!/bin/sh\n")?;
 
         let decision = tmg_harness::EscalationDecision::Escalate {
             reason: "mode: long_running forced harnessed scope".to_owned(),
@@ -335,21 +374,33 @@ impl LongRunningExecutor {
 
     /// Run a single phase (init or iterate) by delegating to the
     /// engine's standard `run` path.
+    ///
+    /// `extras` is forwarded to [`WorkflowEngine::run_with_extras`] so
+    /// step expressions inside the phase see the long-running
+    /// `${{ artifacts.* }}` / `${{ artifact.* }}` scopes. The progress
+    /// channel is drained synchronously inside the same future via
+    /// `tokio::join!` (no spawn-then-abort): the engine never blocks on
+    /// a slow consumer because the local drain runs concurrently, and
+    /// when the engine returns the receiver is closed which terminates
+    /// the drain naturally.
     async fn run_phase(
         &self,
         phase_workflow: &WorkflowDef,
         inputs: BTreeMap<String, Value>,
+        extras: EngineExtras,
     ) -> Result<()> {
         let (tx, mut rx) = mpsc::channel::<WorkflowProgress>(64);
-        // Spawn a drain task so the engine can keep emitting progress
-        // even when no UI is attached.
-        let drain = tokio::spawn(async move {
+        let cancel = CancellationToken::new();
+        let drain = async move {
             while rx.recv().await.is_some() {
                 // Discard for now; SPEC §8.10 wires this to the TUI.
             }
-        });
-        let _outputs = self.engine.run(phase_workflow, inputs, tx).await?;
-        drain.abort();
+        };
+        let exec = self
+            .engine
+            .run_with_extras(phase_workflow, inputs, tx, cancel, extras);
+        let (outcome, ()) = tokio::join!(exec, drain);
+        let _outputs = outcome?;
         Ok(())
     }
 
@@ -381,7 +432,8 @@ impl LongRunningExecutor {
                     let runner = self.run_runner.lock().await;
                     let workspace = runner.workspace_path_owned();
                     drop(runner);
-                    let output = run_shell_in(&workspace, &cmd).await?;
+                    let sandbox = self.engine.sandbox();
+                    let output = run_shell_in(&sandbox, &workspace, &cmd).await?;
                     let _ = writeln!(buf, "$ {cmd}");
                     let _ = writeln!(buf, "{}", output.trim_end());
                 }
@@ -404,8 +456,22 @@ impl LongRunningExecutor {
                     }
                 }
                 BootstrapItem::SmokeTest(step) => {
-                    let summary = self.run_smoke_test(step, inputs).await?;
-                    let _ = writeln!(buf, "# smoke_test: {summary}");
+                    let outcome = self.run_smoke_test(step, inputs).await?;
+                    let _ = writeln!(buf, "# smoke_test: {summary}", summary = outcome.summary);
+                    if !outcome.passed {
+                        // SPEC §8.12: a failing smoke_test surfaces as
+                        // a workflow error so the operator (and the
+                        // `until` expression — which can react to the
+                        // bootstrap_context string) can distinguish a
+                        // green session from a flagged-as-broken one.
+                        return Err(WorkflowError::StepFailed {
+                            step_id: step.id().to_owned(),
+                            message: format!(
+                                "smoke_test failed: {summary}",
+                                summary = outcome.summary
+                            ),
+                        });
+                    }
                 }
             }
         }
@@ -413,12 +479,38 @@ impl LongRunningExecutor {
     }
 
     /// Dispatch a single smoke-test step through a one-shot synthetic
-    /// workflow and return a short summary string.
+    /// workflow and return a [`SmokeTestOutcome`] summary.
+    ///
+    /// ## Shared resources
+    ///
+    /// The smoke-test step runs through the same [`WorkflowEngine`]
+    /// instance as the iterate phase and therefore competes for the
+    /// engine's `agent_semaphore` (the cap configured by
+    /// `[workflow] max_parallel_agents`). For shell-typed smoke tests
+    /// this is irrelevant — `shell` and `write_file` steps don't take
+    /// a permit. For agent-typed smoke tests, however, an in-flight
+    /// iterate-phase agent step would block the smoke test until it
+    /// drops its permit (and vice versa).
+    ///
+    /// `convert_bootstrap_item` rejects non-shell `smoke_test` step types
+    /// at parse time so the contention question never arises in
+    /// practice; this docs section is here so the constraint is
+    /// surfaced if the rejection is ever relaxed.
+    ///
+    /// ## Error propagation
+    ///
+    /// Engine-level failures (parse / validation / runtime) and
+    /// non-zero process exits both flow back as
+    /// `outcome.passed == false` with a descriptive `summary`. The
+    /// caller (`resolve_bootstrap`) maps a failed outcome to a
+    /// [`WorkflowError::StepFailed`] so the iterate session ends with
+    /// `RunStatus::Failed` instead of a silently-broken bootstrap
+    /// context.
     async fn run_smoke_test(
         &self,
         step: &StepDef,
         inputs: &BTreeMap<String, Value>,
-    ) -> Result<String> {
+    ) -> Result<SmokeTestOutcome> {
         let phase = synthesize_phase_workflow(
             "smoke_test",
             "smoke_test",
@@ -428,7 +520,7 @@ impl LongRunningExecutor {
         );
         let (tx, mut rx) = mpsc::channel::<WorkflowProgress>(32);
         let id = step.id().to_owned();
-        let drain = tokio::spawn(async move {
+        let drain = async {
             // Capture a one-line summary from the StepCompleted event.
             let mut last_exit: Option<i32> = None;
             while let Some(evt) = rx.recv().await {
@@ -439,16 +531,22 @@ impl LongRunningExecutor {
                 }
             }
             last_exit
-        });
-        let outcome = self.engine.run(&phase, inputs.clone(), tx).await;
-        let exit = drain.await.unwrap_or(None);
+        };
+        let exec = self.engine.run(&phase, inputs.clone(), tx);
+        let (outcome, exit) = tokio::join!(exec, drain);
         match outcome {
-            Ok(_) => Ok(format!(
-                "{step_id} exit={exit}",
-                step_id = step.id(),
-                exit = exit.map_or_else(|| "?".to_owned(), |c| c.to_string()),
-            )),
-            Err(e) => Ok(format!("{step_id} ERROR: {e}", step_id = step.id())),
+            Ok(_) => {
+                let exit_code = exit.unwrap_or(-1);
+                let passed = exit_code == 0;
+                Ok(SmokeTestOutcome {
+                    summary: format!("{step_id} exit={exit_code}", step_id = step.id()),
+                    passed,
+                })
+            }
+            Err(e) => Ok(SmokeTestOutcome {
+                summary: format!("{step_id} ERROR: {e}", step_id = step.id()),
+                passed: false,
+            }),
         }
     }
 
@@ -458,24 +556,55 @@ impl LongRunningExecutor {
         let mut runner = self.run_runner.lock().await;
         runner.arm_session_timeout_watchdog(duration, tx);
     }
-}
 
-/// Run the workflow engine and drain the progress channel locally so
-/// the engine stays unblocked even when no UI is attached.
-async fn run_engine_drain(
-    engine: Arc<WorkflowEngine>,
-    workflow: WorkflowDef,
-    inputs: BTreeMap<String, Value>,
-) -> Result<crate::def::WorkflowOutputs> {
-    let (tx, mut rx) = mpsc::channel::<WorkflowProgress>(64);
-    let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
-    let outputs = engine.run(&workflow, inputs, tx).await?;
-    drain.abort();
-    Ok(outputs)
+    /// Build an [`EngineExtras`] bundle that exposes the run's
+    /// artifacts and a live `artifact.*` resolver. Used by both init
+    /// and iterate phases so any inner step expression can read
+    /// `${{ artifacts.<name> }}` / `${{ artifact.<name>.<method> }}`.
+    fn build_extras(&self, artifacts: &BTreeMap<String, PathBuf>) -> EngineExtras {
+        let resolver: Arc<dyn ArtifactResolver> = Arc::new(RunRunnerArtifactResolver {
+            runner: Arc::clone(&self.run_runner),
+        });
+        EngineExtras {
+            artifacts: Some(Arc::new(artifacts.clone())),
+            artifact_resolver: Some(resolver),
+        }
+    }
+
+    /// Drive the engine for one iterate-phase session.
+    ///
+    /// Drains the progress channel locally so the engine never blocks
+    /// on a slow UI; uses the same `tokio::join!` pattern as
+    /// [`Self::run_phase`] (no spawn-then-abort).
+    async fn run_iterate_engine(
+        &self,
+        workflow: WorkflowDef,
+        inputs: BTreeMap<String, Value>,
+        artifacts: &BTreeMap<String, PathBuf>,
+    ) -> Result<crate::def::WorkflowOutputs> {
+        let (tx, mut rx) = mpsc::channel::<WorkflowProgress>(64);
+        let cancel = CancellationToken::new();
+        let extras = self.build_extras(artifacts);
+        let drain = async move { while rx.recv().await.is_some() {} };
+        let exec = self
+            .engine
+            .run_with_extras(&workflow, inputs, tx, cancel, extras);
+        let (outcome, ()) = tokio::join!(exec, drain);
+        outcome
+    }
 }
 
 /// Synthesize a single-phase [`WorkflowDef`] from `steps` so the
 /// engine's existing `run()` path can drive it.
+///
+/// `artifacts` is *not* embedded in the synthesized workflow: the
+/// `${{ artifacts.* }}` / `${{ artifact.* }}` scopes are wired in
+/// separately via the [`EngineExtras`] passed to
+/// [`WorkflowEngine::run_with_extras`]. We still accept the parameter
+/// here so the call site reads symmetrically with the parent
+/// workflow's artifact map; future grammar additions (e.g. embedding
+/// init artifacts in `WorkflowMeta`) can plug into this without
+/// reshuffling callers.
 fn synthesize_phase_workflow(
     parent_id: &str,
     phase: &str,
@@ -498,18 +627,42 @@ fn synthesize_phase_workflow(
     }
 }
 
+/// Outcome of a single smoke-test bootstrap step.
+struct SmokeTestOutcome {
+    /// One-line summary embedded into the bootstrap context block.
+    summary: String,
+    /// Whether the test passed (exit code 0 for shell-typed steps).
+    passed: bool,
+}
+
 /// Bridge a [`tmg_harness::RunRunner`] into the [`ArtifactResolver`]
 /// trait, exposing the run-level data sources to the expression
 /// evaluator.
 ///
 /// Currently supported `tail` values:
 ///
-/// - `features.all_passing` → bool (vacuously true on an empty list).
+/// - `features.all_passing` → bool. **An empty feature list is rejected
+///   as an error**, not treated as vacuously true. This is critical for
+///   long-running workflows: an iterate-phase `until:
+///   artifact.features.all_passing` against an empty `features.json`
+///   would otherwise complete the run on the very first session before
+///   any work happens. The init phase is expected to populate
+///   `features.json` with the work to do; if it didn't, the iterate
+///   phase must surface that as a workflow authoring error.
 /// - `features.passing_count` → integer.
 ///
 /// Unknown tails return a clear error message that lists the known
 /// names. To extend: add another arm in `resolve` and document it
 /// here.
+///
+/// ## Concurrent access
+///
+/// The resolver is invoked from the synchronous expression-evaluation
+/// path while the executor temporarily releases the `Mutex<RunRunner>`.
+/// In rare contended cases (e.g. a parallel agent step racing the
+/// `until` evaluator), `try_lock` returns an error and `resolve` reports
+/// it back to the caller. Callers that re-evaluate `until` shortly
+/// after typically resolve the contention naturally.
 struct RunRunnerArtifactResolver {
     runner: Arc<Mutex<RunRunner>>,
 }
@@ -524,15 +677,30 @@ impl ArtifactResolver for RunRunnerArtifactResolver {
         let guard = self.runner.try_lock().map_err(|_| {
             WorkflowError::expression(
                 "could not acquire RunRunner lock for artifact.* resolution; \
-                 the long_running executor releases the lock before evaluating expressions",
+                 the long_running executor releases the lock before evaluating \
+                 expressions, but a concurrent step may have re-acquired it. \
+                 Re-evaluation on the next iteration typically succeeds.",
             )
         })?;
         match tail {
             "features.all_passing" => {
-                let v = guard
+                // Reject empty feature lists explicitly. SPEC §8.12
+                // expects long-running workflows to declare their
+                // backlog in `features.json`; an empty file means the
+                // init phase failed to produce one and the iterate
+                // loop has nothing to drive.
+                let parsed = guard
                     .features()
-                    .all_passing()
+                    .read()
                     .map_err(|e| WorkflowError::expression(format!("features.all_passing: {e}")))?;
+                if parsed.features.is_empty() {
+                    return Err(WorkflowError::expression(
+                        "artifact.features.all_passing: no features declared yet \
+                         (features.json is empty); the init phase must populate \
+                         the feature list before the iterate phase can complete",
+                    ));
+                }
+                let v = parsed.features.iter().all(|f| f.passes);
                 Ok(json!(v))
             }
             "features.passing_count" => {
@@ -557,27 +725,52 @@ fn map_to_obj(map: &BTreeMap<String, Value>) -> serde_json::Map<String, Value> {
     map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
 }
 
-/// Run a shell command in `workspace` and return combined stdout/stderr.
-async fn run_shell_in(workspace: &Path, cmd: &str) -> Result<String> {
-    let output = tokio::process::Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
-        .current_dir(workspace)
-        .output()
+/// Run a shell command via the engine's [`SandboxContext`] and return
+/// combined stdout/stderr.
+///
+/// Routing through the sandbox layer means bootstrap commands inherit
+/// the same Landlock filesystem rules, command timeout, and OOM-score
+/// adjustment as `shell` steps elsewhere in the workflow. The
+/// `_workspace` parameter is documented for API symmetry; the sandbox
+/// itself was constructed with the workspace path and `sh -c` runs in
+/// the inherited cwd of the parent process (which the harness wires to
+/// the workspace).
+async fn run_shell_in(sandbox: &SandboxContext, _workspace: &Path, cmd: &str) -> Result<String> {
+    let output = sandbox
+        .run_command(cmd)
         .await
-        .map_err(|e| WorkflowError::io(format!("running bootstrap command '{cmd}'"), e))?;
-    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+        .map_err(WorkflowError::from)?;
+    let success = output.success();
+    let exit_code = output.exit_code;
+    let mut combined = output.stdout;
     if !output.stderr.is_empty() {
         combined.push_str("\n--- stderr ---\n");
-        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+        combined.push_str(&output.stderr);
+    }
+    if !success {
+        let _ = writeln!(combined, "\n--- exit code ---\n{exit_code}");
     }
     Ok(combined)
 }
 
 /// Read a file or fall back to a default literal when the file is
-/// missing / unreadable.
-fn read_or_default(path: &Path, fallback: &str) -> String {
-    std::fs::read_to_string(path).unwrap_or_else(|_| fallback.to_owned())
+/// missing.
+///
+/// `NotFound` is the only I/O error we translate to the fallback —
+/// every other error (permission denied, invalid UTF-8, etc.) is
+/// propagated as a [`WorkflowError::Io`]. This avoids the silent-clobber
+/// hazard the previous swallow-all behaviour created: an unreadable
+/// existing `features.json` would otherwise be replaced with the
+/// fallback contents during the harness escalation step.
+fn read_or_default(path: &Path, fallback: &str) -> Result<String> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Ok(text),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(fallback.to_owned()),
+        Err(e) => Err(WorkflowError::io(
+            format!("read_or_default: {}", path.display()),
+            e,
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -620,5 +813,31 @@ mod tests {
         assert_eq!(wf.id, "build_app__init");
         assert_eq!(wf.mode, WorkflowMode::Normal);
         assert_eq!(wf.steps.len(), 1);
+    }
+
+    /// PR #66 review fix #9: `read_or_default` returns the fallback
+    /// only for `NotFound`; any other I/O error propagates.
+    #[test]
+    fn read_or_default_returns_fallback_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let missing = dir.path().join("nope.txt");
+        let body = read_or_default(&missing, "fallback").unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(body, "fallback");
+    }
+
+    /// PR #66 review fix #9: a path that points at a *directory* (not a
+    /// regular file) is not `NotFound`, so the function must propagate
+    /// the I/O error rather than silently returning the fallback.
+    #[test]
+    fn read_or_default_propagates_non_not_found_errors() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        // Reading a directory as a string returns IsADirectory /
+        // InvalidInput depending on the platform — either way it's
+        // *not* `NotFound`, which is exactly what we want to test.
+        let result = read_or_default(dir.path(), "fallback");
+        assert!(
+            matches!(result, Err(WorkflowError::Io { .. })),
+            "expected propagated I/O error, got {result:?}"
+        );
     }
 }

--- a/crates/tmg-workflow/src/parse.rs
+++ b/crates/tmg-workflow/src/parse.rs
@@ -6,12 +6,15 @@
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::Deserialize;
 
-use crate::def::{FailurePolicy, InputDef, StepDef, WorkflowDef, WorkflowMode};
+use crate::def::{
+    BootstrapItem, FailurePolicy, InitPhase, InputDef, IteratePhase, StepDef, WorkflowDef,
+    WorkflowMode,
+};
 use crate::error::{Result, WorkflowError};
 
 /// Identifier pattern enforced for workflow ids and step ids.
@@ -66,6 +69,47 @@ struct RawWorkflow {
     stages: Option<Vec<RawPipelineStage>>,
     #[serde(default)]
     outputs: BTreeMap<String, String>,
+    /// `mode: long_running`-only `init:` phase.
+    #[serde(default)]
+    init: Option<RawInitPhase>,
+    /// `mode: long_running`-only `iterate:` phase.
+    #[serde(default)]
+    iterate: Option<RawIteratePhase>,
+}
+
+/// Permissive serde mirror for the `init:` phase.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawInitPhase {
+    #[serde(default)]
+    artifacts: BTreeMap<String, String>,
+    #[serde(default)]
+    steps: Vec<RawStepOrRef>,
+}
+
+/// Permissive serde mirror for the `iterate:` phase.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawIteratePhase {
+    #[serde(default)]
+    bootstrap: Vec<RawBootstrapItem>,
+    #[serde(default)]
+    steps: Vec<RawStepOrRef>,
+    until: String,
+    max_sessions: u32,
+    /// Humantime-style duration (e.g. `"30m"`, `"2h"`) or seconds.
+    session_timeout: RawTimeout,
+}
+
+/// One entry of `iterate.bootstrap:`. Untagged so the YAML can use the
+/// shorthand `{run: ...}` / `{read: ...}` / `{smoke_test: ...}` without
+/// a wrapping `kind:` discriminator.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawBootstrapItem {
+    Run { run: String },
+    Read { read: String },
+    SmokeTest { smoke_test: Box<RawStep> },
 }
 
 /// One entry in a pipeline's `stages:` list.
@@ -265,6 +309,10 @@ pub async fn parse_workflow_file(path: impl AsRef<Path>) -> Result<WorkflowDef> 
     parse_workflow_str(&content, path)
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear validation: id, mode, inputs, steps, init, iterate. Splitting this would scatter the validation matrix without aiding clarity."
+)]
 fn finalize_workflow(raw: RawWorkflow, path: &Path) -> Result<WorkflowDef> {
     let path_display = path.display().to_string();
 
@@ -360,6 +408,41 @@ fn finalize_workflow(raw: RawWorkflow, path: &Path) -> Result<WorkflowDef> {
         out
     };
 
+    // Validate init/iterate against mode (SPEC §8.12 / §9.9).
+    match mode {
+        WorkflowMode::Normal => {
+            if raw.init.is_some() {
+                return Err(WorkflowError::invalid_workflow(
+                    &path_display,
+                    "`init:` is only allowed when `mode: long_running`",
+                ));
+            }
+            if raw.iterate.is_some() {
+                return Err(WorkflowError::invalid_workflow(
+                    &path_display,
+                    "`iterate:` is only allowed when `mode: long_running`",
+                ));
+            }
+        }
+        WorkflowMode::LongRunning => {
+            if raw.iterate.is_none() {
+                return Err(WorkflowError::invalid_workflow(
+                    &path_display,
+                    "`mode: long_running` requires an `iterate:` phase",
+                ));
+            }
+        }
+    }
+
+    let init = match raw.init {
+        Some(init) => Some(convert_init_phase(init, &path_display, &registry)?),
+        None => None,
+    };
+    let iterate = match raw.iterate {
+        Some(iter) => Some(convert_iterate_phase(iter, &path_display, &registry)?),
+        None => None,
+    };
+
     Ok(WorkflowDef {
         id: raw.id,
         description: raw.description,
@@ -367,6 +450,8 @@ fn finalize_workflow(raw: RawWorkflow, path: &Path) -> Result<WorkflowDef> {
         inputs,
         steps,
         outputs: raw.outputs,
+        init,
+        iterate,
     })
 }
 
@@ -438,6 +523,109 @@ fn convert_pipeline_stage(
         loop_spec,
     })
 }
+
+/// Convert an [`RawInitPhase`] into a validated [`InitPhase`].
+///
+/// Inner steps share a fresh seen-set (init steps live in their own
+/// scope, distinct from top-level steps and from `iterate.steps`).
+fn convert_init_phase(
+    raw: RawInitPhase,
+    path_display: &str,
+    outer_registry: &BTreeMap<String, StepDef>,
+) -> Result<InitPhase> {
+    let mut artifacts: BTreeMap<String, PathBuf> = BTreeMap::new();
+    for (name, raw_path) in raw.artifacts {
+        if name.is_empty() {
+            return Err(WorkflowError::invalid_workflow(
+                path_display,
+                "init.artifacts: artifact names must not be empty",
+            ));
+        }
+        if !is_valid_id(&name) {
+            return Err(WorkflowError::invalid_workflow(
+                path_display,
+                format!("init.artifacts: '{name}' must match {ID_PATTERN}"),
+            ));
+        }
+        artifacts.insert(name, PathBuf::from(raw_path));
+    }
+    let mut inner_seen: BTreeSet<String> = BTreeSet::new();
+    let steps = resolve_steps(raw.steps, path_display, &mut inner_seen, outer_registry)?;
+    Ok(InitPhase { artifacts, steps })
+}
+
+/// Convert an [`RawIteratePhase`] into a validated [`IteratePhase`].
+fn convert_iterate_phase(
+    raw: RawIteratePhase,
+    path_display: &str,
+    outer_registry: &BTreeMap<String, StepDef>,
+) -> Result<IteratePhase> {
+    if raw.max_sessions == 0 {
+        return Err(WorkflowError::invalid_workflow(
+            path_display,
+            "iterate.max_sessions must be >= 1",
+        ));
+    }
+    let session_timeout = raw
+        .session_timeout
+        .into_duration("iterate.session_timeout")?;
+    if session_timeout.is_zero() {
+        return Err(WorkflowError::invalid_workflow(
+            path_display,
+            "iterate.session_timeout must be > 0",
+        ));
+    }
+    let mut bootstrap: Vec<BootstrapItem> = Vec::with_capacity(raw.bootstrap.len());
+    for entry in raw.bootstrap {
+        bootstrap.push(convert_bootstrap_item(entry, path_display, outer_registry)?);
+    }
+    let mut inner_seen: BTreeSet<String> = BTreeSet::new();
+    let steps = resolve_steps(raw.steps, path_display, &mut inner_seen, outer_registry)?;
+    Ok(IteratePhase {
+        bootstrap,
+        steps,
+        until: raw.until,
+        max_sessions: raw.max_sessions,
+        session_timeout,
+    })
+}
+
+/// Convert one raw bootstrap entry into its canonical
+/// [`BootstrapItem`].
+fn convert_bootstrap_item(
+    raw: RawBootstrapItem,
+    path_display: &str,
+    outer_registry: &BTreeMap<String, StepDef>,
+) -> Result<BootstrapItem> {
+    match raw {
+        RawBootstrapItem::Run { run } => {
+            if run.trim().is_empty() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    "iterate.bootstrap: `run:` value must not be empty",
+                ));
+            }
+            Ok(BootstrapItem::Run(run))
+        }
+        RawBootstrapItem::Read { read } => {
+            if read.trim().is_empty() {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    "iterate.bootstrap: `read:` value must not be empty",
+                ));
+            }
+            Ok(BootstrapItem::Read(read))
+        }
+        RawBootstrapItem::SmokeTest { smoke_test } => {
+            // The smoke_test step gets its own seen-set so its id
+            // doesn't collide with anything else.
+            let mut seen: BTreeSet<String> = BTreeSet::new();
+            let step = convert_step(*smoke_test, path_display, &mut seen, outer_registry)?;
+            Ok(BootstrapItem::SmokeTest(Box::new(step)))
+        }
+    }
+}
+
 
 #[expect(
     clippy::too_many_lines,
@@ -1184,14 +1372,169 @@ steps: []
     }
 
     #[test]
-    fn long_running_mode_parses() {
-        let yaml = r"
+    fn long_running_mode_parses_with_iterate() {
+        let yaml = r#"
 id: lr
+mode: long_running
+iterate:
+  until: "false"
+  max_sessions: 5
+  session_timeout: "30s"
+  steps:
+    - id: noop
+      type: shell
+      command: "true"
+"#;
+        let wf = parse_workflow_str(yaml, p()).unwrap();
+        assert_eq!(wf.mode, WorkflowMode::LongRunning);
+        let iter = wf.iterate.as_ref().unwrap();
+        assert_eq!(iter.max_sessions, 5);
+        assert_eq!(iter.session_timeout, Duration::from_secs(30));
+        assert_eq!(iter.until, "false");
+        assert_eq!(iter.steps.len(), 1);
+    }
+
+    #[test]
+    fn long_running_without_iterate_errors() {
+        let yaml = r"
+id: bad_lr
 mode: long_running
 steps: []
 ";
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(
+            err.to_string().contains("requires an `iterate:` phase"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn normal_mode_with_iterate_errors() {
+        let yaml = r#"
+id: bad_normal
+iterate:
+  until: "false"
+  max_sessions: 1
+  session_timeout: "10s"
+  steps:
+    - id: x
+      type: shell
+      command: "true"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("only allowed when `mode: long_running`"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn normal_mode_with_init_errors() {
+        let yaml = r"
+id: bad_normal_init
+init:
+  steps: []
+";
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("only allowed when `mode: long_running`"),
+            "{err}"
+        );
+    }
+
+    /// SPEC §8.12 `build-app` sample: a `long_running` workflow with
+    /// `init`, `iterate`, `bootstrap` (`run`/`read`/`smoke_test`) and
+    /// an `until` based on the artifact resolver.
+    #[test]
+    fn parses_spec_8_12_build_app_sample() {
+        let yaml = r#"
+id: build_app
+mode: long_running
+
+init:
+  artifacts:
+    progress_file: ".tsumugi/runs/RUNID/progress.md"
+    features_file: ".tsumugi/runs/RUNID/features.json"
+  steps:
+    - id: bootstrap_init
+      type: agent
+      subagent: initializer
+      prompt: "Read the codebase and produce features.json + init.sh."
+
+iterate:
+  bootstrap:
+    - run: "git status --porcelain"
+    - read: "${{ artifacts.progress_file }}"
+    - smoke_test:
+        id: smoke
+        type: shell
+        command: "cargo check"
+  steps:
+    - id: implement
+      type: agent
+      subagent: worker
+      prompt: "Pick the next failing feature and implement it."
+    - id: verify
+      type: shell
+      command: "cargo test --workspace"
+  until: "artifact.features.all_passing"
+  max_sessions: 20
+  session_timeout: "30m"
+"#;
         let wf = parse_workflow_str(yaml, p()).unwrap();
+        assert_eq!(wf.id, "build_app");
         assert_eq!(wf.mode, WorkflowMode::LongRunning);
+
+        let init = wf.init.as_ref().unwrap();
+        assert_eq!(init.artifacts.len(), 2);
+        assert!(init.artifacts.contains_key("progress_file"));
+        assert_eq!(init.steps.len(), 1);
+        match &init.steps[0] {
+            StepDef::Agent { subagent, .. } => assert_eq!(subagent, "initializer"),
+            other => panic!("expected agent step, got {other:?}"),
+        }
+
+        let iter = wf.iterate.as_ref().unwrap();
+        assert_eq!(iter.bootstrap.len(), 3);
+        match &iter.bootstrap[0] {
+            BootstrapItem::Run(s) => assert_eq!(s, "git status --porcelain"),
+            other => panic!("expected Run, got {other:?}"),
+        }
+        match &iter.bootstrap[1] {
+            BootstrapItem::Read(s) => assert!(s.contains("artifacts.progress_file")),
+            other => panic!("expected Read, got {other:?}"),
+        }
+        match &iter.bootstrap[2] {
+            BootstrapItem::SmokeTest(step) => {
+                assert_eq!(step.id(), "smoke");
+                assert_eq!(step.step_type(), "shell");
+            }
+            other => panic!("expected SmokeTest, got {other:?}"),
+        }
+        assert_eq!(iter.steps.len(), 2);
+        assert_eq!(iter.until, "artifact.features.all_passing");
+        assert_eq!(iter.max_sessions, 20);
+        assert_eq!(iter.session_timeout, Duration::from_secs(30 * 60));
+    }
+
+    #[test]
+    fn iterate_max_sessions_zero_errors() {
+        let yaml = r#"
+id: bad_max
+mode: long_running
+iterate:
+  until: "false"
+  max_sessions: 0
+  session_timeout: "10s"
+  steps:
+    - id: x
+      type: shell
+      command: "true"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        assert!(err.to_string().contains("max_sessions"), "{err}");
     }
 
     /// SPEC §8.4 `review_loop` sample: top-level steps + a loop body

--- a/crates/tmg-workflow/src/parse.rs
+++ b/crates/tmg-workflow/src/parse.rs
@@ -101,15 +101,71 @@ struct RawIteratePhase {
     session_timeout: RawTimeout,
 }
 
-/// One entry of `iterate.bootstrap:`. Untagged so the YAML can use the
-/// shorthand `{run: ...}` / `{read: ...}` / `{smoke_test: ...}` without
-/// a wrapping `kind:` discriminator.
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
+/// One entry of `iterate.bootstrap:`. Uses a manual `Deserialize` impl
+/// (rather than `#[serde(untagged)]`) so a malformed entry produces a
+/// precise error: zero or multiple of `run:` / `read:` / `smoke_test:`
+/// keys are rejected with a clear message naming the offending keys.
+#[derive(Debug)]
 enum RawBootstrapItem {
     Run { run: String },
     Read { read: String },
     SmokeTest { smoke_test: Box<RawStep> },
+}
+
+impl<'de> Deserialize<'de> for RawBootstrapItem {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Helper struct that captures *all three* shorthand keys so we
+        // can detect "none" and "more than one" cases ourselves rather
+        // than relying on serde(untagged)'s generic
+        // "data did not match any variant" message.
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Helper {
+            #[serde(default)]
+            run: Option<String>,
+            #[serde(default)]
+            read: Option<String>,
+            #[serde(default)]
+            smoke_test: Option<Box<RawStep>>,
+        }
+        let helper = Helper::deserialize(deserializer)?;
+        let mut present: Vec<&'static str> = Vec::new();
+        if helper.run.is_some() {
+            present.push("run");
+        }
+        if helper.read.is_some() {
+            present.push("read");
+        }
+        if helper.smoke_test.is_some() {
+            present.push("smoke_test");
+        }
+        match present.len() {
+            0 => Err(serde::de::Error::custom(
+                "bootstrap entry must declare exactly one of `run:`, `read:`, or `smoke_test:`; found none",
+            )),
+            1 => {
+                if let Some(run) = helper.run {
+                    Ok(Self::Run { run })
+                } else if let Some(read) = helper.read {
+                    Ok(Self::Read { read })
+                } else if let Some(smoke_test) = helper.smoke_test {
+                    Ok(Self::SmokeTest { smoke_test })
+                } else {
+                    // Unreachable: present.len() == 1 implies exactly
+                    // one is_some() above.
+                    Err(serde::de::Error::custom(
+                        "internal error: present-count desync in bootstrap entry parser",
+                    ))
+                }
+            }
+            _ => Err(serde::de::Error::custom(format!(
+                "bootstrap entry must declare exactly one of `run:`, `read:`, or `smoke_test:`; found {present:?}"
+            ))),
+        }
+    }
 }
 
 /// One entry in a pipeline's `stages:` list.
@@ -621,11 +677,25 @@ fn convert_bootstrap_item(
             // doesn't collide with anything else.
             let mut seen: BTreeSet<String> = BTreeSet::new();
             let step = convert_step(*smoke_test, path_display, &mut seen, outer_registry)?;
+            // Reject non-shell smoke_test step types until shared
+            // resource semantics (agent_semaphore contention with the
+            // iterate phase, sandbox plumbing for write_file) are
+            // pinned down. See `LongRunningExecutor::run_smoke_test`'s
+            // doc comment for the rationale.
+            if !matches!(step, StepDef::Shell { .. }) {
+                return Err(WorkflowError::invalid_workflow(
+                    path_display,
+                    format!(
+                        "iterate.bootstrap.smoke_test: only `type: shell` steps are \
+                         supported (got '{kind}')",
+                        kind = step.step_type(),
+                    ),
+                ));
+            }
             Ok(BootstrapItem::SmokeTest(Box::new(step)))
         }
     }
 }
-
 
 #[expect(
     clippy::too_many_lines,
@@ -1929,6 +1999,96 @@ steps:
             err.to_string()
                 .contains("does not currently support 'when'"),
             "{err}"
+        );
+    }
+
+    /// PR #66 review fix #6: a bootstrap entry that declares none of
+    /// `run:` / `read:` / `smoke_test:` produces a precise error
+    /// message naming all three keys.
+    #[test]
+    fn bootstrap_entry_with_no_keys_is_rejected() {
+        let yaml = r#"
+id: lr_bad_bootstrap
+mode: long_running
+
+iterate:
+  bootstrap:
+    - {}
+  steps:
+    - id: noop
+      type: shell
+      command: "true"
+  until: "true"
+  max_sessions: 1
+  session_timeout: "5s"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("`run:`") && msg.contains("`read:`") && msg.contains("`smoke_test:`"),
+            "missing key list in error: {msg}"
+        );
+        assert!(msg.contains("found none"), "wrong wording: {msg}");
+    }
+
+    /// PR #66 review fix #6: a bootstrap entry that declares more than
+    /// one key (e.g. both `run:` and `read:`) is rejected with a list
+    /// of the offending keys.
+    #[test]
+    fn bootstrap_entry_with_multiple_keys_is_rejected() {
+        let yaml = r#"
+id: lr_bad_bootstrap_multi
+mode: long_running
+
+iterate:
+  bootstrap:
+    - run: "echo a"
+      read: "b.txt"
+  steps:
+    - id: noop
+      type: shell
+      command: "true"
+  until: "true"
+  max_sessions: 1
+  session_timeout: "5s"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("\"run\"") && msg.contains("\"read\""),
+            "expected key names in error: {msg}"
+        );
+    }
+
+    /// PR #66 review fix #7: `smoke_test` entries must be `type: shell`
+    /// — non-shell steps are rejected at parse time until shared
+    /// resource semantics are pinned down.
+    #[test]
+    fn bootstrap_smoke_test_rejects_non_shell_steps() {
+        let yaml = r#"
+id: lr_smoke_non_shell
+mode: long_running
+
+iterate:
+  bootstrap:
+    - smoke_test:
+        id: bad
+        type: write_file
+        path: "x"
+        content: "y"
+  steps:
+    - id: noop
+      type: shell
+      command: "true"
+  until: "true"
+  max_sessions: 1
+  session_timeout: "5s"
+"#;
+        let err = parse_workflow_str(yaml, p()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("only `type: shell`") || msg.contains("only `type: shell` steps"),
+            "expected shell-only restriction: {msg}"
         );
     }
 }

--- a/crates/tmg-workflow/src/steps/branch.rs
+++ b/crates/tmg-workflow/src/steps/branch.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 use serde_json::json;
 
 use crate::def::{StepDef, StepResult};
-use crate::engine::{EngineCtx, StepOutcome, dispatch_step};
+use crate::engine::{EngineCtx, StepOutcome, build_eval_ctx, dispatch_step};
 use crate::error::{Result, WorkflowError};
 use crate::expr;
 use crate::progress::WorkflowProgress;
@@ -40,9 +40,7 @@ pub(crate) async fn execute(
 
     let stages_snapshot = ctx.stages.read().await.clone();
     for (idx, (when_expr, _)) in conditions.iter().enumerate() {
-        let inner_ctx =
-            expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
-                .with_stages(&stages_snapshot);
+        let inner_ctx = build_eval_ctx(ctx, step_results, &stages_snapshot);
         let cond =
             expr::eval_bool(when_expr, &inner_ctx).map_err(|e| WorkflowError::StepFailed {
                 step_id: id.clone(),

--- a/crates/tmg-workflow/src/steps/human.rs
+++ b/crates/tmg-workflow/src/steps/human.rs
@@ -24,7 +24,7 @@ use serde_json::json;
 use tokio::sync::{Mutex, oneshot};
 
 use crate::def::{StepDef, StepResult};
-use crate::engine::{EngineCtx, StepOutcome};
+use crate::engine::{EngineCtx, StepOutcome, build_eval_ctx};
 use crate::error::{Result, WorkflowError};
 use crate::expr;
 use crate::progress::{HumanResponseKind, WorkflowProgress};
@@ -59,8 +59,7 @@ pub(crate) async fn execute(
     // Render the prompt and `show:` payload eagerly so the receiver
     // sees the substituted values, not the raw template.
     let stages_snapshot = ctx.stages.read().await.clone();
-    let inner_ctx = expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
-        .with_stages(&stages_snapshot);
+    let inner_ctx = build_eval_ctx(ctx, step_results, &stages_snapshot);
     let rendered_message = expr::eval_string(message, &inner_ctx)?;
     let rendered_show = match show {
         Some(template) => Some(expr::eval_string(template, &inner_ctx)?),

--- a/crates/tmg-workflow/src/steps/loop_step.rs
+++ b/crates/tmg-workflow/src/steps/loop_step.rs
@@ -28,7 +28,7 @@ use std::collections::BTreeMap;
 use serde_json::json;
 
 use crate::def::{StepDef, StepResult};
-use crate::engine::{EngineCtx, StepOutcome, dispatch_step};
+use crate::engine::{EngineCtx, StepOutcome, build_eval_ctx, dispatch_step};
 use crate::error::{Result, WorkflowError};
 use crate::expr;
 use crate::progress::WorkflowProgress;
@@ -145,9 +145,7 @@ pub(crate) async fn execute(
         // is included so a pipeline-aware loop body can branch on
         // upstream stage outputs (issue #41).
         let stages_snapshot = ctx.stages.read().await.clone();
-        let inner_ctx =
-            expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
-                .with_stages(&stages_snapshot);
+        let inner_ctx = build_eval_ctx(ctx, step_results, &stages_snapshot);
         let cond = expr::eval_bool(until, &inner_ctx).map_err(|e| WorkflowError::StepFailed {
             step_id: id.clone(),
             message: format!("until-expression error: {e}"),

--- a/crates/tmg-workflow/src/steps/workflow.rs
+++ b/crates/tmg-workflow/src/steps/workflow.rs
@@ -24,7 +24,7 @@ use std::collections::BTreeMap;
 use serde_json::{Value, json};
 
 use crate::def::{LoopSpec, StepDef, StepResult, WorkflowOutputs};
-use crate::engine::{EngineCtx, StepOutcome, run_nested_workflow};
+use crate::engine::{EngineCtx, StepOutcome, build_eval_ctx, run_nested_workflow};
 use crate::error::{Result, WorkflowError};
 use crate::expr;
 use crate::progress::WorkflowProgress;
@@ -123,9 +123,7 @@ async fn run_with_loop(
         // Evaluate `until` with stages visible so the typical pattern
         // `${{ stages.<id>.outputs.findings_count == 0 }}` works.
         let stages_snapshot = ctx.stages.read().await.clone();
-        let inner_ctx =
-            expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
-                .with_stages(&stages_snapshot);
+        let inner_ctx = build_eval_ctx(ctx, step_results, &stages_snapshot);
         let cond =
             expr::eval_bool(&spec.until, &inner_ctx).map_err(|e| WorkflowError::StepFailed {
                 step_id: stage_id.to_owned(),
@@ -173,8 +171,7 @@ async fn render_inputs(
     step_results: &BTreeMap<String, StepResult>,
 ) -> Result<BTreeMap<String, Value>> {
     let stages_snapshot = ctx.stages.read().await.clone();
-    let eval_ctx = expr::ExprContext::new(&ctx.inputs, step_results, &ctx.config_json, &ctx.env)
-        .with_stages(&stages_snapshot);
+    let eval_ctx = build_eval_ctx(ctx, step_results, &stages_snapshot);
     let mut resolved: BTreeMap<String, Value> = BTreeMap::new();
     for (key, tmpl) in inputs_template {
         let rendered =

--- a/crates/tmg-workflow/tests/long_running.rs
+++ b/crates/tmg-workflow/tests/long_running.rs
@@ -312,6 +312,275 @@ iterate:
     assert_eq!(r.run().session_count, 1);
 }
 
+/// PR #66 review fix #2: an empty `features.json` must not let
+/// `until: artifact.features.all_passing` complete the run silently
+/// on iteration 1. The resolver now reports an error which surfaces as
+/// `RunStatus::Failed`.
+#[tokio::test]
+async fn empty_features_rejects_all_passing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    // Empty features.json (init has not yet declared the work).
+    let features_path = {
+        let r = runner.lock().await;
+        r.features().path().to_path_buf()
+    };
+    if let Some(parent) = features_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&features_path, r#"{"features":[]}"#).unwrap();
+
+    let yaml = r#"
+id: lr_empty_features
+mode: long_running
+
+init:
+  steps: []
+
+iterate:
+  bootstrap: []
+  steps:
+    - id: noop
+      type: shell
+      command: "true"
+  until: "artifact.features.all_passing"
+  max_sessions: 2
+  session_timeout: "5s"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    let status = exec.run(&wf, BTreeMap::new()).await.unwrap();
+    match status {
+        RunStatus::Failed { error } => {
+            assert!(
+                error.contains("no features declared yet"),
+                "expected 'no features declared yet' message, got: {error}"
+            );
+        }
+        other => panic!("expected Failed for empty features.json, got {other:?}"),
+    }
+}
+
+/// PR #66 review fix #3: an iterate-phase step's `write_file.path`
+/// can resolve `${{ artifacts.<name> }}` (the named-artifact map is
+/// plumbed through to iterate-phase steps via `EngineExtras`).
+#[tokio::test]
+async fn iterate_step_resolves_artifacts_path_template() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+    let canonical_workspace = std::fs::canonicalize(&workspace).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    // Use a workspace-local path so the sandbox accepts the write.
+    let progress_target = "progress.md";
+    let yaml = format!(
+        r#"
+id: lr_artifact_in_iterate
+mode: long_running
+
+init:
+  artifacts:
+    progress_file: "{progress_target}"
+  steps: []
+
+iterate:
+  bootstrap: []
+  steps:
+    - id: write_progress
+      type: write_file
+      path: "${{{{ artifacts.progress_file }}}}"
+      content: "session-${{{{ inputs.session_index }}}}"
+  until: "true"
+  max_sessions: 1
+  session_timeout: "5s"
+"#,
+    );
+    let wf = parse_workflow_str(&yaml, "<inline>").unwrap();
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    let status = exec.run(&wf, BTreeMap::new()).await.unwrap();
+    assert_eq!(status, RunStatus::Completed);
+
+    let written = canonical_workspace.join(progress_target);
+    let body = std::fs::read_to_string(&written)
+        .unwrap_or_else(|e| panic!("read {}: {e}", written.display()));
+    assert!(body.contains("session-1"), "unexpected body: {body}");
+}
+
+/// PR #66 review fix #3: an iterate-phase step's `when:` can reference
+/// `${{ artifact.<name>.<method> }}` so step gating reflects the live
+/// run state (the resolver is plumbed through to iterate steps).
+#[tokio::test]
+async fn iterate_step_when_uses_artifact_resolver() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+    let canonical_workspace = std::fs::canonicalize(&workspace).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    // Pre-populate features.json with two passing features so
+    // `passing_count == 2` is observable from the iterate step's
+    // `when:` expression.
+    let features_path = {
+        let r = runner.lock().await;
+        r.features().path().to_path_buf()
+    };
+    if let Some(parent) = features_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(
+        &features_path,
+        r#"{"features":[
+            {"id":"a","category":"x","description":"d","steps":["s"],"passes":true},
+            {"id":"b","category":"x","description":"d","steps":["s"],"passes":true}
+        ]}"#,
+    )
+    .unwrap();
+
+    let marker_path = canonical_workspace.join("marker.txt");
+    let never_path = canonical_workspace.join("never.txt");
+    let yaml = format!(
+        r#"
+id: lr_when_artifact
+mode: long_running
+
+init:
+  steps: []
+
+iterate:
+  bootstrap: []
+  steps:
+    - id: marker_when_two
+      type: shell
+      command: "echo TWO_PASSING > {marker}"
+      when: "artifact.features.passing_count == 2"
+    - id: marker_never
+      type: shell
+      command: "echo NEVER > {never}"
+      when: "artifact.features.passing_count == 99"
+  until: "true"
+  max_sessions: 1
+  session_timeout: "5s"
+"#,
+        marker = marker_path.display(),
+        never = never_path.display(),
+    );
+    let wf = parse_workflow_str(&yaml, "<inline>").unwrap();
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    let status = exec.run(&wf, BTreeMap::new()).await.unwrap();
+    assert_eq!(status, RunStatus::Completed);
+
+    assert!(
+        marker_path.exists(),
+        "expected marker.txt (when-true gate) at {}",
+        marker_path.display()
+    );
+    assert!(
+        !never_path.exists(),
+        "never.txt should not exist (when-false gate) at {}",
+        never_path.display()
+    );
+}
+
+/// PR #66 review fix #14: a non-trivial `features.json` followed by
+/// an iterate loop that marks each feature passing should drive
+/// `artifact.features.all_passing` to true and stop with
+/// `RunStatus::Completed`. The iterate phase mutates the file via a
+/// shell step on each session until every feature flips to `passes:
+/// true`. This exercises the end-to-end loop the long-running mode is
+/// designed for.
+#[tokio::test]
+async fn init_writes_features_iterate_marks_passing_until_done() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    // Seed three failing features. We pre-write directly so the test
+    // doesn't depend on the sandbox accepting writes outside the
+    // workspace; the iterate-phase shell step (which uses the sandbox
+    // and runs without a fixed cwd) reads/writes the file via its
+    // absolute path.
+    let features_path = {
+        let r = runner.lock().await;
+        r.features().path().to_path_buf()
+    };
+    if let Some(parent) = features_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(
+        &features_path,
+        r#"{"features":[
+{"id":"alpha","category":"x","description":"d","steps":["s"],"passes":false},
+{"id":"beta","category":"x","description":"d","steps":["s"],"passes":false},
+{"id":"gamma","category":"x","description":"d","steps":["s"],"passes":false}
+]}"#,
+    )
+    .unwrap();
+
+    // The mark-passing helper script (a tiny python program) is
+    // staged on disk and invoked from the iterate-phase shell step.
+    // Each invocation flips the first still-failing feature's
+    // `passes` flag to true and exits 0.
+    let helper_path = workspace.join("mark_one.py");
+    std::fs::write(
+        &helper_path,
+        format!(
+            "import json\np=r'{p}'\nd=json.load(open(p))\nfor f in d['features']:\n    if not f['passes']:\n        f['passes']=True\n        json.dump(d, open(p,'w'))\n        break\n",
+            p = features_path.display(),
+        ),
+    )
+    .unwrap();
+
+    let yaml = format!(
+        r#"
+id: lr_full_loop
+mode: long_running
+
+iterate:
+  bootstrap: []
+  steps:
+    - id: mark_one
+      type: shell
+      command: "python3 {helper}"
+  until: "artifact.features.all_passing"
+  max_sessions: 5
+  session_timeout: "10s"
+"#,
+        helper = helper_path.display(),
+    );
+
+    let wf = parse_workflow_str(&yaml, "<inline>")
+        .unwrap_or_else(|e| panic!("parse failed: {e}\nyaml:\n{yaml}"));
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    let status = exec.run(&wf, BTreeMap::new()).await.unwrap();
+    assert_eq!(status, RunStatus::Completed, "expected Completed");
+
+    // Three iterations were needed (one per feature) before
+    // all_passing flipped true.
+    let r = runner.lock().await;
+    let count = r.run().session_count;
+    assert_eq!(
+        count, 3,
+        "expected 3 iterations (one per feature), got {count}"
+    );
+}
+
 /// Session timeout fires when the iterate steps take longer than the
 /// configured `session_timeout`.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/tmg-workflow/tests/long_running.rs
+++ b/crates/tmg-workflow/tests/long_running.rs
@@ -1,0 +1,357 @@
+//! Integration tests for [`LongRunningExecutor`] (SPEC §8.12 + §9.9).
+//!
+//! These tests exercise the executor end-to-end against a real
+//! [`tmg_harness::RunRunner`] so the harnessed-scope upgrade is
+//! observable on disk. Steps use `shell` + `write_file` leaves so the
+//! tests don't depend on a live LLM.
+//!
+//! Coverage matrix (matches the issue's acceptance list):
+//!
+//! - init phase flips the run from ad-hoc to harnessed.
+//! - bootstrap output is injected into the iterate-step context as
+//!   `inputs.bootstrap_context`.
+//! - `until: artifact.features.all_passing` stops the loop when every
+//!   feature is marked passing.
+//! - `max_sessions` exhaustion returns `RunStatus::Exhausted`.
+//! - `session_timeout` is honoured (the engine returns inside the
+//!   budget; the runner records a `Timeout` trigger).
+
+#![expect(clippy::unwrap_used, reason = "test assertions")]
+#![expect(clippy::expect_used, reason = "test assertions")]
+#![expect(clippy::panic, reason = "test assertions")]
+#![expect(clippy::similar_names, reason = "runs_dir vs run_dir is intentional")]
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use tmg_agents::SubagentManager;
+use tmg_harness::{Run, RunRunner, RunStore};
+use tmg_llm::{LlmPool, PoolConfig};
+use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
+use tmg_tools::ToolRegistry;
+use tmg_workflow::{
+    LongRunningExecutor, RunStatus, WorkflowConfig, WorkflowEngine, parse_workflow_str,
+};
+
+/// Build the engine + workspace + sandbox + run-runner harness for
+/// tests.
+fn build_harness(
+    workspace: &Path,
+    runs_dir: &Path,
+) -> (Arc<WorkflowEngine>, Arc<Mutex<RunRunner>>) {
+    let llm_pool =
+        Arc::new(LlmPool::new(&PoolConfig::single("http://localhost:9999"), "test-model").unwrap());
+    let canonical_workspace =
+        std::fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
+    let sandbox = Arc::new(SandboxContext::new(
+        SandboxConfig::new(&canonical_workspace).with_mode(SandboxMode::WorkspaceWrite),
+    ));
+    let tool_registry = Arc::new(ToolRegistry::new());
+
+    let llm_client_cfg = tmg_llm::LlmClientConfig::new("http://localhost:9999", "test-model");
+    let llm_client = tmg_llm::LlmClient::new(llm_client_cfg).unwrap();
+    let cancel = CancellationToken::new();
+    let manager = SubagentManager::new(llm_client, cancel, "http://localhost:9999", "test-model");
+    let subagent_manager = Arc::new(Mutex::new(manager));
+
+    let engine = Arc::new(WorkflowEngine::new(
+        llm_pool,
+        sandbox,
+        tool_registry,
+        subagent_manager,
+        WorkflowConfig::default(),
+        serde_json::Value::Null,
+    ));
+
+    let store = Arc::new(RunStore::new(runs_dir.to_path_buf()));
+    let run = Run::new_ad_hoc(canonical_workspace);
+    // Manually create the run dir so the runner can write artifacts.
+    let run_dir = store.run_dir(&run.id);
+    std::fs::create_dir_all(&run_dir).unwrap();
+    store.save(&run).unwrap();
+    let runner = RunRunner::new(run, store);
+    let run_runner = Arc::new(Mutex::new(runner));
+
+    (engine, run_runner)
+}
+
+/// Init phase escalates the run from ad-hoc to harnessed.
+#[tokio::test]
+async fn init_phase_escalates_run_to_harnessed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    // Confirm starting scope.
+    {
+        let r = runner.lock().await;
+        assert!(r.scope().is_ad_hoc());
+    }
+
+    // For this integration test we directly invoke the executor and
+    // assert the post-state. We intentionally use simple shell-only
+    // steps so no live LLM is required.
+    let yaml_simple = r#"
+id: lr_init
+mode: long_running
+
+init:
+  steps:
+    - id: marker
+      type: shell
+      command: "echo init-ran"
+
+iterate:
+  bootstrap: []
+  steps:
+    - id: stop
+      type: shell
+      command: "true"
+  until: "true"
+  max_sessions: 1
+  session_timeout: "5s"
+"#;
+    let wf = parse_workflow_str(yaml_simple, "<inline>").unwrap();
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    let status = exec.run(&wf, BTreeMap::new()).await.unwrap();
+
+    // The until="true" stops the loop on iteration 1 -> Completed.
+    assert_eq!(status, RunStatus::Completed);
+
+    // The run is now harnessed.
+    let r = runner.lock().await;
+    assert!(!r.scope().is_ad_hoc(), "run should be harnessed after init");
+}
+
+/// `until` evaluating to true on the first session returns Completed.
+#[tokio::test]
+async fn until_true_stops_loop_immediately() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    let yaml = r#"
+id: lr_until
+mode: long_running
+
+iterate:
+  bootstrap: []
+  steps:
+    - id: noop
+      type: shell
+      command: "true"
+  until: "true"
+  max_sessions: 5
+  session_timeout: "5s"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    let status = exec.run(&wf, BTreeMap::new()).await.unwrap();
+    assert_eq!(status, RunStatus::Completed);
+
+    // Exactly one session was begun.
+    let r = runner.lock().await;
+    assert_eq!(r.run().session_count, 1);
+}
+
+/// `max_sessions` exhaustion returns `Exhausted`.
+#[tokio::test]
+async fn max_sessions_exhausted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    let yaml = r#"
+id: lr_exhaust
+mode: long_running
+
+iterate:
+  bootstrap: []
+  steps:
+    - id: noop
+      type: shell
+      command: "true"
+  until: "false"
+  max_sessions: 3
+  session_timeout: "5s"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    let status = exec.run(&wf, BTreeMap::new()).await.unwrap();
+    match status {
+        RunStatus::Exhausted { reason } => assert_eq!(reason, "max_sessions"),
+        other => panic!("expected Exhausted, got {other:?}"),
+    }
+    let r = runner.lock().await;
+    assert_eq!(r.run().session_count, 3);
+}
+
+/// Bootstrap `run:` output appears in the iterate step context as
+/// `inputs.bootstrap_context`.
+#[tokio::test]
+async fn bootstrap_output_appears_in_context() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    // The iterate step writes the bootstrap_context to a file we can
+    // then assert on.
+    let yaml = r#"
+id: lr_bootstrap
+mode: long_running
+
+iterate:
+  bootstrap:
+    - run: "echo BOOT_OK"
+  steps:
+    - id: snapshot
+      type: write_file
+      path: "snapshot.txt"
+      content: "${{ inputs.bootstrap_context }}"
+  until: "true"
+  max_sessions: 1
+  session_timeout: "5s"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    let status = exec.run(&wf, BTreeMap::new()).await.unwrap();
+    assert_eq!(status, RunStatus::Completed);
+
+    // The write_file step writes to the workspace root.
+    let canonical_workspace = std::fs::canonicalize(&workspace).unwrap();
+    let snapshot_path = canonical_workspace.join("snapshot.txt");
+    let snapshot = std::fs::read_to_string(&snapshot_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", snapshot_path.display()));
+    assert!(
+        snapshot.contains("BOOT_OK"),
+        "expected bootstrap output in snapshot: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("[bootstrap]"),
+        "expected '[bootstrap]' header: {snapshot}"
+    );
+    assert!(
+        snapshot.contains("$ echo BOOT_OK"),
+        "expected command echo header: {snapshot}"
+    );
+}
+
+/// `until: artifact.features.all_passing` stops when features.json is
+/// populated with all-passing features. We exercise this by writing
+/// `features.json` directly into the run directory between iterations.
+#[tokio::test]
+async fn until_artifact_features_all_passing_stops_loop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    // Pre-write features.json with one passing feature and escalate
+    // the run manually so the resolver finds the file. The init phase
+    // is empty (no steps) so the executor only escalates.
+    let features_path = {
+        let r = runner.lock().await;
+        r.features().path().to_path_buf()
+    };
+    if let Some(parent) = features_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(
+        &features_path,
+        r#"{"features":[{"id":"a","category":"x","description":"d","steps":["s"],"passes":true}]}"#,
+    )
+    .unwrap();
+
+    let yaml = r#"
+id: lr_artifact
+mode: long_running
+
+init:
+  steps: []
+
+iterate:
+  bootstrap: []
+  steps:
+    - id: noop
+      type: shell
+      command: "true"
+  until: "artifact.features.all_passing"
+  max_sessions: 5
+  session_timeout: "5s"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    let status = exec.run(&wf, BTreeMap::new()).await.unwrap();
+    assert_eq!(status, RunStatus::Completed);
+    // First session triggers the stop because all features pass.
+    let r = runner.lock().await;
+    assert_eq!(r.run().session_count, 1);
+}
+
+/// Session timeout fires when the iterate steps take longer than the
+/// configured `session_timeout`.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_timeout_fires() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let runs_dir = tmp.path().join("runs");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&runs_dir).unwrap();
+
+    let (engine, runner) = build_harness(&workspace, &runs_dir);
+
+    // Iterate runs `sleep 2` but session_timeout is 200ms. We expect
+    // the executor to abandon the session, record a Timeout, and
+    // come back around for another iteration. With max_sessions=2
+    // and until="false" the run exhausts after two timeouts.
+    let yaml = r#"
+id: lr_timeout
+mode: long_running
+
+iterate:
+  bootstrap: []
+  steps:
+    - id: slow
+      type: shell
+      command: "sleep 2"
+  until: "false"
+  max_sessions: 2
+  session_timeout: "200ms"
+"#;
+    let wf = parse_workflow_str(yaml, "<inline>").unwrap();
+    let exec = LongRunningExecutor::new(engine, Arc::clone(&runner));
+    // The whole call must finish in well under the slow command's
+    // 2-second budget; if the timeout doesn't fire we'd block here.
+    let status = tokio::time::timeout(Duration::from_secs(10), exec.run(&wf, BTreeMap::new()))
+        .await
+        .expect("LongRunningExecutor::run did not respect session_timeout")
+        .unwrap();
+    match status {
+        RunStatus::Exhausted { reason } => assert_eq!(reason, "max_sessions"),
+        other => panic!("expected Exhausted after timeout, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Implements SPEC §8.12 + §9.9 — the `mode: long_running` workflow lifecycle on top of the existing `WorkflowEngine`.

- Adds `WorkflowDef::{init, iterate}`, `InitPhase`, `IteratePhase`, and `BootstrapItem::{Run, Read, SmokeTest}` (with the `{run|read|smoke_test}` YAML shorthand parsed via a serde-untagged enum).
- New `LongRunningExecutor` drives init → forced harnessed escalation → per-session iterate loop with bootstrap injection, `until:` evaluation, `max_sessions`, and `session_timeout`.
- `ExprContext` gains two opt-in scopes: `artifacts.<name>` (path string lookup) and `artifact.<name>.<method>` (dispatched through a new `ArtifactResolver` trait; the executor wires `RunRunner::features()` so `artifact.features.all_passing` and `artifact.features.passing_count` work in `until:` expressions).
- `tmg-workflow` now depends on `tmg-harness`. Verified acyclic.

## Behaviour

1. **Init phase** (run still ad-hoc): execute `init.steps` via the existing engine, then call `RunRunner::escalate_to_harnessed` with a synthesized `Escalate` decision (SPEC §9.9 forced harnessed scope). Re-feed any existing `features.json` / `init.sh` so a successful init phase isn't clobbered.
2. **Iterate phase**:
   - `RunRunner::begin_session` (the existing watchdog auto-arms on harnessed runs).
   - Resolve `bootstrap` items: `run:` shells in the workspace, `read:` reads with `${{ artifacts.* }}` support, `smoke_test:` dispatches as a one-shot synthetic phase.
   - Concatenate outputs into `inputs.bootstrap_context` for the iterate steps.
   - Execute `iterate.steps` under `tokio::time::timeout(session_timeout)`. The runner's watchdog channel is consumed to attribute the persisted `SessionEndTrigger::Timeout` correctly.
   - Evaluate `until`. Truthy → `RunStatus::Completed`. Otherwise loop until `>= max_sessions` → `RunStatus::Exhausted { reason: "max_sessions" }`.
3. Step-level failures inside iterate surface as `RunStatus::Failed { error }` so the caller can persist `run.toml` cleanly.

## Trade-offs

- **Timeout split between watchdog and `tokio::time::timeout`.** The runner's existing `arm_session_timeout_watchdog` is best-effort `try_send` — it doesn't unwind the engine. We use it for trigger *attribution* and pair it with `tokio::time::timeout` for the actual unwind. This avoids cancelling mid-shell-command and matches the runner's published contract; once #46 (TUI banner) lands, plumbing a `CancellationToken` into the engine is a clean follow-up.
- **Synthetic phase workflows.** Init / iterate / smoke_test all run through `WorkflowEngine::run` against a freshly synthesized `WorkflowDef` so they inherit step-type validation, snapshot/revise, and the parallel-agent semaphore. The synthesized workflow is rebuilt per session because `bootstrap_context` and `session_index` change.
- **`ArtifactResolver::resolve` uses `try_lock`** because it runs synchronously inside the expression evaluator. The executor always releases the runner mutex before evaluating expressions, so contention is impossible in normal flow; the error message is tuned for the rare misuse.
- **Forced escalation reads back artifacts.** When init produces `features.json` / `init.sh`, the escalation path re-reads them; when init runs no steps, the path falls back to empty stubs (`{"features":[]}` + a stub shell script). The scope flip in `run.toml` is the SPEC §9.3 source of truth either way.

## Files

- `crates/tmg-workflow/Cargo.toml` — adds `tmg-harness` dep
- `crates/tmg-workflow/src/def.rs` — `InitPhase`, `IteratePhase`, `BootstrapItem`, `WorkflowDef::{init, iterate}`
- `crates/tmg-workflow/src/parse.rs` — YAML parsing + mode/phase validation
- `crates/tmg-workflow/src/expr.rs` — `ArtifactResolver` trait, `with_artifacts` / `with_artifact_resolver` builders, `artifacts.*` and `artifact.*.*` resolution
- `crates/tmg-workflow/src/long_running.rs` — new module; `LongRunningExecutor`, `RunStatus`
- `crates/tmg-workflow/src/lib.rs` — public re-exports
- `crates/tmg-workflow/tests/long_running.rs` — 6 integration tests

## Tests

- **Unit (parse.rs)**: 6 new tests — SPEC §8.12 build-app sample, `mode: long_running` requires `iterate:`, `mode: normal` rejects `init:` / `iterate:`, `max_sessions: 0` rejection, the existing `long_running_mode_parses` test was updated to match the new validation.
- **Unit (expr.rs)**: 4 new tests — `artifacts.<name>`, missing-name error, missing-map error, `artifact.*.*` dispatch via a test resolver, missing-resolver error.
- **Unit (long_running.rs)**: smoke tests for the synthetic-phase builder.
- **Integration (`tests/long_running.rs`)**: `init_phase_escalates_run_to_harnessed`, `until_true_stops_loop_immediately`, `max_sessions_exhausted`, `bootstrap_output_appears_in_context`, `until_artifact_features_all_passing_stops_loop`, `session_timeout_fires` (multi-thread to actually exercise the watchdog).

All 661+ workspace tests pass.

## Quality gates

- `cargo build --workspace` ✓
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` ✓
- `cargo fmt --all -- --check` ✓
- `cargo test --workspace` ✓ (all green)

### Runtime Verification
- LLM server: available
- One-shot mode: PASS
  - Events: 2 tokens, 0 errors, 1 done (response: `BUILD_OK`)
- TUI mode: SKIP — issue #42 introduces no CLI/TUI surface; the `run_workflow` tool that exercises `LongRunningExecutor` is tracked separately as #41 (and TUI integration as #46). One-shot binary smoke is sufficient evidence the workspace changes don't regress the runtime.

Closes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)