### PR TITLE
tmg-cli: tmg run subcommand family (#43)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,6 +1823,7 @@ name = "tmg-harness"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,6 +1778,7 @@ name = "tmg-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "dirs",
  "humantime",

--- a/crates/tmg-harness/Cargo.toml
+++ b/crates/tmg-harness/Cargo.toml
@@ -15,6 +15,9 @@ tokio = { workspace = true, features = ["sync", "process", "time"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 # Workspace crates
 tmg-agents = { workspace = true }
 tmg-core = { workspace = true }

--- a/crates/tmg-harness/src/commands.rs
+++ b/crates/tmg-harness/src/commands.rs
@@ -148,7 +148,21 @@ pub fn status(
 /// Flips `run.toml` status to [`RunStatus::Paused`]. The runner
 /// remains usable; a follow-up `tmg run resume` will pick it back up
 /// because [`RunStatus::Paused`] is treated as resumable.
+///
+/// **Refuses if a TUI is currently attached** to the same run (see
+/// [`crate::tui_sentinel`]): an in-memory runner inside the TUI would
+/// otherwise silently overwrite the `Paused` status on its next
+/// persist. Outside a TUI session the operation is best-effort — the
+/// CLI surfaces the in-TUI alternative in the returned error.
+///
+/// # Errors
+///
+/// - [`HarnessError::TuiAttached`] when a live TUI sentinel is
+///   detected for this run.
+/// - [`HarnessError::Io`] / [`HarnessError::Serialize`] when persisting
+///   `run.toml` fails.
 pub fn pause(runner: &mut RunRunner) -> Result<(), HarnessError> {
+    refuse_if_tui_attached(runner)?;
     runner.set_status(RunStatus::Paused)
 }
 
@@ -158,10 +172,36 @@ pub fn pause(runner: &mut RunRunner) -> Result<(), HarnessError> {
 /// message. The CLI's `tmg run abort` command uses
 /// `"user aborted"` as the reason; other call sites can pass a more
 /// specific string.
+///
+/// **Refuses if a TUI is currently attached** to the same run; see
+/// [`pause`] for the rationale and [`HarnessError::TuiAttached`] for
+/// the surfaced error.
+///
+/// # Errors
+///
+/// - [`HarnessError::TuiAttached`] when a live TUI sentinel is
+///   detected for this run.
+/// - [`HarnessError::Io`] / [`HarnessError::Serialize`] when persisting
+///   `run.toml` fails.
 pub fn abort(runner: &mut RunRunner, reason: impl Into<String>) -> Result<(), HarnessError> {
+    refuse_if_tui_attached(runner)?;
     runner.set_status(RunStatus::Failed {
         reason: reason.into(),
     })
+}
+
+/// Surface [`HarnessError::TuiAttached`] when the run's TUI sentinel
+/// reports a live process. Used by `pause` / `abort` to short-circuit
+/// before mutating `run.toml`.
+fn refuse_if_tui_attached(runner: &RunRunner) -> Result<(), HarnessError> {
+    let run_dir = runner.store().run_dir(runner.run_id());
+    if let Some(pid) = crate::tui_sentinel::read_live_pid(&run_dir)? {
+        return Err(HarnessError::TuiAttached {
+            run_id: runner.run_id().as_str().to_owned(),
+            pid,
+        });
+    }
+    Ok(())
 }
 
 /// Force the run to harnessed scope without going through the
@@ -175,11 +215,47 @@ pub fn abort(runner: &mut RunRunner, reason: impl Into<String>) -> Result<(), Ha
 /// re-installing a [`crate::tools::RunRunnerToolProvider`] so the
 /// LLM sees the harnessed-only tools.
 ///
-/// Idempotent: when the run is already harnessed, the call is a
-/// no-op (still re-saves `run.toml` for durability).
+/// **Pre-condition**: `features.json` must exist in the run's
+/// workspace. The doc invariant on
+/// [`crate::store::RunStore::upgrade_to_harnessed`] is that the
+/// initializer subagent has already populated the artifacts; this
+/// helper checks the file is on disk before flipping the on-disk
+/// scope so a typo'd `tmg run upgrade <id>` outside the TUI does not
+/// end up with a harnessed `run.toml` that points at non-existent
+/// artifacts.
+///
+/// **Idempotent**: when the run is already harnessed, the call
+/// returns `Ok(())` immediately without touching `run.toml` or the
+/// in-memory runner. This avoids re-stamping `upgraded_at` /
+/// `upgraded_from_session` / `upgrade_reason` every time the user
+/// re-runs `tmg run upgrade` against an already-harnessed run.
+///
+/// # Errors
+///
+/// - [`HarnessError::Precondition`] when `features.json` is missing
+///   from the run's workspace directory.
+/// - [`HarnessError::Io`] / [`HarnessError::Serialize`] for write
+///   failures on `run.toml`.
 pub fn upgrade(runner: &mut RunRunner) -> Result<(), HarnessError> {
+    if runner.is_harnessed() {
+        // True no-op: re-saving `run.toml` with the same scope would
+        // reset `upgraded_at` and the upgrade-reason metadata, which
+        // is misleading after a real prior promotion. Leave the
+        // record untouched.
+        return Ok(());
+    }
     let session_count = runner.run().session_count;
     let store = runner.store().clone();
+    let features_path = store.features_file(runner.run_id());
+    if !features_path.exists() {
+        return Err(HarnessError::Precondition {
+            message: format!(
+                "cannot upgrade: features.json not found at {}; \
+                 run the initializer first or upgrade from inside a TUI session",
+                features_path.display(),
+            ),
+        });
+    }
     let run = store.upgrade_to_harnessed(runner.run_id(), session_count, "manual /run upgrade")?;
     runner.replace_run(run);
     Ok(())
@@ -245,6 +321,17 @@ mod tests {
         (tmp, store, runner)
     }
 
+    /// Plant a minimal valid `features.json` so `upgrade` clears its
+    /// pre-condition check.
+    fn write_minimal_features(store: &RunStore, run_id: &crate::run::RunId) {
+        let path = store.features_file(run_id);
+        std::fs::write(
+            &path,
+            r#"{"features":[{"id":"f0","category":"test","description":"d","steps":[],"passes":false}]}"#,
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+    }
+
     #[test]
     fn pause_flips_status_to_paused() {
         let (_tmp, store, mut runner) = make_runner_ad_hoc();
@@ -266,10 +353,64 @@ mod tests {
         }
     }
 
+    /// `pause` refuses with [`HarnessError::TuiAttached`] when the
+    /// run's `.tui-pid` sentinel reports a live process. Use the
+    /// current process's PID so the liveness probe definitely
+    /// resolves to "alive".
+    #[test]
+    fn pause_refuses_when_tui_sentinel_is_live() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        let run_dir = store.run_dir(&id);
+        crate::tui_sentinel::write(&run_dir).unwrap_or_else(|e| panic!("{e}"));
+
+        match pause(&mut runner) {
+            Err(HarnessError::TuiAttached { run_id, pid }) => {
+                assert_eq!(run_id, id.as_str());
+                assert_eq!(pid, std::process::id());
+            }
+            other => panic!("expected TuiAttached, got {other:?}"),
+        }
+        // The on-disk status must NOT have been flipped to Paused.
+        let reloaded = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(reloaded.status, RunStatus::Running);
+    }
+
+    /// Same guard for `abort`.
+    #[test]
+    fn abort_refuses_when_tui_sentinel_is_live() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        let run_dir = store.run_dir(&id);
+        crate::tui_sentinel::write(&run_dir).unwrap_or_else(|e| panic!("{e}"));
+
+        match abort(&mut runner, "user aborted") {
+            Err(HarnessError::TuiAttached { .. }) => {}
+            other => panic!("expected TuiAttached, got {other:?}"),
+        }
+        let reloaded = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(reloaded.status, RunStatus::Running);
+    }
+
+    /// Once the sentinel is cleared, `pause` proceeds normally.
+    #[test]
+    fn pause_proceeds_after_tui_sentinel_cleared() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        let run_dir = store.run_dir(&id);
+        crate::tui_sentinel::write(&run_dir).unwrap_or_else(|e| panic!("{e}"));
+        crate::tui_sentinel::clear(&run_dir).unwrap_or_else(|e| panic!("{e}"));
+
+        pause(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+        let reloaded = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(reloaded.status, RunStatus::Paused);
+    }
+
     #[test]
     fn upgrade_flips_scope_to_harnessed() {
         let (_tmp, store, mut runner) = make_runner_ad_hoc();
         let id = runner.run_id().clone();
+        write_minimal_features(&store, &id);
         upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
         let reloaded = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
         assert!(matches!(reloaded.scope, RunScope::Harnessed { .. }));
@@ -277,9 +418,55 @@ mod tests {
     }
 
     #[test]
+    fn upgrade_without_features_file_returns_precondition_error() {
+        let (_tmp, _store, mut runner) = make_runner_ad_hoc();
+        let result = upgrade(&mut runner);
+        match result {
+            Err(HarnessError::Precondition { message }) => {
+                assert!(
+                    message.contains("features.json not found"),
+                    "expected precondition message about features.json, got {message:?}",
+                );
+            }
+            other => panic!("expected Precondition error, got {other:?}"),
+        }
+        assert!(
+            !runner.is_harnessed(),
+            "scope must remain ad-hoc when precondition fails",
+        );
+    }
+
+    #[test]
+    fn upgrade_already_harnessed_is_noop_and_preserves_metadata() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        write_minimal_features(&store, &id);
+
+        // First upgrade: stamps the upgrade metadata.
+        upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+        let first = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        let first_upgraded_at = match &first.scope {
+            RunScope::Harnessed { upgraded_at, .. } => *upgraded_at,
+            RunScope::AdHoc => panic!("expected harnessed after first upgrade"),
+        };
+        // Sleep so a subsequent re-stamp would observably differ.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        // Second upgrade: must be a no-op. The on-disk record must
+        // not have its upgrade timestamp re-stamped.
+        upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+        let second = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        match &second.scope {
+            RunScope::Harnessed { upgraded_at, .. } => assert_eq!(*upgraded_at, first_upgraded_at),
+            RunScope::AdHoc => panic!("expected harnessed after second upgrade"),
+        }
+    }
+
+    #[test]
     fn downgrade_flips_scope_back_to_ad_hoc() {
         let (_tmp, store, mut runner) = make_runner_ad_hoc();
         let id = runner.run_id().clone();
+        write_minimal_features(&store, &id);
         upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
         assert!(runner.is_harnessed());
 
@@ -293,9 +480,11 @@ mod tests {
     fn downgrade_preserves_features_file_on_disk() {
         let (_tmp, store, mut runner) = make_runner_ad_hoc();
         let id = runner.run_id().clone();
+        write_minimal_features(&store, &id);
         upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
 
-        // Write a fake features.json so we can verify it is preserved.
+        // Overwrite the planted features.json with a richer payload so
+        // we can verify it's preserved across the downgrade.
         let features_path = store.features_file(&id);
         std::fs::write(
             &features_path,
@@ -342,8 +531,11 @@ mod tests {
     fn status_returns_feature_histogram_for_harnessed() {
         let (_tmp, store, mut runner) = make_runner_ad_hoc();
         let id = runner.run_id().clone();
+        write_minimal_features(&store, &id);
         upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
 
+        // Overwrite the planted features.json with the richer payload
+        // the histogram test wants to assert against.
         let features_path = store.features_file(&id);
         std::fs::write(
             &features_path,

--- a/crates/tmg-harness/src/commands.rs
+++ b/crates/tmg-harness/src/commands.rs
@@ -1,0 +1,387 @@
+//! Shared CLI/TUI command logic.
+//!
+//! These functions encapsulate the run-management operations exposed
+//! by the [`tmg run`](https://github.com/Kurogoma4D/tsumugi/issues/43)
+//! subcommand family and the matching TUI slash-commands (issue #46).
+//! Both call sites use the same building blocks here so the on-disk
+//! state transitions stay consistent regardless of which entry point
+//! drove them.
+//!
+//! The functions take borrowed handles to the [`RunStore`] /
+//! [`RunRunner`] rather than owning them; this keeps the helpers
+//! callable from inside an `Arc<Mutex<RunRunner>>` guard or from a
+//! one-shot CLI invocation that constructs a runner just to flip a
+//! single field.
+//!
+//! See SPEC §9.8 for the canonical command reference.
+//!
+//! # Reading status detail
+//!
+//! [`StatusReport`] bundles the structured fields the CLI's
+//! `tmg run status` formats. Higher-level surfaces (TUI, JSON
+//! exporters) can render the same struct without re-parsing
+//! `progress.md` themselves.
+
+use crate::artifacts::FeatureList;
+use crate::error::HarnessError;
+use crate::run::{Run, RunId, RunScope, RunStatus, RunSummary};
+use crate::runner::RunRunner;
+use crate::session::{Session, SessionEndTrigger};
+use crate::store::RunStore;
+
+/// Snapshot of a single run for the `tmg run status` command.
+///
+/// Combines the stored [`Run`] record with the tail of `progress.md`
+/// (if any), the most recent persisted [`Session`] (if any), and the
+/// harnessed-only feature pass/fail histogram. Higher-level surfaces
+/// can render this structure without re-reading any artifact files.
+#[derive(Debug, Clone)]
+pub struct StatusReport {
+    /// Full run record (scope, status, session counts).
+    pub run: Run,
+    /// Last `n` lines of `progress.md`, joined with `\n`. Empty when
+    /// the file does not exist or has no content.
+    pub progress_tail: String,
+    /// Number of progress lines actually returned.
+    pub progress_tail_lines: usize,
+    /// Most recent persisted session, when one exists.
+    pub last_session: Option<Session>,
+    /// Feature pass/fail histogram for harnessed runs. `None` for
+    /// ad-hoc or when `features.json` is missing/malformed.
+    pub feature_histogram: Option<FeatureHistogram>,
+}
+
+/// Pass/fail histogram for a harnessed run's `features.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FeatureHistogram {
+    /// Total number of features in `features.json`.
+    pub total: usize,
+    /// Number of features whose `passes` field is `true`.
+    pub passing: usize,
+}
+
+impl FeatureHistogram {
+    /// Number of failing features (`total - passing`).
+    #[must_use]
+    pub fn failing(&self) -> usize {
+        self.total.saturating_sub(self.passing)
+    }
+}
+
+/// Return all runs as [`RunSummary`] entries (newest first).
+///
+/// This is a thin wrapper over [`RunStore::list`] so the CLI / TUI
+/// share one entry point.
+pub fn list(store: &RunStore) -> Result<Vec<RunSummary>, HarnessError> {
+    store.list()
+}
+
+/// Build a [`StatusReport`] for the given run.
+///
+/// `progress_tail_lines` controls how many lines of `progress.md` to
+/// include in the report (the most recent N). The CLI defaults to
+/// twenty.
+pub fn status(
+    store: &RunStore,
+    run_id: &RunId,
+    progress_tail_lines: usize,
+) -> Result<StatusReport, HarnessError> {
+    let run = store.load(run_id)?;
+
+    let progress_path = store.progress_file(run_id);
+    let progress_tail = match std::fs::read_to_string(&progress_path) {
+        Ok(c) => tail_lines(&c, progress_tail_lines),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(HarnessError::io(&progress_path, e)),
+    };
+    let actual_lines = if progress_tail.is_empty() {
+        0
+    } else {
+        progress_tail.lines().count()
+    };
+
+    let last_session = if run.session_count == 0 {
+        None
+    } else {
+        let session_dir = store.session_log_dir(run_id);
+        let log = crate::artifacts::SessionLog::new(session_dir);
+        log.load(run.session_count)?
+    };
+
+    let feature_histogram = match &run.scope {
+        RunScope::Harnessed { .. } => {
+            let features_path = store.features_file(run_id);
+            if features_path.exists() {
+                let list = FeatureList::new(features_path);
+                match list.read() {
+                    Ok(features) => {
+                        let total = features.features.len();
+                        let passing = features.features.iter().filter(|f| f.passes).count();
+                        Some(FeatureHistogram { total, passing })
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "failed to read features.json for status report"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        }
+        RunScope::AdHoc => None,
+    };
+
+    Ok(StatusReport {
+        run,
+        progress_tail,
+        progress_tail_lines: actual_lines,
+        last_session,
+        feature_histogram,
+    })
+}
+
+/// Mark the run as paused.
+///
+/// Flips `run.toml` status to [`RunStatus::Paused`]. The runner
+/// remains usable; a follow-up `tmg run resume` will pick it back up
+/// because [`RunStatus::Paused`] is treated as resumable.
+pub fn pause(runner: &mut RunRunner) -> Result<(), HarnessError> {
+    runner.set_status(RunStatus::Paused)
+}
+
+/// Mark the run as failed with the supplied reason.
+///
+/// Flips `run.toml` status to [`RunStatus::Failed`] with the given
+/// message. The CLI's `tmg run abort` command uses
+/// `"user aborted"` as the reason; other call sites can pass a more
+/// specific string.
+pub fn abort(runner: &mut RunRunner, reason: impl Into<String>) -> Result<(), HarnessError> {
+    runner.set_status(RunStatus::Failed {
+        reason: reason.into(),
+    })
+}
+
+/// Force the run to harnessed scope without going through the
+/// auto-promotion gate.
+///
+/// Unlike [`RunRunner::escalate_to_harnessed`], this does not write
+/// `features.json` / `init.sh` (they are assumed to either already
+/// exist from a prior promotion or be supplied by the user out-of-
+/// band). The on-disk `run.toml` flips to harnessed and the runner's
+/// in-memory state is updated; the caller is responsible for
+/// re-installing a [`crate::tools::RunRunnerToolProvider`] so the
+/// LLM sees the harnessed-only tools.
+///
+/// Idempotent: when the run is already harnessed, the call is a
+/// no-op (still re-saves `run.toml` for durability).
+pub fn upgrade(runner: &mut RunRunner) -> Result<(), HarnessError> {
+    let session_count = runner.run().session_count;
+    let store = runner.store().clone();
+    let run = store.upgrade_to_harnessed(runner.run_id(), session_count, "manual /run upgrade")?;
+    runner.replace_run(run);
+    Ok(())
+}
+
+/// Demote a harnessed run back to ad-hoc.
+///
+/// The on-disk `features.json` / `init.sh` artifacts are preserved
+/// (see [`RunStore::downgrade_to_ad_hoc`] for rationale). Only the
+/// `run.toml` scope flips, so the LLM stops seeing harnessed-only
+/// tools after the caller re-installs a fresh
+/// [`crate::tools::RunRunnerToolProvider`].
+///
+/// Idempotent: when the run is already ad-hoc, the call is a no-op
+/// (still re-saves `run.toml`).
+pub fn downgrade(runner: &mut RunRunner) -> Result<(), HarnessError> {
+    let store = runner.store().clone();
+    let run = store.downgrade_to_ad_hoc(runner.run_id())?;
+    runner.replace_run(run);
+    Ok(())
+}
+
+/// Trigger a manual session rotation.
+///
+/// Equivalent to [`RunRunner::end_session_with_rotation`] with
+/// [`SessionEndTrigger::UserNewSession`]. The current session is
+/// closed and a fresh successor session is started.
+pub fn new_session(runner: &mut RunRunner) -> Result<(), HarnessError> {
+    runner
+        .end_session_with_rotation(SessionEndTrigger::UserNewSession)
+        .map(|_started| ())
+}
+
+/// Return the last `n` lines of `s` joined with `\n`.
+///
+/// `n == 0` returns an empty string. Lines beyond the tail are
+/// dropped. The return value never has a trailing `\n` so the CLI
+/// can append its own terminator.
+fn tail_lines(s: &str, n: usize) -> String {
+    if n == 0 || s.is_empty() {
+        return String::new();
+    }
+    let lines: Vec<&str> = s.lines().collect();
+    let take_from = lines.len().saturating_sub(n);
+    lines[take_from..].join("\n")
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn make_runner_ad_hoc() -> (tempfile::TempDir, Arc<RunStore>, RunRunner) {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let store = Arc::new(RunStore::new(tmp.path().join("runs")));
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let runner = RunRunner::new(run, Arc::clone(&store));
+        (tmp, store, runner)
+    }
+
+    #[test]
+    fn pause_flips_status_to_paused() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        pause(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+        let reloaded = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(reloaded.status, RunStatus::Paused);
+    }
+
+    #[test]
+    fn abort_flips_status_to_failed() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        abort(&mut runner, "user aborted").unwrap_or_else(|e| panic!("{e}"));
+        let reloaded = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        match reloaded.status {
+            RunStatus::Failed { reason } => assert_eq!(reason, "user aborted"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn upgrade_flips_scope_to_harnessed() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+        let reloaded = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        assert!(matches!(reloaded.scope, RunScope::Harnessed { .. }));
+        assert!(runner.is_harnessed());
+    }
+
+    #[test]
+    fn downgrade_flips_scope_back_to_ad_hoc() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+        assert!(runner.is_harnessed());
+
+        downgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+        let reloaded = store.load(&id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(reloaded.scope, RunScope::AdHoc);
+        assert!(!runner.is_harnessed());
+    }
+
+    #[test]
+    fn downgrade_preserves_features_file_on_disk() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+
+        // Write a fake features.json so we can verify it is preserved.
+        let features_path = store.features_file(&id);
+        std::fs::write(
+            &features_path,
+            r#"{"features":[{"id":"f1","category":"test","description":"x","steps":[],"passes":true}]}"#,
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        downgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            features_path.exists(),
+            "features.json should NOT be deleted on downgrade",
+        );
+    }
+
+    #[test]
+    fn list_returns_summaries() {
+        let (_tmp, store, _runner) = make_runner_ad_hoc();
+        let summaries = list(&store).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(summaries.len(), 1);
+    }
+
+    #[test]
+    fn status_includes_progress_tail() {
+        let (_tmp, store, runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        // Append some content so the tail has lines to return.
+        let progress = store.progress_file(&id);
+        std::fs::write(
+            &progress,
+            "# Progress Log\n\n## Session #1 (2024-01-01) [ad-hoc]\n- did stuff\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let report = status(&store, &id, 10).unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            report.progress_tail.contains("did stuff"),
+            "expected progress tail, got {:?}",
+            report.progress_tail,
+        );
+        assert!(report.feature_histogram.is_none());
+    }
+
+    #[test]
+    fn status_returns_feature_histogram_for_harnessed() {
+        let (_tmp, store, mut runner) = make_runner_ad_hoc();
+        let id = runner.run_id().clone();
+        upgrade(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+
+        let features_path = store.features_file(&id);
+        std::fs::write(
+            &features_path,
+            r#"{"features":[
+              {"id":"f1","category":"a","description":"x","steps":[],"passes":true},
+              {"id":"f2","category":"a","description":"y","steps":[],"passes":false}
+            ]}"#,
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let report = status(&store, &id, 5).unwrap_or_else(|e| panic!("{e}"));
+        let hist = report
+            .feature_histogram
+            .unwrap_or_else(|| panic!("expected histogram"));
+        assert_eq!(hist.total, 2);
+        assert_eq!(hist.passing, 1);
+        assert_eq!(hist.failing(), 1);
+    }
+
+    #[test]
+    fn tail_lines_returns_last_n() {
+        let s = "a\nb\nc\nd\n";
+        assert_eq!(tail_lines(s, 2), "c\nd");
+        assert_eq!(tail_lines(s, 10), "a\nb\nc\nd");
+        assert_eq!(tail_lines(s, 0), "");
+        assert_eq!(tail_lines("", 5), "");
+    }
+
+    #[tokio::test]
+    async fn new_session_rotates_active_session() {
+        let (_tmp, _store, mut runner) = make_runner_ad_hoc();
+        let _ = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(runner.run().session_count, 1);
+
+        new_session(&mut runner).unwrap_or_else(|e| panic!("{e}"));
+
+        // After rotation, session_count should be incremented.
+        assert_eq!(runner.run().session_count, 2);
+        assert!(runner.active_session().is_some());
+    }
+}

--- a/crates/tmg-harness/src/error.rs
+++ b/crates/tmg-harness/src/error.rs
@@ -130,6 +130,48 @@ pub enum HarnessError {
     /// so we bail out and leave the runner untouched.
     #[error("end_session_with_rotation called without an active session")]
     NoActiveSession,
+
+    /// A user-supplied run id did not match the canonical 8-character
+    /// hexadecimal shape ([`crate::run::RunId::is_valid_shape`]).
+    ///
+    /// Surfaced from [`crate::run::RunId::parse`] when the CLI / TUI
+    /// receives an id that could otherwise be used to construct an
+    /// arbitrary path under the runs-dir (e.g. `"../foo"`).
+    #[error("invalid run id {run_id:?}: expected 8 lowercase hex characters")]
+    InvalidRunId {
+        /// The rejected raw input.
+        run_id: String,
+    },
+
+    /// A precondition for a run operation was not satisfied.
+    ///
+    /// Used by run-mutation commands that need a specific on-disk file
+    /// (e.g. `tmg run upgrade` requires `features.json`) to bail out
+    /// with a clear, actionable message instead of silently proceeding.
+    #[error("{message}")]
+    Precondition {
+        /// Human-readable explanation; surfaced verbatim by the CLI.
+        message: String,
+    },
+
+    /// A run operation was refused because a TUI is currently attached
+    /// to the same run.
+    ///
+    /// Surfaced by `tmg run pause` / `tmg run abort` when the TUI
+    /// sentinel (`.tsumugi/runs/<id>/.tui-pid`) is present and the
+    /// recorded process is still alive: the in-memory runner inside
+    /// the TUI would silently overwrite our `run.toml` mutation,
+    /// so we refuse rather than racing.
+    #[error(
+        "a tmg TUI is currently attached to run {run_id} (pid {pid}); \
+         use the in-TUI /run pause command instead, or kill the tmg process first"
+    )]
+    TuiAttached {
+        /// The run id whose `.tui-pid` sentinel is live.
+        run_id: String,
+        /// The PID recorded in the sentinel.
+        pid: u32,
+    },
 }
 
 impl HarnessError {

--- a/crates/tmg-harness/src/lib.rs
+++ b/crates/tmg-harness/src/lib.rs
@@ -27,6 +27,7 @@
 //! - `tester` subagent for the harnessed `smoke_test_result` field
 
 pub mod artifacts;
+pub mod commands;
 pub mod error;
 pub mod escalation;
 pub mod run;
@@ -42,6 +43,7 @@ pub use artifacts::{
     InitScriptError, InitScriptOutput, ProgressLog, SUMMARY_AGGREGATE_FILENAME, SessionLog,
     SessionLogEntry, SessionSummaryAggregate, SessionSummaryEntry,
 };
+pub use commands::{FeatureHistogram, StatusReport};
 pub use error::HarnessError;
 pub use escalation::{
     EscalationConfig, EscalationConfigError, EscalationDecision, EscalationError,
@@ -57,8 +59,8 @@ pub use session::{Session, SessionEndTrigger, SessionHandle};
 pub use sink::HarnessStreamSink;
 pub use state::{SessionState, TurnSummary};
 pub use store::{
-    FEATURES_FILENAME, INIT_SCRIPT_FILENAME, PROGRESS_FILENAME, RUN_FILENAME, RunStore,
-    SESSION_LOG_DIRNAME, WORKSPACE_LINK,
+    CURRENT_FILENAME, CURRENT_POINTER_FILENAME, FEATURES_FILENAME, INIT_SCRIPT_FILENAME,
+    PROGRESS_FILENAME, RUN_FILENAME, RunStore, SESSION_LOG_DIRNAME, WORKSPACE_LINK,
 };
 pub use tools::{
     BootstrapPayload, FeatureListMarkPassingTool, FeatureListReadTool, InitScriptStatus,

--- a/crates/tmg-harness/src/lib.rs
+++ b/crates/tmg-harness/src/lib.rs
@@ -37,6 +37,7 @@ pub mod sink;
 pub mod state;
 pub mod store;
 pub mod tools;
+pub mod tui_sentinel;
 
 pub use artifacts::{
     Feature, FeatureList, Features, FeaturesSummary, FeaturesSummaryEntry, InitScript,

--- a/crates/tmg-harness/src/run.rs
+++ b/crates/tmg-harness/src/run.rs
@@ -17,6 +17,8 @@ use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::error::HarnessError;
+
 /// Short hex identifier for a run, e.g. `"a3f1e2b9"`.
 ///
 /// Generated from a UUID v4 by taking the first 8 hex characters of the
@@ -37,10 +39,52 @@ impl RunId {
         Self(simple[..8].to_owned())
     }
 
-    /// Construct a run id from a raw string (e.g. when loading from disk).
+    /// Parse a user-supplied run id, validating that it matches the
+    /// canonical 8-character hexadecimal shape produced by [`Self::new`].
+    ///
+    /// Returns [`HarnessError::InvalidRunId`] when `s` does not match
+    /// `^[0-9a-f]{8}$`. This is the only constructor that should be used
+    /// at trust boundaries (CLI arguments, network input, etc.) so we
+    /// never construct paths from caller-controlled values that escape
+    /// the runs-dir.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarnessError::InvalidRunId`] when `s` is not exactly
+    /// eight ASCII hex digits (lowercase a-f).
+    pub fn parse(s: impl Into<String>) -> Result<Self, HarnessError> {
+        let raw = s.into();
+        if Self::is_valid_shape(&raw) {
+            Ok(Self(raw))
+        } else {
+            Err(HarnessError::InvalidRunId { run_id: raw })
+        }
+    }
+
+    /// Construct a run id from a raw string without validating its
+    /// shape.
+    ///
+    /// Internal-only escape hatch for callers that have already
+    /// validated the input by other means — primarily
+    /// [`crate::store::RunStore::list`] (the directory name on disk
+    /// stands in for validation; a hand-edited directory with a bogus
+    /// name will simply fail to load `run.toml`) and the JSON-pointer
+    /// fallback inside [`crate::store::RunStore::current`] (the
+    /// pointer's payload is also self-validated when the run is loaded).
+    /// **Do not** use this for CLI arguments or any other untrusted
+    /// input — call [`Self::parse`] instead.
     #[must_use]
-    pub fn from_string(s: impl Into<String>) -> Self {
+    pub(crate) fn from_string_unchecked(s: impl Into<String>) -> Self {
         Self(s.into())
+    }
+
+    /// Return `true` when `s` matches the canonical 8-char hex shape
+    /// produced by [`Self::new`].
+    #[must_use]
+    pub fn is_valid_shape(s: &str) -> bool {
+        s.len() == 8
+            && s.bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
     }
 
     /// Return the run id as a string slice.
@@ -322,14 +366,61 @@ mod tests {
 
     #[test]
     fn run_id_short_handles_long_strings() {
-        let id = RunId::from_string("abcdef0123456789");
+        let id = RunId::from_string_unchecked("abcdef0123456789");
         assert_eq!(id.short(), "abcdef01");
     }
 
     #[test]
     fn run_id_short_handles_short_strings() {
-        let id = RunId::from_string("abc");
+        let id = RunId::from_string_unchecked("abc");
         assert_eq!(id.short(), "abc");
+    }
+
+    #[test]
+    fn run_id_parse_accepts_canonical_shape() {
+        let id = RunId::parse("abc12345").unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(id.as_str(), "abc12345");
+    }
+
+    #[test]
+    fn run_id_parse_rejects_uppercase() {
+        match RunId::parse("ABC12345") {
+            Err(HarnessError::InvalidRunId { run_id }) => assert_eq!(run_id, "ABC12345"),
+            Ok(id) => panic!("expected InvalidRunId, got Ok({})", id.as_str()),
+            Err(other) => panic!("expected InvalidRunId, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_id_parse_rejects_wrong_length() {
+        assert!(matches!(
+            RunId::parse("abc"),
+            Err(HarnessError::InvalidRunId { .. })
+        ));
+        assert!(matches!(
+            RunId::parse("abc1234567"),
+            Err(HarnessError::InvalidRunId { .. })
+        ));
+    }
+
+    #[test]
+    fn run_id_parse_rejects_non_hex() {
+        assert!(matches!(
+            RunId::parse("../foo12"),
+            Err(HarnessError::InvalidRunId { .. })
+        ));
+        assert!(matches!(
+            RunId::parse("zzzzzzzz"),
+            Err(HarnessError::InvalidRunId { .. })
+        ));
+    }
+
+    #[test]
+    fn run_id_new_passes_parse_validation() {
+        let generated = RunId::new();
+        let raw = generated.as_str().to_owned();
+        let reparsed = RunId::parse(raw.clone()).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(reparsed.as_str(), raw);
     }
 
     #[test]

--- a/crates/tmg-harness/src/runner.rs
+++ b/crates/tmg-harness/src/runner.rs
@@ -1091,6 +1091,41 @@ impl RunRunner {
     pub fn run_id(&self) -> &crate::run::RunId {
         &self.run.id
     }
+
+    /// Borrow the [`RunStore`] backing this runner.
+    ///
+    /// Used by the CLI's `tmg run upgrade` / `downgrade` paths to
+    /// drive the underlying store mutations from a shared runner
+    /// without having to thread an extra `Arc<RunStore>` through every
+    /// command.
+    #[must_use]
+    pub fn store(&self) -> &Arc<RunStore> {
+        &self.store
+    }
+
+    /// Replace the in-memory [`Run`] record after the underlying
+    /// `run.toml` has been mutated out-of-band (e.g. by
+    /// [`RunStore::upgrade_to_harnessed`] /
+    /// [`RunStore::downgrade_to_ad_hoc`] /
+    /// [`Self::set_status`]).
+    ///
+    /// Also keeps the [`SessionState`] scope flag in sync so escalator
+    /// signals continue to fire against the current scope.
+    pub fn replace_run(&mut self, run: Run) {
+        self.session_state.set_scope(run.scope.clone());
+        self.run = run;
+    }
+
+    /// Update the run's [`RunStatus`](crate::run::RunStatus) and
+    /// persist `run.toml`.
+    ///
+    /// Used by the CLI's `tmg run pause` / `abort` commands. The
+    /// runner does not enforce a state machine; the caller decides
+    /// whether the new status is reachable from the current one.
+    pub fn set_status(&mut self, status: crate::run::RunStatus) -> Result<(), HarnessError> {
+        self.run.status = status;
+        self.store.save(&self.run)
+    }
 }
 
 impl Drop for RunRunner {

--- a/crates/tmg-harness/src/store.rs
+++ b/crates/tmg-harness/src/store.rs
@@ -21,6 +21,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
+use serde::ser::Error as _;
 
 use crate::artifacts::ProgressLog;
 use crate::error::HarnessError;
@@ -31,6 +32,20 @@ pub const RUN_FILENAME: &str = "run.toml";
 
 /// Filename of the workspace symlink under each run directory.
 pub const WORKSPACE_LINK: &str = "workspace";
+
+/// Filename of the "current run" pointer at the runs-dir root.
+///
+/// The pointer is written as a symlink on Unix-like platforms (the
+/// runtime falls back to a JSON pointer file if symlink creation
+/// fails). [`RunStore::current`] resolves it back to a [`RunId`] for
+/// CLI commands that default to the most-recent active run.
+pub const CURRENT_FILENAME: &str = "current";
+
+/// Fallback pointer-file name used when symlink creation fails.
+///
+/// Stores `{ "run_id": "<id>" }` in JSON so the CLI can still resolve
+/// the current run on platforms where symlinks are restricted.
+pub const CURRENT_POINTER_FILENAME: &str = "current.json";
 
 /// Filename of the human-readable progress log under each run directory.
 pub const PROGRESS_FILENAME: &str = "progress.md";
@@ -143,6 +158,11 @@ impl RunStore {
         ProgressLog::init(self.progress_file(&run.id))?;
 
         self.save(&run)?;
+        // Best-effort: point `current` at the freshly-created run so
+        // CLI commands without a `run_id` argument default to it.
+        if let Err(e) = self.set_current(&run.id) {
+            tracing::warn!(error = %e, "failed to update current run pointer");
+        }
         Ok(run)
     }
 
@@ -271,6 +291,42 @@ impl RunStore {
         Ok(run)
     }
 
+    /// Demote a harnessed run back to ad-hoc scope.
+    ///
+    /// SPEC §9.8 `tmg run downgrade`: flips `Run::scope` back to
+    /// [`RunScope::AdHoc`] and clears the top-level `workflow_id` /
+    /// `max_sessions` mirrors so the LLM stops seeing harnessed-only
+    /// tools on the next registry refresh.
+    ///
+    /// **Important:** the on-disk `features.json` and `init.sh` files
+    /// are intentionally **not** deleted. They are preserved so a
+    /// subsequent `tmg run upgrade` can re-promote without losing the
+    /// initializer's work, and so post-mortem inspection of an
+    /// ad-hoc-now run still has access to the harness artifacts. The
+    /// `RunRunnerToolProvider` re-installed by the caller decides
+    /// whether the LLM sees those tools — see
+    /// [`crate::tools::RunRunnerToolProvider`] for the policy.
+    ///
+    /// Returns the updated [`Run`] record. A no-op when the run is
+    /// already ad-hoc (still re-saves to keep `run.toml` durable).
+    ///
+    /// # Errors
+    ///
+    /// - [`HarnessError::RunNotFound`] when the run id has no
+    ///   corresponding `run.toml`.
+    /// - [`HarnessError::IdMismatch`] when the loaded record's id
+    ///   disagrees with the directory name.
+    /// - [`HarnessError::Serialize`] / [`HarnessError::Io`] for write
+    ///   failures.
+    pub fn downgrade_to_ad_hoc(&self, run_id: &RunId) -> Result<Run, HarnessError> {
+        let mut run = self.load(run_id)?;
+        run.scope = RunScope::AdHoc;
+        run.workflow_id = None;
+        run.max_sessions = None;
+        self.save(&run)?;
+        Ok(run)
+    }
+
     /// List all runs as lightweight summaries.
     ///
     /// Entries that fail to load (e.g. missing or malformed `run.toml`)
@@ -327,6 +383,11 @@ impl RunStore {
     /// `Some`, only runs whose stored `workspace_path` matches are
     /// eligible; this prevents resuming a run from a different project
     /// when several projects share the same `runs_dir` configuration.
+    ///
+    /// As a side-effect, the [`current`](Self::current) pointer is
+    /// updated to the returned run so subsequent argument-less CLI
+    /// commands target it. Failures to update the pointer are logged
+    /// at `warn` and do not propagate.
     pub fn latest_resumable(
         &self,
         workspace_path: Option<&Path>,
@@ -346,9 +407,133 @@ impl RunStore {
                     continue;
                 }
             }
+            // Best-effort: update `current` to the resolved run.
+            if let Err(e) = self.set_current(&summary.id) {
+                tracing::warn!(error = %e, "failed to update current run pointer");
+            }
             return Ok(Some(summary));
         }
         Ok(None)
+    }
+
+    /// Path of the `current` pointer at the runs-dir root.
+    ///
+    /// Symlink form is preferred but a `current.json` pointer file is
+    /// used as a fallback when symlink creation fails.
+    #[must_use]
+    pub fn current_link_path(&self) -> PathBuf {
+        self.runs_dir.join(CURRENT_FILENAME)
+    }
+
+    /// Path of the JSON-pointer fallback used when symlink creation
+    /// fails.
+    #[must_use]
+    pub fn current_pointer_path(&self) -> PathBuf {
+        self.runs_dir.join(CURRENT_POINTER_FILENAME)
+    }
+
+    /// Set the `current` pointer to `run_id`.
+    ///
+    /// Tries to create a symlink at `<runs_dir>/current` pointing at
+    /// `<run_id>`. If symlink creation fails (e.g. on platforms where
+    /// symlinks require elevated permissions), a JSON pointer file
+    /// (`<runs_dir>/current.json`) is written as a fallback so the
+    /// CLI's `tmg run resume` / `status` / etc. can still resolve the
+    /// most recent active run.
+    pub fn set_current(&self, run_id: &RunId) -> Result<(), HarnessError> {
+        fs::create_dir_all(&self.runs_dir).map_err(|e| HarnessError::io(&self.runs_dir, e))?;
+
+        let link = self.current_link_path();
+        let pointer = self.current_pointer_path();
+
+        // Remove any existing symlink/pointer-file before re-creating
+        // so we never observe a stale value mid-update.
+        let _ = fs::remove_file(&link);
+        let _ = fs::remove_file(&pointer);
+
+        match create_current_symlink(run_id.as_str(), &link) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "current symlink creation failed; falling back to JSON pointer file",
+                );
+                let payload = serde_json::json!({ "run_id": run_id.as_str() });
+                let serialized = serde_json::to_string(&payload).map_err(|src| {
+                    HarnessError::Serialize {
+                        path: pointer.clone(),
+                        // Re-package serde_json error as toml::ser::Error
+                        // is awkward; fall back to an `Io` error so the
+                        // caller still sees the failure path. We embed
+                        // the JSON error message into the chained error.
+                        source: toml::ser::Error::custom(src.to_string()),
+                    }
+                })?;
+                fs::write(&pointer, serialized).map_err(|e| HarnessError::io(&pointer, e))?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Resolve the `current` pointer back to a [`RunId`], or `None` if
+    /// no current pointer is set.
+    ///
+    /// Tries the symlink first, then the JSON-pointer fallback. A
+    /// dangling symlink (target run was deleted) is treated as `None`.
+    pub fn current(&self) -> Result<Option<RunId>, HarnessError> {
+        let link = self.current_link_path();
+        match fs::read_link(&link) {
+            Ok(target) => {
+                // The symlink target is the run-id (relative path).
+                let id_str = target
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .map(str::to_owned);
+                if let Some(id) = id_str {
+                    let run_id = RunId::from_string(id);
+                    // Verify the target run still exists; treat
+                    // dangling links as "no current".
+                    if self.run_file(&run_id).exists() {
+                        return Ok(Some(run_id));
+                    }
+                }
+                // Fall through to JSON pointer if the symlink is
+                // dangling or otherwise unparseable.
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Try the JSON-pointer fallback below.
+            }
+            Err(_) => {
+                // Some other read error (e.g. EINVAL because the entry
+                // is not a symlink). Fall through to JSON pointer.
+            }
+        }
+
+        let pointer = self.current_pointer_path();
+        let content = match fs::read_to_string(&pointer) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(HarnessError::io(&pointer, e)),
+        };
+        let parsed: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    path = %pointer.display(),
+                    error = %e,
+                    "current.json is not valid JSON; treating as no current",
+                );
+                return Ok(None);
+            }
+        };
+        let Some(id_str) = parsed.get("run_id").and_then(serde_json::Value::as_str) else {
+            return Ok(None);
+        };
+        let run_id = RunId::from_string(id_str.to_owned());
+        if !self.run_file(&run_id).exists() {
+            return Ok(None);
+        }
+        Ok(Some(run_id))
     }
 }
 
@@ -411,6 +596,33 @@ fn create_workspace_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
 
 #[cfg(not(any(unix, windows)))]
 fn create_workspace_symlink(_target: &Path, _link: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "symlinks not supported on this platform",
+    ))
+}
+
+/// Create a symlink at `link` pointing at `<runs_dir>/<target>`. The
+/// link target is a *relative* path (just the run id) so the symlink
+/// works irrespective of how the runs-dir is reached.
+#[cfg(unix)]
+fn create_current_symlink(target: &str, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn create_current_symlink(target: &str, link: &Path) -> std::io::Result<()> {
+    // Windows directory symlinks need an absolute or canonical-ish
+    // path; we resolve it relative to the link's parent directory.
+    let target_path = match link.parent() {
+        Some(parent) => parent.join(target),
+        None => std::path::PathBuf::from(target),
+    };
+    std::os::windows::fs::symlink_dir(&target_path, link)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_current_symlink(_target: &str, _link: &Path) -> std::io::Result<()> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
         "symlinks not supported on this platform",
@@ -645,6 +857,72 @@ mod tests {
         let reloaded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
         assert!(matches!(reloaded.scope, RunScope::Harnessed { .. }));
         assert_eq!(reloaded.workflow_id.as_deref(), Some("auto-promoted"));
+    }
+
+    #[test]
+    fn create_ad_hoc_sets_current_pointer() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let resolved = store
+            .current()
+            .unwrap_or_else(|e| panic!("{e}"))
+            .unwrap_or_else(|| panic!("expected current pointer to be set"));
+        assert_eq!(resolved, run.id);
+    }
+
+    #[test]
+    fn set_current_overwrites_previous_pointer() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run_a = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let run_b = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        // After two `create_ad_hoc` calls the pointer should track the
+        // most recent one.
+        let resolved = store
+            .current()
+            .unwrap_or_else(|e| panic!("{e}"))
+            .unwrap_or_else(|| panic!("expected current pointer to be set"));
+        assert_eq!(resolved, run_b.id);
+        assert_ne!(resolved, run_a.id);
+    }
+
+    #[test]
+    fn current_returns_none_when_unset() {
+        let (_tmp, store) = make_store();
+        // No runs created yet; no pointer should exist.
+        let resolved = store.current().unwrap_or_else(|e| panic!("{e}"));
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn current_returns_none_for_dangling_pointer() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        // Delete the run directory underneath the pointer.
+        std::fs::remove_dir_all(store.run_dir(&run.id)).unwrap_or_else(|e| panic!("{e}"));
+
+        let resolved = store.current().unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            resolved.is_none(),
+            "dangling current pointer should resolve to None"
+        );
     }
 
     #[test]

--- a/crates/tmg-harness/src/store.rs
+++ b/crates/tmg-harness/src/store.rs
@@ -21,7 +21,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
-use serde::ser::Error as _;
 
 use crate::artifacts::ProgressLog;
 use crate::error::HarnessError;
@@ -356,7 +355,20 @@ impl RunStore {
                 );
                 continue;
             };
-            let run_id = RunId::from_string(name.clone());
+            // Directory names that are not valid run-id shapes are
+            // skipped rather than treated as runs (defensive against
+            // hand-edited runs-dir contents). Internal-only construction
+            // is fine here because the loader will surface
+            // [`HarnessError::IdMismatch`] / [`HarnessError::Deserialize`]
+            // for any tampered `run.toml` on disk.
+            if !RunId::is_valid_shape(&name) {
+                tracing::debug!(
+                    name = %name,
+                    "skipping non-run directory in runs-dir",
+                );
+                continue;
+            }
+            let run_id = RunId::from_string_unchecked(name.clone());
             match self.load(&run_id) {
                 Ok(run) => summaries.push(RunSummary::from_run(&run)),
                 Err(err) => {
@@ -384,10 +396,12 @@ impl RunStore {
     /// eligible; this prevents resuming a run from a different project
     /// when several projects share the same `runs_dir` configuration.
     ///
-    /// As a side-effect, the [`current`](Self::current) pointer is
-    /// updated to the returned run so subsequent argument-less CLI
-    /// commands target it. Failures to update the pointer are logged
-    /// at `warn` and do not propagate.
+    /// **Read-only**: this method does not update the
+    /// [`current`](Self::current) pointer. Callers that want the
+    /// resolved run to become the implicit default for subsequent CLI
+    /// commands must invoke [`Self::set_current`] themselves; read-only
+    /// callers (e.g. `tmg run status`'s fallback) can rely on this
+    /// being a pure query.
     pub fn latest_resumable(
         &self,
         workspace_path: Option<&Path>,
@@ -406,10 +420,6 @@ impl RunStore {
                 if run.workspace_path != expected {
                     continue;
                 }
-            }
-            // Best-effort: update `current` to the resolved run.
-            if let Err(e) = self.set_current(&summary.id) {
-                tracing::warn!(error = %e, "failed to update current run pointer");
             }
             return Ok(Some(summary));
         }
@@ -434,42 +444,84 @@ impl RunStore {
 
     /// Set the `current` pointer to `run_id`.
     ///
-    /// Tries to create a symlink at `<runs_dir>/current` pointing at
-    /// `<run_id>`. If symlink creation fails (e.g. on platforms where
-    /// symlinks require elevated permissions), a JSON pointer file
-    /// (`<runs_dir>/current.json`) is written as a fallback so the
-    /// CLI's `tmg run resume` / `status` / etc. can still resolve the
-    /// most recent active run.
+    /// Atomically replaces `<runs_dir>/current` (or `current.json` on
+    /// the JSON-fallback branch). On Unix, the new symlink is created
+    /// at a unique sibling path and `rename(2)`-d over `current`; this
+    /// avoids the unlink-then-create window during which a concurrent
+    /// reader could see no pointer at all. The JSON-fallback branch
+    /// uses the same write-then-rename pattern.
+    ///
+    /// Falls back to a JSON pointer file (`<runs_dir>/current.json`)
+    /// when symlink creation is rejected by the platform / filesystem
+    /// (e.g. unprivileged Windows accounts, restricted FUSE mounts).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `serde_json` cannot serialize a fixed
+    /// `serde_json::json!({...})` value. The payload contains only
+    /// owned `String`s with no foreign `Serialize` impls, so this is
+    /// effectively unreachable; a panic here would indicate a
+    /// `serde_json` regression rather than a runtime condition.
+    #[expect(
+        clippy::expect_used,
+        reason = "serializing a serde_json::json! macro value with only String contents is infallible; see #panics in this method's docs"
+    )]
     pub fn set_current(&self, run_id: &RunId) -> Result<(), HarnessError> {
         fs::create_dir_all(&self.runs_dir).map_err(|e| HarnessError::io(&self.runs_dir, e))?;
 
         let link = self.current_link_path();
         let pointer = self.current_pointer_path();
 
-        // Remove any existing symlink/pointer-file before re-creating
-        // so we never observe a stale value mid-update.
-        let _ = fs::remove_file(&link);
-        let _ = fs::remove_file(&pointer);
+        // Pick a per-call tmp suffix so concurrent invocations cannot
+        // clobber each other's staging file. PID + nanoseconds is
+        // overkill for the single-process model the store assumes, but
+        // is cheap and protects us against a future inter-process
+        // locking layer that might allow concurrent writers.
+        let tmp_suffix = format!(
+            "{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or_default(),
+        );
 
-        match create_current_symlink(run_id.as_str(), &link) {
-            Ok(()) => Ok(()),
+        match create_current_symlink_atomic(run_id.as_str(), &link, &self.runs_dir, &tmp_suffix) {
+            Ok(()) => {
+                // The JSON pointer is no longer authoritative; remove
+                // it so a later `current()` call doesn't fall back to a
+                // stale JSON file that disagrees with the symlink.
+                let _ = fs::remove_file(&pointer);
+                Ok(())
+            }
             Err(e) => {
                 tracing::debug!(
                     error = %e,
                     "current symlink creation failed; falling back to JSON pointer file",
                 );
+                // `serde_json::json!` builds a `Value` whose
+                // serialization is infallible (no foreign Serialize
+                // impls in the tree); a panic here would indicate a
+                // serde_json regression rather than a recoverable
+                // error.
                 let payload = serde_json::json!({ "run_id": run_id.as_str() });
-                let serialized = serde_json::to_string(&payload).map_err(|src| {
-                    HarnessError::Serialize {
-                        path: pointer.clone(),
-                        // Re-package serde_json error as toml::ser::Error
-                        // is awkward; fall back to an `Io` error so the
-                        // caller still sees the failure path. We embed
-                        // the JSON error message into the chained error.
-                        source: toml::ser::Error::custom(src.to_string()),
-                    }
-                })?;
-                fs::write(&pointer, serialized).map_err(|e| HarnessError::io(&pointer, e))?;
+                let serialized = serde_json::to_string(&payload)
+                    .expect("serializing a json! macro value is infallible");
+                let pointer_tmp = self
+                    .runs_dir
+                    .join(format!("{CURRENT_POINTER_FILENAME}.{tmp_suffix}"));
+                if let Err(e) = fs::write(&pointer_tmp, serialized) {
+                    let _ = fs::remove_file(&pointer_tmp);
+                    return Err(HarnessError::io(&pointer_tmp, e));
+                }
+                if let Err(e) = fs::rename(&pointer_tmp, &pointer) {
+                    let _ = fs::remove_file(&pointer_tmp);
+                    return Err(HarnessError::io(&pointer, e));
+                }
+                // Clear any prior symlink so `current()` doesn't pick
+                // up a now-stale link in preference to the freshly
+                // written JSON pointer.
+                let _ = fs::remove_file(&link);
                 Ok(())
             }
         }
@@ -489,8 +541,8 @@ impl RunStore {
                     .file_name()
                     .and_then(|s| s.to_str())
                     .map(str::to_owned);
-                if let Some(id) = id_str {
-                    let run_id = RunId::from_string(id);
+                if let Some(id) = id_str.filter(|s| RunId::is_valid_shape(s)) {
+                    let run_id = RunId::from_string_unchecked(id);
                     // Verify the target run still exists; treat
                     // dangling links as "no current".
                     if self.run_file(&run_id).exists() {
@@ -529,7 +581,14 @@ impl RunStore {
         let Some(id_str) = parsed.get("run_id").and_then(serde_json::Value::as_str) else {
             return Ok(None);
         };
-        let run_id = RunId::from_string(id_str.to_owned());
+        if !RunId::is_valid_shape(id_str) {
+            tracing::warn!(
+                value = id_str,
+                "current.json contains a malformed run id; treating as no current",
+            );
+            return Ok(None);
+        }
+        let run_id = RunId::from_string_unchecked(id_str.to_owned());
         if !self.run_file(&run_id).exists() {
             return Ok(None);
         }
@@ -627,6 +686,34 @@ fn create_current_symlink(_target: &str, _link: &Path) -> std::io::Result<()> {
         std::io::ErrorKind::Unsupported,
         "symlinks not supported on this platform",
     ))
+}
+
+/// Atomically install a symlink at `link` pointing at `target` (a run
+/// id, relative to the symlink's parent).
+///
+/// Creates the symlink at a unique sibling path under `parent` first,
+/// then `rename(2)`-s it over `link`. The rename is atomic on POSIX
+/// when source and destination share a directory, which they do here
+/// by construction.
+///
+/// Cleans up the staged symlink on failure; the original `link` (if
+/// any) is left intact so `current()` continues to resolve to whatever
+/// it pointed at before the failed update.
+fn create_current_symlink_atomic(
+    target: &str,
+    link: &Path,
+    parent: &Path,
+    tmp_suffix: &str,
+) -> std::io::Result<()> {
+    let staging = parent.join(format!("{CURRENT_FILENAME}.{tmp_suffix}"));
+    // Ensure no stale staging entry from a previously-crashed call.
+    let _ = fs::remove_file(&staging);
+    create_current_symlink(target, &staging)?;
+    if let Err(e) = fs::rename(&staging, link) {
+        let _ = fs::remove_file(&staging);
+        return Err(e);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -788,7 +875,7 @@ mod tests {
     #[test]
     fn load_missing_returns_run_not_found() {
         let (_tmp, store) = make_store();
-        let result = store.load(&RunId::from_string("deadbeef"));
+        let result = store.load(&RunId::parse("deadbeef").unwrap_or_else(|e| panic!("{e}")));
         assert!(matches!(
             result,
             Err(HarnessError::RunNotFound { ref run_id }) if run_id == "deadbeef"
@@ -936,6 +1023,81 @@ mod tests {
         assert!(
             !tmp_path.exists(),
             "atomic save should not leave run.toml.tmp behind"
+        );
+    }
+
+    /// `latest_resumable` is now a pure query: calling it must NOT
+    /// update the `current` pointer. The CLI's resume path is
+    /// responsible for that side-effect when the user actually picks a
+    /// run.
+    #[test]
+    fn latest_resumable_does_not_mutate_current_pointer() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+
+        // Seed two runs; the first becomes `current` via
+        // `create_ad_hoc`'s side-effect, the second overwrites it.
+        let run_a = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let run_b = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        // Force `current` back to A so we can detect an unwanted
+        // mutation by `latest_resumable`.
+        store
+            .set_current(&run_a.id)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let before = store
+            .current()
+            .unwrap_or_else(|e| panic!("{e}"))
+            .unwrap_or_else(|| panic!("current should be set"));
+        assert_eq!(before, run_a.id);
+
+        // Even though `latest_resumable` would resolve to run_b (the
+        // newer resumable), the pointer must remain on A.
+        let resolved = store
+            .latest_resumable(Some(&workspace))
+            .unwrap_or_else(|e| panic!("{e}"))
+            .unwrap_or_else(|| panic!("expected a resumable run"));
+        assert_eq!(resolved.id, run_b.id);
+
+        let after = store
+            .current()
+            .unwrap_or_else(|e| panic!("{e}"))
+            .unwrap_or_else(|| panic!("current should still be set"));
+        assert_eq!(
+            after, run_a.id,
+            "latest_resumable must not mutate the current pointer",
+        );
+    }
+
+    /// `set_current` writes the new symlink atomically: a stage path
+    /// is `rename(2)`-d over the live `current`, leaving no
+    /// `current.<suffix>` litter behind on success.
+    #[test]
+    fn set_current_leaves_no_staging_files() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        store.set_current(&run.id).unwrap_or_else(|e| panic!("{e}"));
+
+        // No `current.<pid>-<nanos>` staging entries should remain.
+        let entries = std::fs::read_dir(store.runs_dir())
+            .unwrap_or_else(|e| panic!("{e}"))
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(
+            !entries
+                .iter()
+                .any(|name| name.starts_with(&format!("{CURRENT_FILENAME}."))),
+            "set_current must not leave staging files behind: {entries:?}",
         );
     }
 }

--- a/crates/tmg-harness/src/tui_sentinel.rs
+++ b/crates/tmg-harness/src/tui_sentinel.rs
@@ -1,0 +1,225 @@
+//! TUI-attached sentinel file management.
+//!
+//! When a `tmg` TUI starts up against a run, it writes a small file at
+//! `<run-dir>/.tui-pid` containing its PID. CLI mutators (`tmg run
+//! pause` / `tmg run abort`) check for this sentinel before writing
+//! `run.toml`: if the sentinel exists and the recorded process is
+//! still alive, the CLI refuses with [`HarnessError::TuiAttached`]
+//! rather than racing the live runner. The TUI removes the file on
+//! shutdown.
+//!
+//! ## Failure model
+//!
+//! - **Stale sentinel** (process no longer alive): treated as
+//!   "no TUI attached"; the CLI proceeds with its mutation. The
+//!   sentinel is removed best-effort on the way through.
+//! - **Unparseable sentinel** (corrupted contents): logged at warn
+//!   and treated as stale; same as above.
+//! - **Sentinel write/remove I/O errors**: surfaced as
+//!   [`HarnessError::Io`] from the corresponding [`write`] / [`clear`]
+//!   helper. The TUI tolerates these (best-effort) so a permission
+//!   problem on the run dir doesn't abort startup.
+//!
+//! ## Filename
+//!
+//! The leading dot keeps the file out of the way of casual `ls`
+//! listings. Tests verify the constant rather than hard-coding the
+//! string elsewhere.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::HarnessError;
+
+/// Filename of the TUI-attached sentinel under each run directory.
+pub const TUI_SENTINEL_FILENAME: &str = ".tui-pid";
+
+/// Compute the sentinel path inside the run directory.
+#[must_use]
+pub fn sentinel_path(run_dir: &Path) -> PathBuf {
+    run_dir.join(TUI_SENTINEL_FILENAME)
+}
+
+/// Write the current process's PID to the sentinel.
+///
+/// Atomically replaces any prior sentinel via a tmp-and-rename, so
+/// concurrent CLI readers never observe a half-written file.
+pub fn write(run_dir: &Path) -> Result<(), HarnessError> {
+    let path = sentinel_path(run_dir);
+    let tmp = path.with_extension("pid.tmp");
+    let pid = std::process::id();
+    if let Err(e) = fs::write(&tmp, format!("{pid}\n")) {
+        let _ = fs::remove_file(&tmp);
+        return Err(HarnessError::io(&tmp, e));
+    }
+    if let Err(e) = fs::rename(&tmp, &path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(HarnessError::io(&path, e));
+    }
+    Ok(())
+}
+
+/// Remove the sentinel, if present. Missing-file is not an error.
+pub fn clear(run_dir: &Path) -> Result<(), HarnessError> {
+    let path = sentinel_path(run_dir);
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(HarnessError::io(&path, e)),
+    }
+}
+
+/// Return the PID currently recorded in the sentinel, when one exists
+/// and the recorded process is still alive.
+///
+/// Stale sentinels (recorded process exited) and corrupt sentinels
+/// (non-numeric contents) resolve to `Ok(None)`. The stale case also
+/// removes the file as a courtesy, so the next caller sees a clean
+/// state. The cleanup is best-effort: a remove failure is logged and
+/// otherwise ignored.
+pub fn read_live_pid(run_dir: &Path) -> Result<Option<u32>, HarnessError> {
+    let path = sentinel_path(run_dir);
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(HarnessError::io(&path, e)),
+    };
+    let trimmed = content.trim();
+    let Ok(pid) = trimmed.parse::<u32>() else {
+        tracing::warn!(
+            path = %path.display(),
+            content = %trimmed,
+            "TUI sentinel has non-numeric contents; treating as stale",
+        );
+        let _ = fs::remove_file(&path);
+        return Ok(None);
+    };
+    if process_is_alive(pid) {
+        Ok(Some(pid))
+    } else {
+        tracing::debug!(pid, "removing stale TUI sentinel for non-running process");
+        let _ = fs::remove_file(&path);
+        Ok(None)
+    }
+}
+
+/// Cross-platform "is this PID currently alive?" probe.
+///
+/// On Unix, `kill(pid, 0)` returns 0 when the process exists (and the
+/// caller has permission to signal it) and `-1` with `ESRCH` when the
+/// PID is not in use. We treat any other errno (including `EPERM`,
+/// which means "the process exists but you can't signal it") as
+/// "alive" — being conservative is safer than silently overwriting a
+/// live runner's `run.toml`.
+///
+/// On non-Unix platforms we currently assume the sentinel is live
+/// when present; the TUI rotation flow has not been validated on
+/// Windows. Refining this is tracked as a follow-up.
+#[cfg(unix)]
+#[expect(
+    unsafe_code,
+    reason = "FFI call to libc::kill(pid, 0) for a permission-only liveness check"
+)]
+fn process_is_alive(pid: u32) -> bool {
+    // Negative or zero PIDs are not valid signal targets; treat as
+    // "not alive" so the sentinel cleanup path runs.
+    if pid == 0 {
+        return false;
+    }
+    // `pid_t` is a signed integer; PIDs above `i32::MAX` are
+    // impossible on every Unix in practice, but guard against
+    // wrap-around on the cast just in case.
+    let Ok(raw_pid) = libc::pid_t::try_from(pid) else {
+        return false;
+    };
+    // SAFETY: `kill` is async-signal-safe and the only precondition
+    // is a valid signal number; signal `0` means "permission check
+    // only" per POSIX, so we never deliver a signal to the target
+    // process. `kill` does not access any memory through pointers we
+    // supply.
+    let rc = unsafe { libc::kill(raw_pid, 0) };
+    if rc == 0 {
+        return true;
+    }
+    // `last_os_error` reads thread-local errno; it is the canonical
+    // way to inspect errno after a failing libc call from Rust.
+    let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+    errno != libc::ESRCH
+}
+
+#[cfg(not(unix))]
+fn process_is_alive(_pid: u32) -> bool {
+    // Conservative fallback: assume alive when present so we never
+    // clobber a live TUI's run.toml on platforms we have not yet
+    // validated.
+    true
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_then_read_live_pid_returns_self_pid() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        write(tmp.path()).unwrap_or_else(|e| panic!("{e}"));
+        let read = read_live_pid(tmp.path()).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(read, Some(std::process::id()));
+    }
+
+    #[test]
+    fn missing_sentinel_resolves_to_none() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let read = read_live_pid(tmp.path()).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(read, None);
+    }
+
+    #[test]
+    fn clear_removes_sentinel_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        write(tmp.path()).unwrap_or_else(|e| panic!("{e}"));
+        clear(tmp.path()).unwrap_or_else(|e| panic!("{e}"));
+        assert!(!sentinel_path(tmp.path()).exists());
+        // Second call is a no-op.
+        clear(tmp.path()).unwrap_or_else(|e| panic!("{e}"));
+    }
+
+    #[test]
+    fn corrupt_sentinel_is_treated_as_stale() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(sentinel_path(tmp.path()), "not a pid\n").unwrap_or_else(|e| panic!("{e}"));
+        let read = read_live_pid(tmp.path()).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(read, None);
+        // Corrupt sentinel was cleaned up.
+        assert!(!sentinel_path(tmp.path()).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stale_sentinel_for_dead_pid_resolves_to_none() {
+        // PID 1 is init / launchd and is always alive on a running
+        // system, so it is not safe for a "definitely dead" check.
+        // Spawn a short-lived child and capture its PID; once
+        // `wait()` returns we know that PID is no longer in use.
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .unwrap_or_else(|e| panic!("{e}"));
+        let pid = child.id();
+        let _ = child.wait();
+        // Give the OS a moment to clean up the zombie; on most
+        // systems `wait` is enough.
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(sentinel_path(tmp.path()), format!("{pid}\n"))
+            .unwrap_or_else(|e| panic!("{e}"));
+        let read = read_live_pid(tmp.path()).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            read, None,
+            "expected stale PID {pid} to be reported as not alive"
+        );
+        assert!(
+            !sentinel_path(tmp.path()).exists(),
+            "stale sentinel should have been cleaned up",
+        );
+    }
+}

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 dirs = { workspace = true }
 humantime = { workspace = true }

--- a/tmg-cli/src/harness_init.rs
+++ b/tmg-cli/src/harness_init.rs
@@ -35,6 +35,10 @@ use crate::config::{HarnessConfig, SandboxConfigSection};
 /// In both cases the run's `last_session_at` and `session_count` are
 /// updated and persisted via the [`RunRunner`](tmg_harness::RunRunner)
 /// elsewhere; this function only handles the load-vs-create choice.
+///
+/// **Note**: this function ignores `tmg run resume <id>`'s explicit
+/// run id. Callers that want to honour an explicit id must short-
+/// circuit the call themselves (see [`select_startup_run`]).
 pub fn resolve_startup_run(
     harness: &HarnessConfig,
     store: &Arc<RunStore>,
@@ -46,6 +50,42 @@ pub fn resolve_startup_run(
         return store.load(&summary.id);
     }
     store.create_ad_hoc(workspace_path, None)
+}
+
+/// Select the run for a startup, honouring an explicit id when one
+/// was supplied via `tmg run resume <id>`.
+///
+/// When `explicit_id` is `Some`, the run is loaded directly; the
+/// load fails if the id has no on-disk record, and a workspace
+/// mismatch surfaces as [`HarnessError::Precondition`] so the caller
+/// can route the message through `anyhow::Error::context`. When
+/// `explicit_id` is `None`, falls through to [`resolve_startup_run`]
+/// (i.e. the legacy auto-resume / create-fresh policy).
+///
+/// Factoring this out of `run_tui` keeps the explicit-id branch
+/// unit-testable without spinning up an `AgentLoop` or a TUI.
+pub fn select_startup_run(
+    harness: &HarnessConfig,
+    store: &Arc<RunStore>,
+    workspace_path: std::path::PathBuf,
+    explicit_id: Option<&tmg_harness::RunId>,
+) -> Result<Run, HarnessError> {
+    if let Some(id) = explicit_id {
+        let loaded = store.load(id)?;
+        if loaded.workspace_path != workspace_path {
+            return Err(HarnessError::Precondition {
+                message: format!(
+                    "run {} belongs to workspace {} but startup cwd is {}; \
+                     change directory or pick a workspace-matching run id",
+                    id.as_str(),
+                    loaded.workspace_path.display(),
+                    workspace_path.display(),
+                ),
+            });
+        }
+        return Ok(loaded);
+    }
+    resolve_startup_run(harness, store, workspace_path)
 }
 
 /// Emit a one-time warning when the user has configured a stricter
@@ -219,6 +259,87 @@ mod tests {
         // Both runs should exist now.
         let listed = store.list().unwrap_or_else(|e| panic!("{e}"));
         assert_eq!(listed.len(), 2);
+    }
+
+    /// `select_startup_run` with an explicit id must load *that*
+    /// run, even when a newer resumable run exists in the same
+    /// workspace. This is the regression test for `tmg run resume
+    /// <older-id>` previously falling back to `latest_resumable`.
+    #[test]
+    fn select_startup_run_honours_explicit_older_id() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+
+        // Create the older run first.
+        let older = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        // Force a later created_at on the second run so
+        // `latest_resumable` would prefer it.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let newer = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let cfg = HarnessConfig {
+            runs_dir: store.runs_dir().to_path_buf(),
+            auto_resume_on_start: true,
+            bootstrap_max_tokens: tmg_harness::DEFAULT_BOOTSTRAP_MAX_TOKENS,
+            ..HarnessConfig::default()
+        };
+
+        // Sanity: with no explicit id, the resolver picks the newer
+        // run.
+        let resolved_default = select_startup_run(&cfg, &store, workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(resolved_default.id, newer.id);
+
+        // With the older id passed explicitly, we must get the
+        // older run back.
+        let resolved_explicit =
+            select_startup_run(&cfg, &store, workspace.clone(), Some(&older.id))
+                .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            resolved_explicit.id, older.id,
+            "explicit id must override latest_resumable",
+        );
+    }
+
+    /// `select_startup_run` rejects an explicit id whose stored
+    /// workspace disagrees with the current cwd.
+    #[test]
+    fn select_startup_run_rejects_workspace_mismatch() {
+        let (tmp, store) = make_store();
+        let workspace_a = tmp.path().join("workspace-a");
+        let workspace_b = tmp.path().join("workspace-b");
+        std::fs::create_dir_all(&workspace_a).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::create_dir_all(&workspace_b).unwrap_or_else(|e| panic!("{e}"));
+
+        let run_a = store
+            .create_ad_hoc(workspace_a.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let cfg = HarnessConfig {
+            runs_dir: store.runs_dir().to_path_buf(),
+            auto_resume_on_start: true,
+            bootstrap_max_tokens: tmg_harness::DEFAULT_BOOTSTRAP_MAX_TOKENS,
+            ..HarnessConfig::default()
+        };
+
+        match select_startup_run(&cfg, &store, workspace_b, Some(&run_a.id)) {
+            Err(HarnessError::Precondition { message }) => {
+                assert!(
+                    message.contains("belongs to workspace"),
+                    "expected workspace-mismatch message, got {message:?}",
+                );
+            }
+            Ok(run) => panic!(
+                "expected Precondition error, got Ok with id {}",
+                run.id.as_str(),
+            ),
+            Err(other) => panic!("expected Precondition, got {other:?}"),
+        }
     }
 
     /// Integration-style test exercising the resume flow end-to-end:

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -120,11 +120,19 @@ enum RunCommand {
         run_id: Option<String>,
     },
     /// Mark a run as paused without launching the TUI.
+    ///
+    /// Best-effort outside an active TUI: when a tmg TUI is currently
+    /// attached to the run (`.tsumugi/runs/<id>/.tui-pid` sentinel),
+    /// the command refuses with an error. Use the in-TUI `/run pause`
+    /// slash command (issue #46) to pause an attached run.
     Pause {
         /// Optional run id; defaults to current.
         run_id: Option<String>,
     },
     /// Mark a run as failed (`reason = "user aborted"`).
+    ///
+    /// Best-effort outside an active TUI: refuses while a tmg TUI is
+    /// attached to the run, for the same reason as `pause`.
     Abort {
         /// Optional run id; defaults to current.
         run_id: Option<String>,
@@ -200,6 +208,7 @@ fn main() -> anyhow::Result<()> {
                     &config.harness,
                     &config.sandbox,
                     &config.workflow,
+                    None,
                 )
             }
         }
@@ -223,10 +232,6 @@ fn resolve_runs_dir(harness_config: &HarnessConfig) -> anyhow::Result<(PathBuf, 
 /// Dispatch one `tmg run <op>` invocation. The TUI-bound operations
 /// (`Resume`, `NewSession`) delegate back into [`run_tui`] (or print
 /// an explanatory error). The rest mutate `run.toml` directly.
-#[expect(
-    clippy::print_stderr,
-    reason = "tmg run new-session must explain itself when invoked outside a TUI session"
-)]
 fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Result<()> {
     let (runs_dir, canonical_cwd) = resolve_runs_dir(&config.harness)?;
     let store = Arc::new(RunStore::new(runs_dir));
@@ -238,15 +243,25 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
                 compression_threshold: config.llm.compression_threshold,
                 max_tool_result_tokens: config.llm.max_tool_result_tokens,
             };
+            // When the user supplied an explicit id, validate its
+            // shape at the boundary. We thread the validated id
+            // through to `run_tui` so the TUI loads exactly that run
+            // (bypassing `harness_init::resolve_startup_run`'s
+            // latest-resumable fallback). If no id was supplied, we
+            // try `current` as a hint and fall back to the resolver.
             let resolved = if let Some(id) = run_id {
-                Some(tmg_harness::RunId::from_string(id))
+                Some(
+                    tmg_harness::RunId::parse(id)
+                        .context("parsing explicit run id for `tmg run resume`")?,
+                )
             } else {
-                // Fall back through `current` → `latest_resumable`.
+                // Best-effort: prefer `current` so subsequent
+                // argument-less commands inherit the same target.
                 store.current().context("reading current run pointer")?
             };
-            // If we resolved an explicit id, point `current` at it
-            // before launching so subsequent argument-less commands
-            // inherit the same target.
+            // If we resolved a run, point `current` at it before
+            // launching so the TUI shutdown / re-open paths agree on
+            // the active id.
             if let Some(ref id) = resolved
                 && let Err(e) = store.set_current(id)
             {
@@ -261,6 +276,7 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
                 &config.harness,
                 &config.sandbox,
                 &config.workflow,
+                resolved.as_ref(),
             )
         }
         RunCommand::List => run_commands::cmd_list(&store),
@@ -290,15 +306,16 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
         }
         RunCommand::NewSession => {
             // `new-session` rotates the *active* TUI session. Outside
-            // a TUI we have no live runner, so we surface an explanatory
-            // error rather than silently writing the on-disk session.
-            // The TUI slash-command equivalent (`/run new-session`) is
-            // tracked in #46.
-            eprintln!(
-                "tmg run new-session must be invoked from inside an active TUI session.\n\
+            // a TUI we have no live runner, so we surface an
+            // explanatory error rather than silently writing the
+            // on-disk session. The TUI slash-command equivalent
+            // (`/run new-session`) is tracked in #46. The single
+            // `bail!` carries the entire message so anyhow's error
+            // chain is the sole source of truth.
+            anyhow::bail!(
+                "tmg run new-session must be invoked from inside an active TUI session. \
                  Use the `/run new-session` slash command from within `tmg` (see #46).",
             );
-            anyhow::bail!("new-session requires an active TUI session");
         }
     }
 }
@@ -413,6 +430,7 @@ fn run_tui(
     harness_config: &HarnessConfig,
     sandbox_config: &SandboxConfigSection,
     workflow_config: &tmg_workflow::WorkflowConfig,
+    explicit_run_id: Option<&tmg_harness::RunId>,
 ) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
@@ -448,8 +466,35 @@ fn run_tui(
             canonical_cwd.join(&harness_config.runs_dir)
         };
         let store = Arc::new(RunStore::new(runs_dir));
-        let run = harness_init::resolve_startup_run(harness_config, &store, canonical_cwd.clone())
-            .context("resolving startup run")?;
+        // `select_startup_run` honours an explicit id from
+        // `tmg run resume <id>` before falling back to the
+        // auto-resume / create-fresh policy. The explicit-id path
+        // bypasses `latest_resumable` so the user genuinely resumes
+        // the run they typed, not "whatever was newest".
+        let run = harness_init::select_startup_run(
+            harness_config,
+            &store,
+            canonical_cwd.clone(),
+            explicit_run_id,
+        )
+        .context("resolving startup run")?;
+        // Whichever path we took, lock the resolved id into `current`
+        // so out-of-TUI CLI mutators agree with the live runner.
+        if let Err(e) = store.set_current(&run.id) {
+            tracing::warn!(error = %e, "failed to update current run pointer at startup");
+        }
+        // Stamp the TUI sentinel so `tmg run pause` / `tmg run abort`
+        // refuse to mutate `run.toml` while we hold the live runner.
+        // Failures here are best-effort (a permission glitch on the
+        // run dir should not abort startup); the worst case is the
+        // CLI mutators not refusing.
+        let sentinel_dir = store.run_dir(&run.id);
+        if let Err(e) = tmg_harness::tui_sentinel::write(&sentinel_dir) {
+            tracing::warn!(error = %e, "failed to write TUI sentinel; CLI mutators may race the live runner");
+        }
+        // Guard ensures the sentinel is removed on every exit path
+        // (including panic propagation through tokio::block_on).
+        let _sentinel_guard = TuiSentinelGuard::new(sentinel_dir);
         let mut runner = RunRunner::new(run, Arc::clone(&store));
         runner.set_bootstrap_max_tokens(harness_config.bootstrap_max_tokens);
         runner.set_default_session_timeout(harness_config.default_session_timeout);
@@ -724,6 +769,32 @@ fn run_tui(
         tui_result?;
         Ok::<(), anyhow::Error>(())
     })
+}
+
+/// RAII guard that clears the TUI-attached sentinel for a run on
+/// `Drop`.
+///
+/// Created right after the sentinel is written so every exit path
+/// from `run_tui` (clean return, error propagation, panic) removes
+/// the file. Without the guard, a panic during agent setup would
+/// leave a stale `.tui-pid` behind that would block CLI mutators
+/// until the recorded PID is reused or the file is manually removed.
+struct TuiSentinelGuard {
+    run_dir: PathBuf,
+}
+
+impl TuiSentinelGuard {
+    fn new(run_dir: PathBuf) -> Self {
+        Self { run_dir }
+    }
+}
+
+impl Drop for TuiSentinelGuard {
+    fn drop(&mut self) {
+        if let Err(e) = tmg_harness::tui_sentinel::clear(&self.run_dir) {
+            tracing::warn!(error = %e, "failed to clear TUI sentinel on shutdown");
+        }
+    }
 }
 
 /// Surface a non-fatal error from `RunRunner::end_session` to the

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use tmg_harness::{
     RunRunner, RunRunnerToolProvider, RunStore, RunSummary, SessionBootstrapTool,
     SessionEndTrigger, register_run_tools,
@@ -13,6 +13,7 @@ use tokio::sync::Mutex;
 mod config;
 mod error;
 mod harness_init;
+mod run_commands;
 
 use config::{HarnessConfig, SandboxConfigSection, TsumugiConfig};
 
@@ -22,34 +23,34 @@ use config::{HarnessConfig, SandboxConfigSection, TsumugiConfig};
 struct Cli {
     /// Send a one-shot prompt to the LLM server and stream the response
     /// to stdout.
-    #[arg(long)]
+    #[arg(long, global = true)]
     prompt: Option<String>,
 
     /// LLM server endpoint URL. Overrides config file and environment.
-    #[arg(long)]
+    #[arg(long, global = true)]
     endpoint: Option<String>,
 
     /// Model name to use. Overrides config file and environment.
-    #[arg(long)]
+    #[arg(long, global = true)]
     model: Option<String>,
 
     /// Path to a `tsumugi.toml` configuration file.
     /// When specified, only this file is loaded (no global/project-local
     /// discovery).
-    #[arg(long)]
+    #[arg(long, global = true)]
     config: Option<PathBuf>,
 
     /// Maximum context window tokens.
-    #[arg(long)]
+    #[arg(long, global = true)]
     max_context_tokens: Option<usize>,
 
     /// Context compression threshold (0.0-1.0). Compression auto-triggers
     /// when context usage exceeds this fraction of `max_context_tokens`.
-    #[arg(long)]
+    #[arg(long, global = true)]
     context_compression_threshold: Option<f64>,
 
     /// Maximum tokens for a single tool result before truncation.
-    #[arg(long)]
+    #[arg(long, global = true)]
     max_tool_result_tokens: Option<usize>,
 
     /// Tool calling mode: "native", "prompt_based", or "auto".
@@ -61,14 +62,81 @@ struct Cli {
         clippy::doc_markdown,
         reason = "clap renders doc comments as --help text; backticks would show literally"
     )]
-    #[arg(long)]
+    #[arg(long, global = true)]
     tool_calling: Option<ToolCallingMode>,
 
     /// Path to write structured event log (JSON Lines format).
     /// Enables diagnostics by recording every agent event (tokens,
     /// tool calls, results) to the specified file.
-    #[arg(long)]
+    #[arg(long, global = true)]
     event_log: Option<PathBuf>,
+
+    /// Top-level subcommand. When omitted, `tmg` launches the
+    /// interactive TUI (or runs one-shot mode if `--prompt` was
+    /// supplied).
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+/// Top-level subcommand surface. Workflow / Init are scoped to #44 /
+/// #46 and intentionally omitted here.
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Run management (`tmg run <op>`). See SPEC §9.8.
+    Run {
+        /// Sub-operation on the active or specified run.
+        #[command(subcommand)]
+        op: RunCommand,
+    },
+}
+
+/// Operations under `tmg run`. SPEC §9.8.
+#[derive(Subcommand, Debug)]
+enum RunCommand {
+    /// Resume a run in the interactive TUI.
+    ///
+    /// With no argument, resumes the run pointed at by
+    /// `.tsumugi/runs/current` (or the most recent resumable run as a
+    /// backwards-compat fallback).
+    Resume {
+        /// Optional explicit run id.
+        run_id: Option<String>,
+    },
+    /// List all runs as a fixed-width table on stdout.
+    List,
+    /// Pretty-print detailed status for one run.
+    Status {
+        /// Optional run id; defaults to current.
+        run_id: Option<String>,
+    },
+    /// Force-promote a run to harnessed scope.
+    Upgrade {
+        /// Optional run id; defaults to current.
+        run_id: Option<String>,
+    },
+    /// Demote a run back to ad-hoc scope (preserves features.json).
+    Downgrade {
+        /// Optional run id; defaults to current.
+        run_id: Option<String>,
+    },
+    /// Mark a run as paused without launching the TUI.
+    Pause {
+        /// Optional run id; defaults to current.
+        run_id: Option<String>,
+    },
+    /// Mark a run as failed (`reason = "user aborted"`).
+    Abort {
+        /// Optional run id; defaults to current.
+        run_id: Option<String>,
+    },
+    /// Open an interactive shell rooted at the run's workspace path.
+    Shell {
+        /// Optional run id; defaults to current.
+        run_id: Option<String>,
+    },
+    /// Force-rotate to a new session. Must be issued from inside an
+    /// active TUI session; outside, prints an explanatory error.
+    NewSession,
 }
 
 impl Cli {
@@ -112,27 +180,127 @@ fn main() -> anyhow::Result<()> {
         max_tool_result_tokens: config.llm.max_tool_result_tokens,
     };
 
-    if let Some(prompt) = cli.prompt {
-        run_prompt(
-            &config.llm.endpoint,
-            &config.llm.model,
-            &prompt,
-            cli.event_log.as_deref(),
-        )?;
-    } else {
-        run_tui(
-            &config.llm.endpoint,
-            &config.llm.model,
-            context_config,
-            config.llm.tool_calling,
-            cli.event_log,
-            &config.harness,
-            &config.sandbox,
-            &config.workflow,
-        )?;
+    match cli.command {
+        Some(Command::Run { op }) => dispatch_run_command(op, &config),
+        None => {
+            if let Some(prompt) = cli.prompt {
+                run_prompt(
+                    &config.llm.endpoint,
+                    &config.llm.model,
+                    &prompt,
+                    cli.event_log.as_deref(),
+                )
+            } else {
+                run_tui(
+                    &config.llm.endpoint,
+                    &config.llm.model,
+                    context_config,
+                    config.llm.tool_calling,
+                    cli.event_log,
+                    &config.harness,
+                    &config.sandbox,
+                    &config.workflow,
+                )
+            }
+        }
     }
+}
 
-    Ok(())
+/// Resolve the runs-dir against the canonical cwd, mirroring the
+/// logic used by [`run_tui`] so the CLI surfaces and the live TUI
+/// agree on which `.tsumugi/runs/` they target.
+fn resolve_runs_dir(harness_config: &HarnessConfig) -> anyhow::Result<(PathBuf, PathBuf)> {
+    let cwd = std::env::current_dir().context("reading current working directory")?;
+    let canonical_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+    let runs_dir = if harness_config.runs_dir.is_absolute() {
+        harness_config.runs_dir.clone()
+    } else {
+        canonical_cwd.join(&harness_config.runs_dir)
+    };
+    Ok((runs_dir, canonical_cwd))
+}
+
+/// Dispatch one `tmg run <op>` invocation. The TUI-bound operations
+/// (`Resume`, `NewSession`) delegate back into [`run_tui`] (or print
+/// an explanatory error). The rest mutate `run.toml` directly.
+#[expect(
+    clippy::print_stderr,
+    reason = "tmg run new-session must explain itself when invoked outside a TUI session"
+)]
+fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Result<()> {
+    let (runs_dir, canonical_cwd) = resolve_runs_dir(&config.harness)?;
+    let store = Arc::new(RunStore::new(runs_dir));
+
+    match op {
+        RunCommand::Resume { run_id } => {
+            let context_config = tmg_core::ContextConfig {
+                max_context_tokens: config.llm.max_context_tokens,
+                compression_threshold: config.llm.compression_threshold,
+                max_tool_result_tokens: config.llm.max_tool_result_tokens,
+            };
+            let resolved = if let Some(id) = run_id {
+                Some(tmg_harness::RunId::from_string(id))
+            } else {
+                // Fall back through `current` → `latest_resumable`.
+                store.current().context("reading current run pointer")?
+            };
+            // If we resolved an explicit id, point `current` at it
+            // before launching so subsequent argument-less commands
+            // inherit the same target.
+            if let Some(ref id) = resolved
+                && let Err(e) = store.set_current(id)
+            {
+                tracing::warn!(error = %e, "failed to update current run pointer");
+            }
+            run_tui(
+                &config.llm.endpoint,
+                &config.llm.model,
+                context_config,
+                config.llm.tool_calling,
+                None,
+                &config.harness,
+                &config.sandbox,
+                &config.workflow,
+            )
+        }
+        RunCommand::List => run_commands::cmd_list(&store),
+        RunCommand::Status { run_id } => {
+            let id = run_commands::resolve_run_id(&store, run_id.as_deref(), Some(&canonical_cwd))?;
+            run_commands::cmd_status(&store, &id)
+        }
+        RunCommand::Upgrade { run_id } => {
+            let id = run_commands::resolve_run_id(&store, run_id.as_deref(), Some(&canonical_cwd))?;
+            run_commands::cmd_upgrade(&store, &id)
+        }
+        RunCommand::Downgrade { run_id } => {
+            let id = run_commands::resolve_run_id(&store, run_id.as_deref(), Some(&canonical_cwd))?;
+            run_commands::cmd_downgrade(&store, &id)
+        }
+        RunCommand::Pause { run_id } => {
+            let id = run_commands::resolve_run_id(&store, run_id.as_deref(), Some(&canonical_cwd))?;
+            run_commands::cmd_pause(&store, &id)
+        }
+        RunCommand::Abort { run_id } => {
+            let id = run_commands::resolve_run_id(&store, run_id.as_deref(), Some(&canonical_cwd))?;
+            run_commands::cmd_abort(&store, &id)
+        }
+        RunCommand::Shell { run_id } => {
+            let id = run_commands::resolve_run_id(&store, run_id.as_deref(), Some(&canonical_cwd))?;
+            run_commands::cmd_shell(&store, &id)
+        }
+        RunCommand::NewSession => {
+            // `new-session` rotates the *active* TUI session. Outside
+            // a TUI we have no live runner, so we surface an explanatory
+            // error rather than silently writing the on-disk session.
+            // The TUI slash-command equivalent (`/run new-session`) is
+            // tracked in #46.
+            eprintln!(
+                "tmg run new-session must be invoked from inside an active TUI session.\n\
+                 Use the `/run new-session` slash command from within `tmg` (see #46).",
+            );
+            anyhow::bail!("new-session requires an active TUI session");
+        }
+    }
 }
 
 /// Run a one-shot streaming prompt against the LLM server.
@@ -871,6 +1039,125 @@ async fn inject_bootstrap(agent: &mut tmg_core::AgentLoop, runner: Arc<Mutex<Run
 #[expect(clippy::panic, reason = "test assertions use panic-based macros")]
 mod tests {
     use super::*;
+    use clap::CommandFactory as _;
+
+    // ---------------------------------------------------------------
+    // CLI subcommand parsing (issue #43)
+    // ---------------------------------------------------------------
+
+    /// `clap` macro hygiene: the derive output should compile and
+    /// validate without `debug_assert` failing.
+    #[test]
+    fn cli_definition_validates() {
+        Cli::command().debug_assert();
+    }
+
+    /// `tmg` with no arguments parses to no subcommand and no prompt;
+    /// this is the legacy "launch the TUI" code path.
+    #[test]
+    fn cli_no_args_launches_tui() {
+        let cli = Cli::try_parse_from(["tmg"]).unwrap_or_else(|e| panic!("{e}"));
+        assert!(cli.command.is_none());
+        assert!(cli.prompt.is_none());
+    }
+
+    /// `tmg --prompt "hello"` parses with `prompt` set and no
+    /// subcommand — the legacy one-shot mode.
+    #[test]
+    fn cli_prompt_only_runs_one_shot() {
+        let cli =
+            Cli::try_parse_from(["tmg", "--prompt", "hello"]).unwrap_or_else(|e| panic!("{e}"));
+        assert!(cli.command.is_none());
+        assert_eq!(cli.prompt.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn cli_run_list_parses() {
+        let cli = Cli::try_parse_from(["tmg", "run", "list"]).unwrap_or_else(|e| panic!("{e}"));
+        match cli.command {
+            Some(Command::Run {
+                op: RunCommand::List,
+            }) => {}
+            other => panic!("expected Run(List), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_run_status_with_id_parses() {
+        let cli = Cli::try_parse_from(["tmg", "run", "status", "abc12345"])
+            .unwrap_or_else(|e| panic!("{e}"));
+        match cli.command {
+            Some(Command::Run {
+                op: RunCommand::Status { run_id },
+            }) => {
+                assert_eq!(run_id.as_deref(), Some("abc12345"));
+            }
+            other => panic!("expected Run(Status), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_run_resume_without_id_parses() {
+        let cli = Cli::try_parse_from(["tmg", "run", "resume"]).unwrap_or_else(|e| panic!("{e}"));
+        match cli.command {
+            Some(Command::Run {
+                op: RunCommand::Resume { run_id },
+            }) => {
+                assert!(run_id.is_none());
+            }
+            other => panic!("expected Run(Resume), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_run_upgrade_parses() {
+        let cli = Cli::try_parse_from(["tmg", "run", "upgrade"]).unwrap_or_else(|e| panic!("{e}"));
+        match cli.command {
+            Some(Command::Run {
+                op: RunCommand::Upgrade { run_id },
+            }) => {
+                assert!(run_id.is_none());
+            }
+            other => panic!("expected Run(Upgrade), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_run_pause_abort_downgrade_parse() {
+        for sub in ["pause", "abort", "downgrade", "shell"] {
+            let cli = Cli::try_parse_from(["tmg", "run", sub]).unwrap_or_else(|e| panic!("{e}"));
+            assert!(matches!(cli.command, Some(Command::Run { .. })));
+        }
+    }
+
+    #[test]
+    fn cli_run_new_session_parses() {
+        let cli =
+            Cli::try_parse_from(["tmg", "run", "new-session"]).unwrap_or_else(|e| panic!("{e}"));
+        match cli.command {
+            Some(Command::Run {
+                op: RunCommand::NewSession,
+            }) => {}
+            other => panic!("expected Run(NewSession), got {other:?}"),
+        }
+    }
+
+    /// `--prompt` is `global = true` so it can be provided either
+    /// before or after the subcommand. We only need the legacy
+    /// "before any subcommand" form to keep working; this asserts
+    /// global-flag plumbing didn't accidentally break it.
+    #[test]
+    fn cli_global_prompt_with_subcommand_parses() {
+        let cli = Cli::try_parse_from(["tmg", "--prompt", "hi", "run", "list"])
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(cli.prompt.as_deref(), Some("hi"));
+        assert!(matches!(
+            cli.command,
+            Some(Command::Run {
+                op: RunCommand::List
+            })
+        ));
+    }
 
     /// Parse the standard `git diff --shortstat` line shape.
     #[test]

--- a/tmg-cli/src/run_commands.rs
+++ b/tmg-cli/src/run_commands.rs
@@ -1,0 +1,518 @@
+//! Implementation of the `tmg run` subcommand family (issue #43).
+//!
+//! Each command resolves the target [`tmg_harness::Run`] (defaulting to
+//! [`tmg_harness::RunStore::current`] when no `run_id` is supplied)
+//! and either prints structured output to stdout (`list`, `status`)
+//! or mutates `run.toml` via [`tmg_harness::commands`]. The TUI-bound
+//! commands (`resume`, `new-session`) delegate back to the regular
+//! TUI startup path; the rest can be invoked outside an active TUI
+//! session because they only need read/write access to the run store.
+//!
+//! The list of commands surfaced here is the SPEC §9.8 minimum:
+//! Resume / List / Status / Upgrade / Downgrade / Pause / Abort /
+//! Shell / `NewSession`. The TUI slash-command equivalents are tracked
+//! in #46.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use chrono::{DateTime, Utc};
+use tmg_harness::{
+    RunId, RunRunner, RunScope, RunStatus, RunStore, RunSummary, StatusReport,
+    commands as harness_commands,
+};
+
+/// Resolve the run id for a CLI command that takes an optional
+/// `run_id` argument.
+///
+/// Resolution order:
+/// 1. CLI-supplied id (verbatim).
+/// 2. The `current` pointer in the runs-dir, when present.
+/// 3. [`RunStore::latest_resumable`] for the supplied workspace, when
+///    present.
+///
+/// Returns an error when no run can be resolved.
+pub(crate) fn resolve_run_id(
+    store: &RunStore,
+    explicit: Option<&str>,
+    workspace_path: Option<&Path>,
+) -> anyhow::Result<RunId> {
+    if let Some(id) = explicit {
+        return Ok(RunId::from_string(id.to_owned()));
+    }
+    if let Some(current) = store.current().context("reading current run pointer")? {
+        return Ok(current);
+    }
+    if let Some(summary) = store
+        .latest_resumable(workspace_path)
+        .context("finding the most recent resumable run")?
+    {
+        return Ok(summary.id);
+    }
+    anyhow::bail!(
+        "no run id supplied and no current/recent run could be resolved; \
+         try `tmg run list` to inspect available runs"
+    );
+}
+
+/// Print a fixed-width table of all runs to stdout.
+///
+/// Columns: `ID  SCOPE  STATUS  SESSIONS  PROGRESS  STARTED`. The
+/// `PROGRESS` column shows `passing/total` for harnessed runs and
+/// `-` for ad-hoc runs.
+#[expect(
+    clippy::print_stdout,
+    reason = "tmg run list prints to stdout by design"
+)]
+pub fn cmd_list(store: &RunStore) -> anyhow::Result<()> {
+    let summaries = harness_commands::list(store).context("listing runs")?;
+    let now = Utc::now();
+
+    if summaries.is_empty() {
+        println!("(no runs found)");
+        return Ok(());
+    }
+
+    let rows: Vec<TableRow> = summaries
+        .iter()
+        .map(|s| TableRow::from_summary(store, s, now))
+        .collect();
+
+    let header = ["ID", "SCOPE", "STATUS", "SESSIONS", "PROGRESS", "STARTED"];
+    let mut widths = header.map(str::len);
+    for row in &rows {
+        let cells = row.cells();
+        for (i, cell) in cells.iter().enumerate() {
+            widths[i] = widths[i].max(cell.len());
+        }
+    }
+
+    let mut out = std::io::stdout().lock();
+    print_row(&mut out, &header, &widths)?;
+    for row in &rows {
+        print_row(&mut out, &row.cells(), &widths)?;
+    }
+    Ok(())
+}
+
+/// Pretty-print a [`StatusReport`] for the given run.
+#[expect(
+    clippy::print_stdout,
+    reason = "tmg run status prints to stdout by design"
+)]
+pub fn cmd_status(store: &RunStore, run_id: &RunId) -> anyhow::Result<()> {
+    let report: StatusReport =
+        harness_commands::status(store, run_id, 20).context("building status report")?;
+
+    let run = &report.run;
+    let scope_label = run.scope.label();
+    let workflow_id = match &run.scope {
+        RunScope::Harnessed { workflow_id, .. } => workflow_id.as_str(),
+        RunScope::AdHoc => "-",
+    };
+    let started = humantime_relative(run.created_at, Utc::now());
+    let status_label = format_status(&run.status);
+    let sessions_cell = format_sessions(run.session_count, run.max_sessions);
+
+    println!("Run: {} ({})", run.id, scope_label);
+    println!("  Status:    {status_label}");
+    println!("  Workflow:  {workflow_id}");
+    println!("  Sessions:  {sessions_cell}");
+    println!("  Started:   {started}");
+    println!("  Workspace: {}", run.workspace_path.display());
+
+    if let Some(hist) = report.feature_histogram {
+        println!(
+            "  Features:  {passing}/{total} passing ({failing} remaining)",
+            passing = hist.passing,
+            total = hist.total,
+            failing = hist.failing(),
+        );
+    }
+
+    if let Some(session) = &report.last_session {
+        let ended = session.ended_at.map_or_else(
+            || "(active)".to_owned(),
+            |t| humantime_relative(t, Utc::now()),
+        );
+        println!(
+            "  Last session #{idx}: {tools} tool calls, {files} files modified, ended {ended}",
+            idx = session.index,
+            tools = session.tool_calls_count,
+            files = session.files_modified.len(),
+        );
+    }
+
+    if report.progress_tail.is_empty() {
+        println!("\nprogress.md: (empty)");
+    } else {
+        println!("\nprogress.md (last {} lines):", report.progress_tail_lines);
+        println!("{}", report.progress_tail);
+    }
+    Ok(())
+}
+
+/// Mutate `run.toml` so the target run is harnessed.
+#[expect(
+    clippy::print_stdout,
+    reason = "tmg run upgrade prints a one-line confirmation"
+)]
+pub fn cmd_upgrade(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
+    let run = store.load(run_id).context("loading run")?;
+    if matches!(run.scope, RunScope::Harnessed { .. }) {
+        println!(
+            "Run {} is already harnessed; no action taken.",
+            run.id.short()
+        );
+        return Ok(());
+    }
+    let mut runner = RunRunner::new(run, Arc::clone(store));
+    harness_commands::upgrade(&mut runner).context("upgrading run to harnessed")?;
+    println!("Upgraded run {} -> harnessed", runner.run_id().short());
+    Ok(())
+}
+
+/// Mutate `run.toml` so the target run is back to ad-hoc.
+#[expect(
+    clippy::print_stdout,
+    reason = "tmg run downgrade prints a one-line confirmation"
+)]
+pub fn cmd_downgrade(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
+    let run = store.load(run_id).context("loading run")?;
+    if matches!(run.scope, RunScope::AdHoc) {
+        println!("Run {} is already ad-hoc; no action taken.", run.id.short());
+        return Ok(());
+    }
+    let mut runner = RunRunner::new(run, Arc::clone(store));
+    harness_commands::downgrade(&mut runner).context("downgrading run to ad-hoc")?;
+    println!("Downgraded run {} -> ad_hoc", runner.run_id().short());
+    Ok(())
+}
+
+/// Flip the run status to `Paused`.
+#[expect(
+    clippy::print_stdout,
+    reason = "tmg run pause prints a one-line confirmation"
+)]
+pub fn cmd_pause(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
+    let run = store.load(run_id).context("loading run")?;
+    let mut runner = RunRunner::new(run, Arc::clone(store));
+    harness_commands::pause(&mut runner).context("pausing run")?;
+    println!("Paused run {}", runner.run_id().short());
+    Ok(())
+}
+
+/// Flip the run status to `Failed { reason }`.
+#[expect(
+    clippy::print_stdout,
+    reason = "tmg run abort prints a one-line confirmation"
+)]
+pub fn cmd_abort(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
+    let run = store.load(run_id).context("loading run")?;
+    let mut runner = RunRunner::new(run, Arc::clone(store));
+    harness_commands::abort(&mut runner, "user aborted").context("aborting run")?;
+    println!("Aborted run {} (status=failed)", runner.run_id().short());
+    Ok(())
+}
+
+/// Spawn an interactive shell rooted at the current run's workspace.
+///
+/// The command does NOT apply any sandbox; this is an explicit
+/// operator action that should reach the workspace exactly as the
+/// user expects.
+pub fn cmd_shell(store: &RunStore, run_id: &RunId) -> anyhow::Result<()> {
+    let run = store.load(run_id).context("loading run")?;
+    let workspace = run.workspace_path.clone();
+    if !workspace.exists() {
+        anyhow::bail!("workspace path does not exist: {}", workspace.display());
+    }
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_owned());
+    let status = std::process::Command::new(&shell)
+        .current_dir(&workspace)
+        .status()
+        .with_context(|| format!("spawning interactive shell {shell}"))?;
+    if !status.success() {
+        // Non-zero exit (including the user typing `exit 1`) is not
+        // a tsumugi error; surface it but do not propagate via `?`.
+        tracing::debug!(?status, "interactive shell exited with non-zero status");
+    }
+    Ok(())
+}
+
+/// Format the SESSIONS column: `count/max` when a max is set,
+/// otherwise just `count`.
+fn format_sessions(count: u32, max: Option<u32>) -> String {
+    match max {
+        Some(m) => format!("{count}/{m}"),
+        None => format!("{count}"),
+    }
+}
+
+/// Stringify a [`RunStatus`] for column display.
+fn format_status(status: &RunStatus) -> String {
+    match status {
+        RunStatus::Running => "running".to_owned(),
+        RunStatus::Paused => "paused".to_owned(),
+        RunStatus::Completed => "completed".to_owned(),
+        RunStatus::Exhausted => "exhausted".to_owned(),
+        RunStatus::Failed { reason } => format!("failed ({reason})"),
+    }
+}
+
+/// Format `created_at` as a human-friendly relative time (e.g.
+/// `"2 hours ago"`).
+fn humantime_relative(then: DateTime<Utc>, now: DateTime<Utc>) -> String {
+    let duration = now.signed_duration_since(then);
+    if duration.num_seconds() < 0 {
+        return "in the future".to_owned();
+    }
+    let Ok(std_duration) = duration.to_std() else {
+        return "(invalid time)".to_owned();
+    };
+    // Clip to whole seconds so humantime prints `2h 5m` rather than
+    // millisecond precision.
+    let truncated = std::time::Duration::from_secs(std_duration.as_secs());
+    let formatted = humantime::format_duration(truncated).to_string();
+    if formatted.is_empty() {
+        "just now".to_owned()
+    } else {
+        // Take the most significant component for compactness:
+        // `2h 5m 30s` → `2h ago`. Falls back to the full string when
+        // splitting fails for any reason.
+        let head = formatted.split_whitespace().next().unwrap_or(&formatted);
+        format!("{head} ago")
+    }
+}
+
+/// One row of the `tmg run list` table.
+struct TableRow {
+    id: String,
+    scope: String,
+    status: String,
+    sessions: String,
+    progress: String,
+    started: String,
+}
+
+impl TableRow {
+    fn from_summary(store: &RunStore, summary: &RunSummary, now: DateTime<Utc>) -> Self {
+        // Look up max_sessions / feature counts on demand. Loading the
+        // full run is cheap (single TOML file) and rare (only the rows
+        // shown by `tmg run list`).
+        let (max_sessions, progress, scope_token) = match store.load(&summary.id) {
+            Ok(run) => {
+                let max = run.max_sessions;
+                let progress = match &run.scope {
+                    RunScope::Harnessed { .. } => format_progress(store, &summary.id),
+                    RunScope::AdHoc => "-".to_owned(),
+                };
+                let scope_token = match &run.scope {
+                    RunScope::AdHoc => "ad_hoc".to_owned(),
+                    RunScope::Harnessed { .. } => "harnessed".to_owned(),
+                };
+                (max, progress, scope_token)
+            }
+            Err(_) => (None, "-".to_owned(), summary.scope_label.replace('-', "_")),
+        };
+        Self {
+            id: summary.short_id().to_owned(),
+            scope: scope_token,
+            status: status_token(&summary.status),
+            sessions: format_sessions(summary.session_count, max_sessions),
+            progress,
+            started: humantime_relative(summary.created_at, now),
+        }
+    }
+
+    fn cells(&self) -> [&str; 6] {
+        [
+            self.id.as_str(),
+            self.scope.as_str(),
+            self.status.as_str(),
+            self.sessions.as_str(),
+            self.progress.as_str(),
+            self.started.as_str(),
+        ]
+    }
+}
+
+fn status_token(status: &RunStatus) -> String {
+    match status {
+        RunStatus::Running => "running".to_owned(),
+        RunStatus::Paused => "paused".to_owned(),
+        RunStatus::Completed => "completed".to_owned(),
+        RunStatus::Exhausted => "exhausted".to_owned(),
+        RunStatus::Failed { .. } => "failed".to_owned(),
+    }
+}
+
+fn format_progress(store: &RunStore, run_id: &RunId) -> String {
+    let path = store.features_file(run_id);
+    if !path.exists() {
+        return "-".to_owned();
+    }
+    let list = tmg_harness::FeatureList::new(path);
+    match list.read() {
+        Ok(features) => {
+            let total = features.features.len();
+            let passing = features.features.iter().filter(|f| f.passes).count();
+            format!("{passing}/{total}")
+        }
+        Err(_) => "-".to_owned(),
+    }
+}
+
+fn print_row(out: &mut impl Write, cells: &[&str; 6], widths: &[usize; 6]) -> std::io::Result<()> {
+    writeln!(
+        out,
+        "{:<w0$}  {:<w1$}  {:<w2$}  {:<w3$}  {:<w4$}  {:<w5$}",
+        cells[0],
+        cells[1],
+        cells[2],
+        cells[3],
+        cells[4],
+        cells[5],
+        w0 = widths[0],
+        w1 = widths[1],
+        w2 = widths[2],
+        w3 = widths[3],
+        w4 = widths[4],
+        w5 = widths[5],
+    )
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tmg_harness::RunStatus;
+
+    fn make_store() -> (tempfile::TempDir, Arc<RunStore>) {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let store = Arc::new(RunStore::new(tmp.path().join("runs")));
+        (tmp, store)
+    }
+
+    #[test]
+    fn resolve_run_id_uses_explicit_first() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let resolved = resolve_run_id(&store, Some("abc123"), Some(&workspace))
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(resolved.as_str(), "abc123");
+    }
+
+    #[test]
+    fn resolve_run_id_falls_back_to_current() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let resolved =
+            resolve_run_id(&store, None, Some(&workspace)).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(resolved, run.id);
+    }
+
+    #[test]
+    fn resolve_run_id_errors_when_no_run() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        let err = resolve_run_id(&store, None, Some(&workspace));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn cmd_pause_writes_paused_status() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        cmd_pause(&store, &run.id).unwrap_or_else(|e| panic!("{e}"));
+        let reloaded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(reloaded.status, RunStatus::Paused);
+    }
+
+    #[test]
+    fn cmd_abort_writes_failed_status() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        cmd_abort(&store, &run.id).unwrap_or_else(|e| panic!("{e}"));
+        let reloaded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
+        match reloaded.status {
+            RunStatus::Failed { reason } => assert_eq!(reason, "user aborted"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cmd_upgrade_flips_scope_and_cmd_downgrade_flips_back() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        cmd_upgrade(&store, &run.id).unwrap_or_else(|e| panic!("{e}"));
+        let upgraded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
+        assert!(matches!(upgraded.scope, RunScope::Harnessed { .. }));
+
+        // Plant a fake features.json and verify downgrade does not
+        // delete it.
+        let features = store.features_file(&run.id);
+        std::fs::write(
+            &features,
+            r#"{"features":[{"id":"f","category":"c","description":"d","steps":[],"passes":false}]}"#,
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        cmd_downgrade(&store, &run.id).unwrap_or_else(|e| panic!("{e}"));
+        let downgraded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(downgraded.scope, RunScope::AdHoc);
+        assert!(features.exists(), "features.json must be preserved");
+    }
+
+    #[test]
+    fn humantime_relative_handles_recent() {
+        let now = Utc::now();
+        let then = now - chrono::Duration::seconds(45);
+        let result = humantime_relative(then, now);
+        assert!(
+            result.ends_with(" ago") || result == "just now",
+            "got {result:?}",
+        );
+    }
+
+    #[test]
+    fn format_sessions_includes_max_when_set() {
+        assert_eq!(format_sessions(3, None), "3");
+        assert_eq!(format_sessions(3, Some(50)), "3/50");
+    }
+
+    #[test]
+    fn cmd_list_runs_without_panicking_on_empty_store() {
+        let (_tmp, store) = make_store();
+        // Just exercise the path; output goes to stdout but we only
+        // check that no error is returned.
+        cmd_list(&store).unwrap_or_else(|e| panic!("{e}"));
+    }
+}

--- a/tmg-cli/src/run_commands.rs
+++ b/tmg-cli/src/run_commands.rs
@@ -28,22 +28,51 @@ use tmg_harness::{
 /// `run_id` argument.
 ///
 /// Resolution order:
-/// 1. CLI-supplied id (verbatim).
-/// 2. The `current` pointer in the runs-dir, when present.
+/// 1. CLI-supplied id (validated via [`RunId::parse`]).
+/// 2. The `current` pointer in the runs-dir, when present **and** its
+///    target run's stored `workspace_path` matches the canonical cwd.
+///    A mismatch falls through to the next step so a stale pointer
+///    from a different project does not silently route the command.
 /// 3. [`RunStore::latest_resumable`] for the supplied workspace, when
 ///    present.
 ///
-/// Returns an error when no run can be resolved.
+/// Returns an error when no run can be resolved or when the
+/// CLI-supplied id is malformed.
 pub(crate) fn resolve_run_id(
     store: &RunStore,
     explicit: Option<&str>,
     workspace_path: Option<&Path>,
 ) -> anyhow::Result<RunId> {
-    if let Some(id) = explicit {
-        return Ok(RunId::from_string(id.to_owned()));
+    if let Some(raw) = explicit {
+        return RunId::parse(raw.to_owned()).with_context(|| format!("invalid run id {raw:?}"));
     }
     if let Some(current) = store.current().context("reading current run pointer")? {
-        return Ok(current);
+        // Validate that the `current` pointer agrees with the cwd we
+        // were launched from. Without this, an out-of-date pointer
+        // (e.g. left over from a different project that shares the
+        // same `runs_dir`) would silently route mutations into an
+        // unrelated run. Mirror the safety net `latest_resumable`
+        // already provides.
+        let agrees = match (workspace_path, store.load(&current)) {
+            (Some(expected), Ok(loaded)) => loaded.workspace_path == expected,
+            // Without an expected workspace, accept the pointer as-is
+            // (caller did not opt in to the workspace check).
+            (None, Ok(_)) => true,
+            // Pointer is dangling (load failed). Fall through to the
+            // next step so we don't propagate a confusing error from
+            // a `current` pointer that should be self-healing.
+            (_, Err(e)) => {
+                tracing::debug!(
+                    run_id = current.as_str(),
+                    error = %e,
+                    "current pointer is dangling; falling back to latest_resumable",
+                );
+                false
+            }
+        };
+        if agrees {
+            return Ok(current);
+        }
     }
     if let Some(summary) = store
         .latest_resumable(workspace_path)
@@ -66,7 +95,7 @@ pub(crate) fn resolve_run_id(
     clippy::print_stdout,
     reason = "tmg run list prints to stdout by design"
 )]
-pub fn cmd_list(store: &RunStore) -> anyhow::Result<()> {
+pub(crate) fn cmd_list(store: &RunStore) -> anyhow::Result<()> {
     let summaries = harness_commands::list(store).context("listing runs")?;
     let now = Utc::now();
 
@@ -102,7 +131,7 @@ pub fn cmd_list(store: &RunStore) -> anyhow::Result<()> {
     clippy::print_stdout,
     reason = "tmg run status prints to stdout by design"
 )]
-pub fn cmd_status(store: &RunStore, run_id: &RunId) -> anyhow::Result<()> {
+pub(crate) fn cmd_status(store: &RunStore, run_id: &RunId) -> anyhow::Result<()> {
     let report: StatusReport =
         harness_commands::status(store, run_id, 20).context("building status report")?;
 
@@ -159,7 +188,7 @@ pub fn cmd_status(store: &RunStore, run_id: &RunId) -> anyhow::Result<()> {
     clippy::print_stdout,
     reason = "tmg run upgrade prints a one-line confirmation"
 )]
-pub fn cmd_upgrade(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
+pub(crate) fn cmd_upgrade(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
     let run = store.load(run_id).context("loading run")?;
     if matches!(run.scope, RunScope::Harnessed { .. }) {
         println!(
@@ -179,7 +208,7 @@ pub fn cmd_upgrade(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> 
     clippy::print_stdout,
     reason = "tmg run downgrade prints a one-line confirmation"
 )]
-pub fn cmd_downgrade(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
+pub(crate) fn cmd_downgrade(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
     let run = store.load(run_id).context("loading run")?;
     if matches!(run.scope, RunScope::AdHoc) {
         println!("Run {} is already ad-hoc; no action taken.", run.id.short());
@@ -196,7 +225,7 @@ pub fn cmd_downgrade(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()
     clippy::print_stdout,
     reason = "tmg run pause prints a one-line confirmation"
 )]
-pub fn cmd_pause(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
+pub(crate) fn cmd_pause(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
     let run = store.load(run_id).context("loading run")?;
     let mut runner = RunRunner::new(run, Arc::clone(store));
     harness_commands::pause(&mut runner).context("pausing run")?;
@@ -209,7 +238,7 @@ pub fn cmd_pause(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
     clippy::print_stdout,
     reason = "tmg run abort prints a one-line confirmation"
 )]
-pub fn cmd_abort(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
+pub(crate) fn cmd_abort(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
     let run = store.load(run_id).context("loading run")?;
     let mut runner = RunRunner::new(run, Arc::clone(store));
     harness_commands::abort(&mut runner, "user aborted").context("aborting run")?;
@@ -222,7 +251,15 @@ pub fn cmd_abort(store: &Arc<RunStore>, run_id: &RunId) -> anyhow::Result<()> {
 /// The command does NOT apply any sandbox; this is an explicit
 /// operator action that should reach the workspace exactly as the
 /// user expects.
-pub fn cmd_shell(store: &RunStore, run_id: &RunId) -> anyhow::Result<()> {
+///
+/// **Exit code propagation**: the function exits the calling process
+/// with the shell's exit status (or `1` when the shell was killed by
+/// a signal and `code()` therefore returns `None`). Callers should
+/// treat the function as `-> !`-equivalent on success; we only
+/// return `Result` so failures *before* the shell starts (load /
+/// missing workspace / spawn) flow through `anyhow` to the
+/// top-level handler.
+pub(crate) fn cmd_shell(store: &RunStore, run_id: &RunId) -> anyhow::Result<()> {
     let run = store.load(run_id).context("loading run")?;
     let workspace = run.workspace_path.clone();
     if !workspace.exists() {
@@ -233,12 +270,11 @@ pub fn cmd_shell(store: &RunStore, run_id: &RunId) -> anyhow::Result<()> {
         .current_dir(&workspace)
         .status()
         .with_context(|| format!("spawning interactive shell {shell}"))?;
-    if !status.success() {
-        // Non-zero exit (including the user typing `exit 1`) is not
-        // a tsumugi error; surface it but do not propagate via `?`.
-        tracing::debug!(?status, "interactive shell exited with non-zero status");
-    }
-    Ok(())
+    // Propagate the shell's exit code so the user's `$?` reflects
+    // what they saw inside the shell. `code()` returns `None` when
+    // the process was killed by a signal; `1` is the conventional
+    // fallback in that case (mirrors `bash` exiting on SIGTERM).
+    std::process::exit(status.code().unwrap_or(1));
 }
 
 /// Format the SESSIONS column: `count/max` when a max is set,
@@ -405,9 +441,64 @@ mod tests {
             .create_ad_hoc(workspace.clone(), None)
             .unwrap_or_else(|e| panic!("{e}"));
 
-        let resolved = resolve_run_id(&store, Some("abc123"), Some(&workspace))
+        let resolved = resolve_run_id(&store, Some("abc12345"), Some(&workspace))
             .unwrap_or_else(|e| panic!("{e}"));
-        assert_eq!(resolved.as_str(), "abc123");
+        assert_eq!(resolved.as_str(), "abc12345");
+    }
+
+    /// `tmg run status ../foo` must surface "invalid run id"; we
+    /// never construct a [`RunId`] from path-traversal-shaped input.
+    #[test]
+    fn resolve_run_id_rejects_malformed_explicit_id() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        match resolve_run_id(&store, Some("../foo"), Some(&workspace)) {
+            Err(err) => {
+                let msg = format!("{err:#}");
+                assert!(
+                    msg.contains("invalid run id"),
+                    "expected error to mention `invalid run id`, got {msg:?}",
+                );
+            }
+            Ok(id) => panic!(
+                "expected error for malformed run id, got Ok({})",
+                id.as_str(),
+            ),
+        }
+    }
+
+    /// When the `current` pointer references a run whose workspace
+    /// disagrees with the cwd we were launched from, fall through to
+    /// `latest_resumable` instead of silently routing the command.
+    #[test]
+    fn resolve_run_id_falls_through_when_current_workspace_mismatch() {
+        let (tmp, store) = make_store();
+        let workspace_a = tmp.path().join("workspace-a");
+        let workspace_b = tmp.path().join("workspace-b");
+        std::fs::create_dir_all(&workspace_a).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::create_dir_all(&workspace_b).unwrap_or_else(|e| panic!("{e}"));
+
+        // Create one run for each workspace.
+        let run_a = store
+            .create_ad_hoc(workspace_a.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let run_b = store
+            .create_ad_hoc(workspace_b.clone(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        // After the second create_ad_hoc, `current` points at run_b.
+        // From cwd=workspace_a, the resolver should NOT return run_b
+        // via the `current` shortcut; instead it should fall through
+        // and pick run_a via `latest_resumable`.
+        let resolved =
+            resolve_run_id(&store, None, Some(&workspace_a)).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(resolved, run_a.id);
+        // Sanity: from workspace_b, the same logic returns run_b.
+        let resolved_b =
+            resolve_run_id(&store, None, Some(&workspace_b)).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(resolved_b, run_b.id);
     }
 
     #[test]
@@ -472,12 +563,8 @@ mod tests {
             .create_ad_hoc(workspace, None)
             .unwrap_or_else(|e| panic!("{e}"));
 
-        cmd_upgrade(&store, &run.id).unwrap_or_else(|e| panic!("{e}"));
-        let upgraded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
-        assert!(matches!(upgraded.scope, RunScope::Harnessed { .. }));
-
-        // Plant a fake features.json and verify downgrade does not
-        // delete it.
+        // Plant a fake features.json BEFORE calling cmd_upgrade so
+        // the precondition check passes.
         let features = store.features_file(&run.id);
         std::fs::write(
             &features,
@@ -485,10 +572,41 @@ mod tests {
         )
         .unwrap_or_else(|e| panic!("{e}"));
 
+        cmd_upgrade(&store, &run.id).unwrap_or_else(|e| panic!("{e}"));
+        let upgraded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
+        assert!(matches!(upgraded.scope, RunScope::Harnessed { .. }));
+
         cmd_downgrade(&store, &run.id).unwrap_or_else(|e| panic!("{e}"));
         let downgraded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
         assert_eq!(downgraded.scope, RunScope::AdHoc);
         assert!(features.exists(), "features.json must be preserved");
+    }
+
+    /// `cmd_upgrade` surfaces a clear precondition error when
+    /// `features.json` is missing. Mirror the harness-level test in
+    /// `commands.rs`; this one exercises the CLI wrapper.
+    #[test]
+    fn cmd_upgrade_without_features_returns_error() {
+        let (tmp, store) = make_store();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
+        let run = store
+            .create_ad_hoc(workspace, None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        match cmd_upgrade(&store, &run.id) {
+            Err(err) => {
+                let msg = format!("{err:#}");
+                assert!(
+                    msg.contains("features.json not found"),
+                    "expected error to mention missing features.json, got {msg:?}",
+                );
+            }
+            Ok(()) => panic!("expected precondition failure but cmd_upgrade succeeded"),
+        }
+        // Scope must remain ad-hoc after the refused upgrade.
+        let reloaded = store.load(&run.id).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(reloaded.scope, RunScope::AdHoc);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Restructures `tmg-cli` from a single-purpose `--prompt`/TUI binary to a `clap` subcommand-based shape, adding the SPEC §9.8 `tmg run <op>` family (resume / list / status / upgrade / downgrade / pause / abort / shell / new-session). Backwards compatibility is preserved: `tmg` with no args still launches the TUI, and `tmg --prompt "..."` still streams a one-shot response to stdout.
- Adds a new `tmg-harness::commands` module that centralises run-management state transitions (`list`, `status`, `pause`, `abort`, `upgrade`, `downgrade`, `new_session`), so CLI and TUI slash-commands (#46) share one source of truth.
- Introduces `.tsumugi/runs/current` (symlink, with `current.json` JSON-pointer fallback) so argument-less CLI invocations target the most recent active run. The pointer is updated by `RunStore::create_ad_hoc`, `RunStore::latest_resumable`, and explicit `tmg run resume <id>` calls.

## Implementation notes
- New `RunStore` APIs: `set_current` / `current` / `current_link_path` / `current_pointer_path` / `downgrade_to_ad_hoc`. `RunRunner` gains `store()` / `replace_run` / `set_status`. `RunRunner::escalate_to_harnessed` is unchanged; the new `commands::upgrade` calls `RunStore::upgrade_to_harnessed` directly so it can run on a freshly-constructed runner that has no active session (i.e. CLI-only invocations).
- `tmg run list` is hand-formatted (fixed-width columns) so we don't add a new dep; columns are `ID  SCOPE  STATUS  SESSIONS  PROGRESS  STARTED` per SPEC §9.8.
- `tmg run new-session` requires an active TUI session and prints an explanatory error outside one. The TUI slash-command equivalent is **deferred to #46** (the issue tracking the TUI surface).
- `tmg run shell` opens `$SHELL` (or `/bin/sh`) rooted at the run's workspace; no sandbox, by design.
- `features.json` is intentionally **not** deleted on downgrade — the LLM stops seeing the harnessed-only tools because the next `RunRunnerToolProvider` install reads the now-flipped scope, but the on-disk artifact is preserved for re-promotion or post-mortem.

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` — 91 tmg-cli tests pass (including parser asserts for `tmg` / `tmg --prompt` / each subcommand) and harness tests cover the new `current` pointer, `downgrade_to_ad_hoc`, and `commands::*` helpers
- [x] Smoke-tested the binary against a live `llama-server`: one-shot mode (`tmg --prompt "Say hello in one word"`) returns a clean event log, TUI session creates `.tsumugi/runs/<id>/run.toml` plus a `current` symlink, and `tmg run list` / `status` / `upgrade` operate correctly on the resulting run

### Runtime Verification
- LLM server: available
- One-shot mode: PASS — token + done events present, no errors
- CLI subcommand smoke: PASS — `list` renders the table, `status` defaults to `current`, `upgrade` flips the on-disk scope (verified by re-running `list`)
- TUI mode: PASS — TUI runs, run state persisted to `.tsumugi/runs/<id>/`, `current` symlink resolves correctly afterwards

## Deferred to #46
- `/run upgrade`, `/run downgrade`, `/run pause`, `/run abort`, `/run new-session` slash commands invoked from inside the TUI (the helpers in `tmg_harness::commands` are already in place; the TUI side still needs to wire the slash-command parser to call them).
- Inside-the-TUI `tmg run new-session` equivalent — currently the CLI surface refuses to rotate when invoked outside the TUI session.

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)