### PR TITLE
tmg-cli: tmg workflow {list,validate,run} + tmg init + builtin templates (#44)

### DIFF
--- a/crates/tmg-workflow/src/lib.rs
+++ b/crates/tmg-workflow/src/lib.rs
@@ -32,6 +32,7 @@ pub mod long_running;
 pub mod parse;
 pub mod progress;
 pub(crate) mod steps;
+pub mod templates;
 pub mod tools;
 
 pub use config::WorkflowConfig;

--- a/crates/tmg-workflow/src/templates.rs
+++ b/crates/tmg-workflow/src/templates.rs
@@ -1,0 +1,251 @@
+//! Built-in workflow / harness / skill templates (issue #44).
+//!
+//! The crate ships a small library of opinionated workflow YAML and a
+//! sample skill so `tmg init` can scaffold a `.tsumugi/` directory
+//! without external network access. Templates are embedded at compile
+//! time via [`include_str!`]; no runtime asset lookup is required.
+//!
+//! ## Naming convention
+//!
+//! Each template has:
+//!
+//! - A short kebab-case **name** (e.g. `"plan"`, `"build-app"`) used by
+//!   `tmg init --workflows ...` and `tmg init --harness ...`.
+//! - A relative **install path** under `.tsumugi/` (e.g.
+//!   `workflows/plan.yaml`).
+//! - A category ([`TemplateCategory`]) so the installer knows which
+//!   subdirectory to create.
+//!
+//! ## Trade-off: `include_str!` vs `include_dir`
+//!
+//! We use plain `include_str!` to avoid pulling another dependency
+//! (`include_dir`) into the workspace just for ~10 small files. The
+//! cost is that adding a new template requires a one-line entry in
+//! [`ALL`] alongside the file. The build is still completely static —
+//! no `build.rs` needed — and the embed is verified at compile time
+//! by `include_str!` itself.
+//!
+//! ## Validation invariant
+//!
+//! `crates/tmg-workflow/src/templates.rs::tests::all_workflow_templates_parse`
+//! asserts that every YAML template parses through
+//! [`crate::parse::parse_workflow_str`]. This catches drift between
+//! the parser and the embedded templates whenever either side changes.
+
+/// Category of a built-in template.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TemplateCategory {
+    /// A plain workflow YAML to be installed under
+    /// `.tsumugi/workflows/`.
+    Workflow,
+    /// A long-running harness workflow YAML to be installed under
+    /// `.tsumugi/workflows/` (harness templates are functionally
+    /// long-running workflows; the separate name is purely UX).
+    Harness,
+    /// A skill bundle entry to be installed under
+    /// `.tsumugi/skills/<skill_id>/`.
+    Skill,
+}
+
+impl TemplateCategory {
+    /// Human-readable label used by `tmg init --help` text and the
+    /// install confirmation messages.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Workflow => "workflow",
+            Self::Harness => "harness",
+            Self::Skill => "skill",
+        }
+    }
+}
+
+/// Metadata for a single built-in template.
+#[derive(Debug, Clone, Copy)]
+pub struct TemplateMeta {
+    /// Short, kebab-case name. Used as the value passed to
+    /// `tmg init --workflows ...` / `--harness ...`.
+    pub name: &'static str,
+    /// Category (workflow / harness / skill).
+    pub category: TemplateCategory,
+    /// Path the file should be installed at, relative to the
+    /// `.tsumugi/` root.
+    pub install_path: &'static str,
+    /// One-line description shown in help output.
+    pub description: &'static str,
+}
+
+// -----------------------------------------------------------------------------
+// Embedded contents
+// -----------------------------------------------------------------------------
+
+const PLAN_YAML: &str = include_str!("../templates/workflows/plan.yaml");
+const IMPLEMENT_YAML: &str = include_str!("../templates/workflows/implement.yaml");
+const REVIEW_YAML: &str = include_str!("../templates/workflows/review.yaml");
+const REFACTOR_YAML: &str = include_str!("../templates/workflows/refactor.yaml");
+const BUILD_APP_YAML: &str = include_str!("../templates/harness/build-app.yaml");
+const MIGRATE_CODEBASE_YAML: &str = include_str!("../templates/harness/migrate-codebase.yaml");
+const ADD_FEATURE_YAML: &str = include_str!("../templates/harness/add-feature.yaml");
+const BUG_FIX_BATCH_YAML: &str = include_str!("../templates/harness/bug-fix-batch.yaml");
+const SKILL_DEVELOP_MD: &str = include_str!("../templates/skills/develop/SKILL.md");
+
+/// Master table of every embedded template.
+///
+/// Order matters for stable output ordering in `tmg init` confirmation
+/// messages: workflows first (alphabetical), then harness templates,
+/// then skills. Adding a new template means adding one line here and
+/// one entry in [`read_template`].
+pub const ALL: &[TemplateMeta] = &[
+    TemplateMeta {
+        name: "plan",
+        category: TemplateCategory::Workflow,
+        install_path: "workflows/plan.yaml",
+        description: "Explore the codebase, draft a plan, and audit it",
+    },
+    TemplateMeta {
+        name: "implement",
+        category: TemplateCategory::Workflow,
+        install_path: "workflows/implement.yaml",
+        description: "Implement a feature with agent + verify (SPEC §8.3)",
+    },
+    TemplateMeta {
+        name: "review",
+        category: TemplateCategory::Workflow,
+        install_path: "workflows/review.yaml",
+        description: "Review-then-fix loop (SPEC §8.4)",
+    },
+    TemplateMeta {
+        name: "refactor",
+        category: TemplateCategory::Workflow,
+        install_path: "workflows/refactor.yaml",
+        description: "Implement a refactor and review it",
+    },
+    TemplateMeta {
+        name: "build-app",
+        category: TemplateCategory::Harness,
+        install_path: "workflows/build-app.yaml",
+        description: "Build a new app from scratch (SPEC §8.12 / §9.12)",
+    },
+    TemplateMeta {
+        name: "migrate-codebase",
+        category: TemplateCategory::Harness,
+        install_path: "workflows/migrate-codebase.yaml",
+        description: "Migrate a codebase file-by-file",
+    },
+    TemplateMeta {
+        name: "add-feature",
+        category: TemplateCategory::Harness,
+        install_path: "workflows/add-feature.yaml",
+        description: "Add a feature to an existing project iteratively",
+    },
+    TemplateMeta {
+        name: "bug-fix-batch",
+        category: TemplateCategory::Harness,
+        install_path: "workflows/bug-fix-batch.yaml",
+        description: "Fix a batch of bugs, one per feature",
+    },
+    TemplateMeta {
+        name: "develop",
+        category: TemplateCategory::Skill,
+        install_path: "skills/develop/SKILL.md",
+        description: "Sample method-1 skill (SPEC §8.5)",
+    },
+];
+
+/// Return the full template catalogue.
+#[must_use]
+pub fn list_available() -> Vec<TemplateMeta> {
+    ALL.to_vec()
+}
+
+/// Look up a template by its kebab-case name.
+///
+/// Returns `None` when no template matches.
+#[must_use]
+pub fn read_template(name: &str) -> Option<&'static str> {
+    match name {
+        "plan" => Some(PLAN_YAML),
+        "implement" => Some(IMPLEMENT_YAML),
+        "review" => Some(REVIEW_YAML),
+        "refactor" => Some(REFACTOR_YAML),
+        "build-app" => Some(BUILD_APP_YAML),
+        "migrate-codebase" => Some(MIGRATE_CODEBASE_YAML),
+        "add-feature" => Some(ADD_FEATURE_YAML),
+        "bug-fix-batch" => Some(BUG_FIX_BATCH_YAML),
+        "develop" => Some(SKILL_DEVELOP_MD),
+        _ => None,
+    }
+}
+
+/// Look up the [`TemplateMeta`] for a kebab-case name.
+#[must_use]
+pub fn find(name: &str) -> Option<TemplateMeta> {
+    ALL.iter().copied().find(|m| m.name == name)
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::parse::parse_workflow_str;
+
+    /// CI guard: every embedded YAML template must parse through
+    /// [`parse_workflow_str`]. This is the single test that catches
+    /// drift between the parser surface and the shipped templates.
+    #[test]
+    fn all_workflow_templates_parse() {
+        for meta in ALL {
+            if matches!(meta.category, TemplateCategory::Skill) {
+                continue;
+            }
+            let content = read_template(meta.name).unwrap_or_else(|| {
+                panic!(
+                    "read_template returned None for known template '{}'",
+                    meta.name
+                )
+            });
+            parse_workflow_str(content, format!("<embedded:{}>", meta.name)).unwrap_or_else(|e| {
+                panic!("template '{}' failed to parse: {e}", meta.name);
+            });
+        }
+    }
+
+    /// Each entry in [`ALL`] must have a working [`read_template`]
+    /// arm. A missing arm would compile but silently lose the template
+    /// at runtime.
+    #[test]
+    fn every_meta_has_a_read_arm() {
+        for meta in ALL {
+            assert!(
+                read_template(meta.name).is_some(),
+                "no read_template arm for '{}'",
+                meta.name,
+            );
+        }
+    }
+
+    /// `find` agrees with the `ALL` table.
+    #[test]
+    fn find_round_trips() {
+        for meta in ALL {
+            let found = find(meta.name).unwrap_or_else(|| panic!("find('{}')", meta.name));
+            assert_eq!(found.name, meta.name);
+            assert_eq!(found.install_path, meta.install_path);
+        }
+        assert!(find("does-not-exist").is_none());
+    }
+
+    /// Names are unique. (Defensive: a duplicate would shadow.)
+    #[test]
+    fn names_are_unique() {
+        let mut seen = std::collections::BTreeSet::new();
+        for meta in ALL {
+            assert!(
+                seen.insert(meta.name),
+                "duplicate template name '{}'",
+                meta.name,
+            );
+        }
+    }
+}

--- a/crates/tmg-workflow/templates/harness/add-feature.yaml
+++ b/crates/tmg-workflow/templates/harness/add-feature.yaml
@@ -1,0 +1,63 @@
+id: add_feature
+description: "Add a feature to an existing project iteratively"
+mode: long_running
+
+inputs:
+  feature_description:
+    type: string
+    required: true
+    description: "What feature to add"
+
+init:
+  artifacts:
+    progress_file: ".tsumugi/runs/RUNID/progress.md"
+    features_file: ".tsumugi/runs/RUNID/features.json"
+  steps:
+    - id: scaffold
+      type: agent
+      subagent: initializer
+      prompt: |
+        Decompose the requested feature into smaller features and
+        produce features.json.  Re-use the project's existing build /
+        test commands for init.sh.
+
+        Feature: ${{ inputs.feature_description }}
+
+iterate:
+  bootstrap:
+    - run: "git status --porcelain"
+    - read: "${{ artifacts.progress_file }}"
+    - smoke_test:
+        id: smoke
+        type: shell
+        command: "cargo check --workspace"
+  steps:
+    - id: implement
+      type: agent
+      subagent: worker
+      prompt: |
+        Implement the next failing sub-feature.
+
+        Feature: ${{ inputs.feature_description }}
+
+        Bootstrap context:
+        ${{ inputs.bootstrap_context }}
+
+    - id: verify
+      type: shell
+      command: "cargo test --workspace"
+      timeout: "15m"
+
+    - id: qa
+      type: agent
+      subagent: qa
+      prompt: |
+        Mark passing sub-features in features.json.  Reply with a
+        brief summary of progress so far.
+
+        Verify stdout:
+        ${{ steps.verify.stdout }}
+
+  until: "artifact.features.all_passing"
+  max_sessions: 15
+  session_timeout: "30m"

--- a/crates/tmg-workflow/templates/harness/bug-fix-batch.yaml
+++ b/crates/tmg-workflow/templates/harness/bug-fix-batch.yaml
@@ -1,0 +1,58 @@
+id: bug_fix_batch
+description: "Fix a batch of bugs, one per feature in features.json"
+mode: long_running
+
+inputs:
+  bug_list_description:
+    type: string
+    required: true
+    description: "Free-form description or path to the bug list"
+
+init:
+  artifacts:
+    progress_file: ".tsumugi/runs/RUNID/progress.md"
+    features_file: ".tsumugi/runs/RUNID/features.json"
+  steps:
+    - id: triage
+      type: agent
+      subagent: initializer
+      prompt: |
+        Read the supplied bug list and convert each bug into a feature
+        in features.json.  Acceptance criteria per feature: the bug's
+        regression test passes.
+
+        Bug list: ${{ inputs.bug_list_description }}
+
+iterate:
+  bootstrap:
+    - run: "git status --porcelain"
+    - read: "${{ artifacts.progress_file }}"
+  steps:
+    - id: fix
+      type: agent
+      subagent: worker
+      prompt: |
+        Pick the next failing bug-feature and fix it.  Add a
+        regression test if one is missing.
+
+        Bootstrap context:
+        ${{ inputs.bootstrap_context }}
+
+    - id: verify
+      type: shell
+      command: "cargo test --workspace"
+      timeout: "15m"
+
+    - id: qa
+      type: agent
+      subagent: qa
+      prompt: |
+        Mark fixed bug-features as passing.  Reply with a brief
+        summary.
+
+        Verify stdout:
+        ${{ steps.verify.stdout }}
+
+  until: "artifact.features.all_passing"
+  max_sessions: 30
+  session_timeout: "30m"

--- a/crates/tmg-workflow/templates/harness/build-app.yaml
+++ b/crates/tmg-workflow/templates/harness/build-app.yaml
@@ -1,0 +1,61 @@
+id: build_app
+description: "Build a new application from scratch (SPEC §8.12 / §9.12)"
+mode: long_running
+
+inputs:
+  app_description:
+    type: string
+    required: true
+    description: "What the application should do"
+
+init:
+  artifacts:
+    progress_file: ".tsumugi/runs/RUNID/progress.md"
+    features_file: ".tsumugi/runs/RUNID/features.json"
+  steps:
+    - id: bootstrap_init
+      type: agent
+      subagent: initializer
+      prompt: |
+        Read the workspace and produce features.json, init.sh, and an
+        initial progress.md for the following application.
+
+        Application: ${{ inputs.app_description }}
+
+iterate:
+  bootstrap:
+    - run: "git status --porcelain"
+    - read: "${{ artifacts.progress_file }}"
+    - smoke_test:
+        id: smoke
+        type: shell
+        command: "cargo check --workspace"
+  steps:
+    - id: implement
+      type: agent
+      subagent: worker
+      prompt: |
+        Pick the next failing feature from features.json and implement
+        it. Update progress.md when done.
+
+        Bootstrap context:
+        ${{ inputs.bootstrap_context }}
+
+    - id: verify
+      type: shell
+      command: "cargo test --workspace"
+      timeout: "15m"
+
+    - id: qa
+      type: agent
+      subagent: qa
+      prompt: |
+        Inspect features.json and mark each newly-passing feature via
+        feature_list_mark_passing. Reply with a one-line summary.
+
+        Test output:
+        ${{ steps.verify.stdout }}
+
+  until: "artifact.features.all_passing"
+  max_sessions: 20
+  session_timeout: "30m"

--- a/crates/tmg-workflow/templates/harness/migrate-codebase.yaml
+++ b/crates/tmg-workflow/templates/harness/migrate-codebase.yaml
@@ -1,0 +1,61 @@
+id: migrate_codebase
+description: "Migrate a codebase file-by-file driven by features.json"
+mode: long_running
+
+inputs:
+  migration_description:
+    type: string
+    required: true
+    description: "What to migrate (e.g. 'Vue 2 -> Vue 3')"
+
+init:
+  artifacts:
+    progress_file: ".tsumugi/runs/RUNID/progress.md"
+    features_file: ".tsumugi/runs/RUNID/features.json"
+  steps:
+    - id: enumerate_targets
+      type: agent
+      subagent: initializer
+      prompt: |
+        Walk the codebase and produce features.json where each feature
+        is one file (or one module) to migrate.  Acceptance criteria
+        per feature: the file builds and tests pass.
+
+        Migration: ${{ inputs.migration_description }}
+
+iterate:
+  bootstrap:
+    - run: "git status --porcelain"
+    - read: "${{ artifacts.progress_file }}"
+  steps:
+    - id: migrate_one
+      type: agent
+      subagent: worker
+      prompt: |
+        Pick the next failing feature (one file or module) and migrate
+        it.  Keep the diff small so the verify step can localise
+        regressions.
+
+        Migration: ${{ inputs.migration_description }}
+
+        Bootstrap context:
+        ${{ inputs.bootstrap_context }}
+
+    - id: verify
+      type: shell
+      command: "cargo test --workspace"
+      timeout: "15m"
+
+    - id: qa
+      type: agent
+      subagent: qa
+      prompt: |
+        Inspect features.json: mark the just-migrated file as passing
+        if its tests are green.
+
+        Verify output:
+        ${{ steps.verify.stdout }}
+
+  until: "artifact.features.all_passing"
+  max_sessions: 50
+  session_timeout: "30m"

--- a/crates/tmg-workflow/templates/skills/develop/SKILL.md
+++ b/crates/tmg-workflow/templates/skills/develop/SKILL.md
@@ -1,0 +1,39 @@
+# develop
+
+A SPEC §8.5 method-1 sample skill for tsumugi.
+
+This skill encapsulates the standard "implement -> verify -> review"
+loop that most coding tasks need.  Drop it into
+`.tsumugi/skills/develop/` and reference it from a workflow or
+subagent prompt.
+
+## When to use
+
+Use when the user asks for a code change that:
+
+- Has clear acceptance criteria (e.g. "tests should pass").
+- Touches a contained area of the codebase (one or two crates).
+- Does not require deep architectural decisions.
+
+## Steps
+
+1. Plan: enumerate the files to touch and the order to do them in.
+2. Implement: produce a minimal change set.
+3. Verify: run `cargo test --workspace` (or the project's equivalent).
+4. Review: re-read the diff with a reviewer mindset; fix obvious
+   issues.
+5. Commit: prepare a Conventional-Commits-style message.
+
+## Allowed tools
+
+- `file_read`, `file_write`, `file_patch`
+- `grep_search`, `list_dir`
+- `shell_exec`
+
+## Hand-off
+
+When you finish, return:
+
+- A short summary of the change.
+- The exit code of the verify step.
+- A list of files changed.

--- a/crates/tmg-workflow/templates/workflows/implement.yaml
+++ b/crates/tmg-workflow/templates/workflows/implement.yaml
@@ -1,0 +1,36 @@
+id: implement
+description: "Implement a feature with agent + verify (SPEC §8.3)"
+mode: normal
+
+inputs:
+  feature_id:
+    type: string
+    required: true
+    description: "Target feature id"
+  budget:
+    type: integer
+    default: 50
+    description: "Soft cap on tool calls"
+
+steps:
+  - id: plan
+    type: agent
+    subagent: plan
+    prompt: "Plan the implementation of feature ${{ inputs.feature_id }}."
+
+  - id: implement
+    type: agent
+    subagent: worker
+    prompt: |
+      Implement based on this plan:
+
+      ${{ steps.plan.output }}
+
+  - id: verify
+    type: shell
+    command: "cargo test --workspace"
+    timeout: "10m"
+
+outputs:
+  plan_summary: "${{ steps.plan.output }}"
+  test_exit:   "${{ steps.verify.exit_code }}"

--- a/crates/tmg-workflow/templates/workflows/plan.yaml
+++ b/crates/tmg-workflow/templates/workflows/plan.yaml
@@ -1,0 +1,53 @@
+id: plan
+description: "Explore the codebase, draft a plan, and audit it in a loop"
+mode: normal
+
+inputs:
+  requirements:
+    type: string
+    required: true
+    description: "What the user wants to plan"
+  max_audit_iterations:
+    type: integer
+    default: 3
+    description: "Cap on plan-audit revisions"
+
+steps:
+  - id: explore
+    type: agent
+    subagent: explore
+    prompt: |
+      Survey the codebase relevant to the following requirement and
+      summarise the salient files / modules / public types in a brief
+      structured report.
+
+      Requirement: ${{ inputs.requirements }}
+
+  - id: draft
+    type: agent
+    subagent: plan
+    prompt: |
+      Draft an implementation plan based on this exploration.
+
+      Requirement: ${{ inputs.requirements }}
+
+      Exploration report:
+      ${{ steps.explore.output }}
+
+  - id: audit_loop
+    type: loop
+    max_iterations: 3
+    until: "steps.draft.output != ''"
+    steps:
+      - id: audit
+        type: agent
+        subagent: plan
+        prompt: |
+          Audit the following plan for completeness and correctness.
+          If issues remain, list them; if it is good, reply "OK".
+
+          Plan:
+          ${{ steps.draft.output }}
+
+outputs:
+  plan: "${{ steps.draft.output }}"

--- a/crates/tmg-workflow/templates/workflows/refactor.yaml
+++ b/crates/tmg-workflow/templates/workflows/refactor.yaml
@@ -1,0 +1,58 @@
+id: refactor
+description: "Implement a refactor and review it (implement + review combined)"
+mode: normal
+
+inputs:
+  target:
+    type: string
+    required: true
+    description: "What to refactor (path, module, or description)"
+  budget:
+    type: integer
+    default: 50
+
+steps:
+  - id: plan
+    type: agent
+    subagent: plan
+    prompt: |
+      Plan the refactor of: ${{ inputs.target }}.
+      List the files to touch and the order to do them in.
+
+  - id: implement
+    type: agent
+    subagent: worker
+    prompt: |
+      Carry out this refactor plan, preserving behaviour.
+
+      ${{ steps.plan.output }}
+
+  - id: verify
+    type: shell
+    command: "cargo test --workspace"
+    timeout: "10m"
+
+  - id: fix_errors
+    type: agent
+    subagent: worker
+    prompt: |
+      The verification step produced this output. If exit_code is
+      non-zero, fix the failures; otherwise reply "OK" and make no
+      changes.
+
+      stdout:
+      ${{ steps.verify.stdout }}
+      stderr:
+      ${{ steps.verify.stderr }}
+
+  - id: review_loop
+    type: loop
+    max_iterations: 3
+    until: "steps.verify.exit_code == 0"
+    steps:
+      - ref: verify
+      - ref: fix_errors
+
+outputs:
+  passed: "${{ steps.verify.exit_code }}"
+  plan_summary: "${{ steps.plan.output }}"

--- a/crates/tmg-workflow/templates/workflows/review.yaml
+++ b/crates/tmg-workflow/templates/workflows/review.yaml
@@ -1,0 +1,43 @@
+id: review
+description: "Review-then-fix loop (SPEC §8.4 review_loop pattern)"
+mode: normal
+
+inputs:
+  target:
+    type: string
+    required: true
+    description: "What to review (path, feature id, or PR description)"
+  max_iterations:
+    type: integer
+    default: 3
+
+steps:
+  - id: verify
+    type: shell
+    command: "cargo test --workspace"
+    timeout: "10m"
+
+  - id: fix_errors
+    type: agent
+    subagent: worker
+    prompt: |
+      The verification step produced this output. If exit_code is
+      non-zero, fix the failures; otherwise reply "OK" and make no
+      changes.
+
+      Target: ${{ inputs.target }}
+      stdout:
+      ${{ steps.verify.stdout }}
+      stderr:
+      ${{ steps.verify.stderr }}
+
+  - id: review_loop
+    type: loop
+    max_iterations: 3
+    until: "steps.verify.exit_code == 0"
+    steps:
+      - ref: verify
+      - ref: fix_errors
+
+outputs:
+  passed: "${{ steps.verify.exit_code }}"

--- a/tmg-cli/src/init_command.rs
+++ b/tmg-cli/src/init_command.rs
@@ -1,0 +1,333 @@
+//! Implementation of the `tmg init` subcommand (issue #44).
+//!
+//! Materialises a `.tsumugi/` directory at the project root from the
+//! built-in template catalogue exposed by [`tmg_workflow::templates`].
+//! The command is non-interactive: every selection is supplied via
+//! flags so CI can call it with confidence. Every existing file is
+//! preserved by default; `--force` is the explicit "I understand this
+//! overwrites" opt-in.
+//!
+//! ## Trade-off: refuse-on-conflict vs. interactive merge
+//!
+//! When `--force` is *not* set and at least one selected template
+//! would clobber an existing file, the command aborts before writing
+//! anything. We deliberately do **not** offer an interactive
+//! per-file prompt: it would defeat the CI-friendly contract and
+//! complicate the binary's surface for what is really a one-time
+//! scaffold operation. Operators who want a partial overwrite should
+//! delete the conflicting files first.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use tmg_workflow::templates::{self, TemplateCategory, TemplateMeta};
+
+/// Plan computed from user flags before any I/O happens.
+///
+/// Building the plan up front means we can detect conflicts and
+/// missing template names *before* writing a single byte. A failed
+/// `tmg init` should leave the workspace untouched.
+#[derive(Debug)]
+pub(crate) struct InitPlan {
+    /// Each selected template plus the absolute target path.
+    pub entries: Vec<InitPlanEntry>,
+    /// Directories that need to exist before any write happens.
+    pub directories: BTreeSet<PathBuf>,
+}
+
+#[derive(Debug)]
+pub(crate) struct InitPlanEntry {
+    pub meta: TemplateMeta,
+    pub target: PathBuf,
+}
+
+/// Build an [`InitPlan`] for the requested templates.
+///
+/// `tsumugi_dir` is the absolute `.tsumugi/` directory the templates
+/// will be installed under. Caller is responsible for picking the
+/// directory (project root vs. a custom path).
+///
+/// # Errors
+///
+/// Returns an error when `--workflows` / `--harness` references a name
+/// that is not in the built-in catalogue. The user-facing message
+/// lists the unknown names so a typo is easy to spot.
+pub(crate) fn build_plan(
+    tsumugi_dir: &Path,
+    workflows: &[String],
+    harness: &[String],
+    all: bool,
+) -> anyhow::Result<InitPlan> {
+    let mut requested: Vec<TemplateMeta> = Vec::new();
+    let mut unknown: Vec<String> = Vec::new();
+
+    if all {
+        requested.extend(templates::list_available());
+    } else {
+        for name in workflows {
+            match templates::find(name) {
+                Some(meta) if matches!(meta.category, TemplateCategory::Workflow) => {
+                    requested.push(meta);
+                }
+                Some(meta) => {
+                    anyhow::bail!(
+                        "template '{name}' is a {category}, not a workflow; pass it via --harness or --all instead",
+                        category = meta.category.label(),
+                    );
+                }
+                None => unknown.push(name.clone()),
+            }
+        }
+        for name in harness {
+            match templates::find(name) {
+                Some(meta) if matches!(meta.category, TemplateCategory::Harness) => {
+                    requested.push(meta);
+                }
+                Some(meta) => {
+                    anyhow::bail!(
+                        "template '{name}' is a {category}, not a harness template; pass it via --workflows or --all instead",
+                        category = meta.category.label(),
+                    );
+                }
+                None => unknown.push(name.clone()),
+            }
+        }
+    }
+
+    if !unknown.is_empty() {
+        anyhow::bail!(
+            "unknown template(s): {}. Run `tmg init --help` to see available names.",
+            unknown.join(", "),
+        );
+    }
+
+    if requested.is_empty() {
+        anyhow::bail!(
+            "no templates selected. Pass --workflows, --harness, or --all (see `tmg init --help`).",
+        );
+    }
+
+    // De-duplicate (--all may overlap; or a user might list the same
+    // name twice). Stable order preserves the first occurrence so the
+    // installer's confirmation lines match the user's flag order.
+    let mut seen: BTreeSet<&'static str> = BTreeSet::new();
+    requested.retain(|meta| seen.insert(meta.name));
+
+    let mut directories: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut entries: Vec<InitPlanEntry> = Vec::with_capacity(requested.len());
+    directories.insert(tsumugi_dir.to_path_buf());
+
+    for meta in requested {
+        let target = tsumugi_dir.join(meta.install_path);
+        if let Some(parent) = target.parent() {
+            directories.insert(parent.to_path_buf());
+        }
+        entries.push(InitPlanEntry { meta, target });
+    }
+
+    Ok(InitPlan {
+        entries,
+        directories,
+    })
+}
+
+/// Detect every entry whose target already exists.
+pub(crate) fn detect_conflicts(plan: &InitPlan) -> Vec<PathBuf> {
+    plan.entries
+        .iter()
+        .filter(|e| e.target.exists())
+        .map(|e| e.target.clone())
+        .collect()
+}
+
+/// Run `tmg init` with the supplied flags.
+///
+/// The function is synchronous (no async work needed for filesystem
+/// writes) and is invoked directly from `main.rs`'s subcommand
+/// dispatch. Returns the number of files written so the caller can
+/// print a concise confirmation.
+#[expect(
+    clippy::print_stdout,
+    reason = "tmg init prints install confirmations to stdout"
+)]
+pub(crate) fn cmd_init(
+    workflows: &[String],
+    harness: &[String],
+    all: bool,
+    force: bool,
+) -> anyhow::Result<()> {
+    let cwd = std::env::current_dir().context("reading current working directory")?;
+    let canonical = cwd.canonicalize().unwrap_or(cwd);
+    let tsumugi_dir = canonical.join(".tsumugi");
+
+    let plan = build_plan(&tsumugi_dir, workflows, harness, all)?;
+
+    let conflicts = detect_conflicts(&plan);
+    if !conflicts.is_empty() && !force {
+        let mut msg = String::from("the following files already exist:\n");
+        for c in &conflicts {
+            // `write!` on a String never fails per std docs.
+            let _ = writeln!(msg, "  {}", c.display());
+        }
+        msg.push_str("re-run with --force to overwrite.");
+        anyhow::bail!(msg);
+    }
+
+    // Materialise directories first so a partial template list still
+    // produces a usable layout.
+    for dir in &plan.directories {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("creating directory {}", dir.display()))?;
+    }
+
+    // Always create the `skills/develop/` parent even when the
+    // `develop` skill template is not selected — the SPEC §8.5 layout
+    // expects the directory to be present so users can drop their own
+    // SKILL.md in.  We only create the *parent* `skills/` directory
+    // here (not `skills/develop/`); a deeper sentinel would over-claim
+    // intent.
+    let skills_dir = tsumugi_dir.join("skills");
+    std::fs::create_dir_all(&skills_dir)
+        .with_context(|| format!("creating directory {}", skills_dir.display()))?;
+    let workflows_dir = tsumugi_dir.join("workflows");
+    std::fs::create_dir_all(&workflows_dir)
+        .with_context(|| format!("creating directory {}", workflows_dir.display()))?;
+    let harness_dir = tsumugi_dir.join("harness");
+    std::fs::create_dir_all(&harness_dir)
+        .with_context(|| format!("creating directory {}", harness_dir.display()))?;
+
+    let mut written = 0usize;
+    for entry in &plan.entries {
+        let content = templates::read_template(entry.meta.name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "template registry desync: '{}' has metadata but no content",
+                entry.meta.name,
+            )
+        })?;
+        if let Some(parent) = entry.target.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating parent {}", parent.display()))?;
+        }
+        std::fs::write(&entry.target, content)
+            .with_context(|| format!("writing {}", entry.target.display()))?;
+        written += 1;
+        let action = if conflicts.contains(&entry.target) {
+            "overwrote"
+        } else {
+            "wrote"
+        };
+        println!(
+            "{action} {} ({} '{}')",
+            entry.target.display(),
+            entry.meta.category.label(),
+            entry.meta.name,
+        );
+    }
+
+    println!(
+        "\ninstalled {written} template{s} into {}",
+        tsumugi_dir.display(),
+        s = if written == 1 { "" } else { "s" },
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn names(plan: &InitPlan) -> Vec<&'static str> {
+        plan.entries.iter().map(|e| e.meta.name).collect()
+    }
+
+    #[test]
+    fn build_plan_all_includes_every_template() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let plan = build_plan(&tmp.path().join(".tsumugi"), &[], &[], true)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let n = templates::list_available().len();
+        assert_eq!(plan.entries.len(), n);
+    }
+
+    #[test]
+    fn build_plan_specific_workflows() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let workflows = vec!["plan".to_owned(), "implement".to_owned()];
+        let plan = build_plan(&tmp.path().join(".tsumugi"), &workflows, &[], false)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(names(&plan), vec!["plan", "implement"]);
+    }
+
+    #[test]
+    fn build_plan_specific_harness() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let harness = vec!["build-app".to_owned()];
+        let plan = build_plan(&tmp.path().join(".tsumugi"), &[], &harness, false)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(names(&plan), vec!["build-app"]);
+    }
+
+    #[test]
+    fn build_plan_rejects_unknown_name() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let workflows = vec!["does-not-exist".to_owned()];
+        let result = build_plan(&tmp.path().join(".tsumugi"), &workflows, &[], false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_plan_rejects_category_mismatch() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        // 'build-app' is a harness template; passing it via --workflows
+        // should fail with a hint to use --harness.
+        let workflows = vec!["build-app".to_owned()];
+        let result = build_plan(&tmp.path().join(".tsumugi"), &workflows, &[], false);
+        match result {
+            Err(err) => {
+                let msg = err.to_string();
+                assert!(msg.contains("--harness"), "{msg}");
+            }
+            Ok(_) => panic!("expected category-mismatch error"),
+        }
+    }
+
+    #[test]
+    fn build_plan_rejects_empty_selection() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        assert!(build_plan(&tmp.path().join(".tsumugi"), &[], &[], false).is_err());
+    }
+
+    #[test]
+    fn build_plan_dedups_repeats() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let workflows = vec!["plan".to_owned(), "plan".to_owned()];
+        let plan = build_plan(&tmp.path().join(".tsumugi"), &workflows, &[], false)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(plan.entries.len(), 1);
+    }
+
+    #[test]
+    fn detect_conflicts_finds_existing_files() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let plan = build_plan(
+            &tmp.path().join(".tsumugi"),
+            &["plan".to_owned()],
+            &[],
+            false,
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+        // Pre-create the target file to simulate a conflict.
+        let parent = plan.entries[0]
+            .target
+            .parent()
+            .unwrap_or_else(|| panic!("template target has no parent"));
+        std::fs::create_dir_all(parent).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(&plan.entries[0].target, "existing").unwrap_or_else(|e| panic!("{e}"));
+        let conflicts = detect_conflicts(&plan);
+        assert_eq!(conflicts.len(), 1);
+    }
+}

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -13,7 +13,9 @@ use tokio::sync::Mutex;
 mod config;
 mod error;
 mod harness_init;
+mod init_command;
 mod run_commands;
+mod workflow_commands;
 
 use config::{HarnessConfig, SandboxConfigSection, TsumugiConfig};
 
@@ -78,8 +80,7 @@ struct Cli {
     command: Option<Command>,
 }
 
-/// Top-level subcommand surface. Workflow / Init are scoped to #44 /
-/// #46 and intentionally omitted here.
+/// Top-level subcommand surface.
 #[derive(Subcommand, Debug)]
 enum Command {
     /// Run management (`tmg run <op>`). See SPEC §9.8.
@@ -88,6 +89,52 @@ enum Command {
         #[command(subcommand)]
         op: RunCommand,
     },
+    /// Workflow management (`tmg workflow <op>`). See SPEC §8.13.
+    Workflow {
+        /// Sub-operation on the workflow catalogue or runtime.
+        #[command(subcommand)]
+        op: WorkflowCommand,
+    },
+    /// Scaffold a `.tsumugi/` directory from the built-in templates.
+    Init(InitArgs),
+}
+
+/// Operations under `tmg workflow`. SPEC §8.13.
+#[derive(Subcommand, Debug)]
+enum WorkflowCommand {
+    /// List discovered workflows in a fixed-width table.
+    List,
+    /// Parse every discovered workflow and report failures.
+    ///
+    /// Exits non-zero when at least one workflow fails to parse.
+    Validate,
+    /// Run the named workflow with `--input k=v` pairs.
+    Run {
+        /// Workflow id (matches the `id:` field in the YAML).
+        workflow: String,
+        /// Repeatable `--input k=v` pair. The value is parsed as JSON
+        /// when it looks like JSON, falling back to a plain string.
+        #[arg(long = "input")]
+        inputs: Vec<String>,
+    },
+}
+
+/// Flags for `tmg init`.
+#[derive(clap::Args, Debug)]
+struct InitArgs {
+    /// Workflow templates to install (comma-separated).
+    #[arg(long, value_delimiter = ',')]
+    workflows: Vec<String>,
+    /// Long-running harness templates to install (comma-separated).
+    #[arg(long, value_delimiter = ',')]
+    harness: Vec<String>,
+    /// Install every built-in template.
+    #[arg(long)]
+    all: bool,
+    /// Overwrite existing files when conflicts are detected. Without
+    /// this flag, `tmg init` aborts and prints the conflict list.
+    #[arg(long)]
+    force: bool,
 }
 
 /// Operations under `tmg run`. SPEC §9.8.
@@ -190,6 +237,10 @@ fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Some(Command::Run { op }) => dispatch_run_command(op, &config),
+        Some(Command::Workflow { op }) => dispatch_workflow_command(op, &config),
+        Some(Command::Init(args)) => {
+            init_command::cmd_init(&args.workflows, &args.harness, args.all, args.force)
+        }
         None => {
             if let Some(prompt) = cli.prompt {
                 run_prompt(
@@ -227,6 +278,19 @@ fn resolve_runs_dir(harness_config: &HarnessConfig) -> anyhow::Result<(PathBuf, 
         canonical_cwd.join(&harness_config.runs_dir)
     };
     Ok((runs_dir, canonical_cwd))
+}
+
+/// Dispatch one `tmg workflow <op>` invocation. None of these
+/// operations attach to an active TUI; they all read or run workflows
+/// against the configured discovery scope.
+fn dispatch_workflow_command(op: WorkflowCommand, config: &TsumugiConfig) -> anyhow::Result<()> {
+    match op {
+        WorkflowCommand::List => workflow_commands::cmd_list(config),
+        WorkflowCommand::Validate => workflow_commands::cmd_validate(config),
+        WorkflowCommand::Run { workflow, inputs } => {
+            workflow_commands::cmd_run(&workflow, &inputs, config)
+        }
+    }
 }
 
 /// Dispatch one `tmg run <op>` invocation. The TUI-bound operations

--- a/tmg-cli/src/workflow_commands.rs
+++ b/tmg-cli/src/workflow_commands.rs
@@ -1,0 +1,646 @@
+//! Implementation of the `tmg workflow` subcommand family (issue #44).
+//!
+//! The three operations:
+//!
+//! - `list`: discover and tabulate available workflows.
+//! - `validate`: parse every YAML in the discovery scope and report
+//!   each failure with `path:line:col` precision.
+//! - `run`: load a workflow and execute it via either
+//!   [`WorkflowEngine`] or [`LongRunningExecutor`] depending on
+//!   `mode:`.
+//!
+//! All three commands are CI-friendly: structured output to stdout,
+//! errors to stderr, non-zero exit codes on failure.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use serde_json::Value;
+use tokio::sync::{Mutex, mpsc};
+use tokio_util::sync::CancellationToken;
+
+use tmg_harness::{RunRunner, RunStore};
+use tmg_workflow::{
+    LongRunningExecutor, RunStatus, WorkflowDef, WorkflowEngine, WorkflowError, WorkflowMode,
+    WorkflowProgress, discover_workflows, parse_workflow_file,
+};
+
+use crate::config::{HarnessConfig, TsumugiConfig};
+
+/// Parse a single `--input k=v` pair into `(key, value)`.
+///
+/// `v` is first parsed as JSON; if that fails the raw string is used.
+/// This means CLI users can write `--input flag=true`,
+/// `--input count=42`, or `--input note="hello"` and get the natural
+/// JSON typing.
+pub(crate) fn parse_input_pair(raw: &str) -> anyhow::Result<(String, Value)> {
+    let Some((key, value)) = raw.split_once('=') else {
+        anyhow::bail!("invalid --input '{raw}': expected key=value form");
+    };
+    if key.is_empty() {
+        anyhow::bail!("invalid --input '{raw}': key must not be empty");
+    }
+    let parsed: Value =
+        serde_json::from_str(value).unwrap_or_else(|_| Value::String(value.to_owned()));
+    Ok((key.to_owned(), parsed))
+}
+
+/// `tmg workflow list` — print a fixed-width table of every discovered
+/// workflow.
+#[expect(
+    clippy::print_stdout,
+    reason = "tmg workflow list prints a table to stdout by design"
+)]
+pub(crate) fn cmd_list(config: &TsumugiConfig) -> anyhow::Result<()> {
+    let project_root = std::env::current_dir().context("reading current working directory")?;
+    let canonical = project_root.canonicalize().unwrap_or(project_root);
+
+    let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
+    let metas = rt
+        .block_on(discover_workflows(&canonical, &config.workflow))
+        .context("discovering workflows")?;
+
+    if metas.is_empty() {
+        println!("(no workflows found)");
+        println!("Run `tmg init --all` to install built-in workflow templates.");
+        return Ok(());
+    }
+
+    let header = ["ID", "DESCRIPTION", "SOURCE"];
+    let rows: Vec<[String; 3]> = metas
+        .iter()
+        .map(|m| {
+            [
+                m.id.clone(),
+                m.description.clone().unwrap_or_else(|| "-".to_owned()),
+                m.source_path.display().to_string(),
+            ]
+        })
+        .collect();
+    let mut widths = header.map(str::len);
+    for row in &rows {
+        for (i, cell) in row.iter().enumerate() {
+            widths[i] = widths[i].max(cell.len());
+        }
+    }
+
+    let mut out = std::io::stdout().lock();
+    writeln!(
+        out,
+        "{:<w0$}  {:<w1$}  {:<w2$}",
+        header[0],
+        header[1],
+        header[2],
+        w0 = widths[0],
+        w1 = widths[1],
+        w2 = widths[2],
+    )?;
+    for row in &rows {
+        writeln!(
+            out,
+            "{:<w0$}  {:<w1$}  {:<w2$}",
+            row[0],
+            row[1],
+            row[2],
+            w0 = widths[0],
+            w1 = widths[1],
+            w2 = widths[2],
+        )?;
+    }
+    Ok(())
+}
+
+/// `tmg workflow validate` — parse every workflow YAML in the
+/// discovery scope and report failures.
+///
+/// On success, prints a one-line summary and returns `Ok(())`. On any
+/// failure, prints each diagnostic to stderr (with `path:line:col`
+/// when the underlying error carries it) and returns an error so the
+/// process exits non-zero.
+#[expect(
+    clippy::print_stdout,
+    reason = "tmg workflow validate prints success summary to stdout"
+)]
+#[expect(
+    clippy::print_stderr,
+    reason = "validation diagnostics belong on stderr"
+)]
+pub(crate) fn cmd_validate(config: &TsumugiConfig) -> anyhow::Result<()> {
+    let project_root = std::env::current_dir().context("reading current working directory")?;
+    let canonical = project_root.canonicalize().unwrap_or(project_root);
+
+    let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
+    let report = rt.block_on(async {
+        let metas = discover_workflows(&canonical, &config.workflow).await;
+        let metas = match metas {
+            Ok(m) => m,
+            Err(e) => return ValidationReport::discovery_failed(e),
+        };
+        let mut report = ValidationReport::default();
+        for meta in metas {
+            match parse_workflow_file(&meta.source_path).await {
+                Ok(_) => report.passed.push(meta.source_path.clone()),
+                Err(err) => report.failed.push((meta.source_path.clone(), err)),
+            }
+        }
+        report
+    });
+
+    if let Some(err) = report.discovery_error {
+        eprintln!("workflow discovery failed: {err}");
+        anyhow::bail!("validation aborted: discovery failure");
+    }
+
+    if report.passed.is_empty() && report.failed.is_empty() {
+        println!("(no workflows found to validate)");
+        return Ok(());
+    }
+
+    if report.failed.is_empty() {
+        println!(
+            "validated {n} workflow{s}",
+            n = report.passed.len(),
+            s = if report.passed.len() == 1 { "" } else { "s" },
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "{} of {} workflow file(s) failed to validate:",
+        report.failed.len(),
+        report.passed.len() + report.failed.len(),
+    );
+    for (path, err) in &report.failed {
+        eprintln!("\n--- {} ---", path.display());
+        // The parser's YAML errors include line/col automatically via
+        // `serde_yml::Error`. Rendering the error chain surfaces the
+        // path:line:col context in a stable shape.
+        eprintln!("{err}");
+    }
+    anyhow::bail!("workflow validation failed");
+}
+
+/// `tmg workflow run <id> --input k=v ...` — load a workflow and run
+/// it through the appropriate executor.
+///
+/// `inputs_raw` is the unparsed `Vec<String>` produced by clap; we
+/// fold it into a `BTreeMap` here so a mistyped pair surfaces with a
+/// clean error before any I/O happens.
+pub(crate) fn cmd_run(
+    workflow_id: &str,
+    inputs_raw: &[String],
+    config: &TsumugiConfig,
+) -> anyhow::Result<()> {
+    // 1. Parse the inputs first so we fail fast on bad CLI input.
+    let mut inputs: BTreeMap<String, Value> = BTreeMap::new();
+    for raw in inputs_raw {
+        let (k, v) = parse_input_pair(raw)?;
+        if inputs.insert(k.clone(), v).is_some() {
+            anyhow::bail!("duplicate --input key '{k}'");
+        }
+    }
+
+    let project_root = std::env::current_dir().context("reading current working directory")?;
+    let canonical = project_root.canonicalize().unwrap_or(project_root);
+
+    let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
+    rt.block_on(async move {
+        // 2. Discover and locate the named workflow.
+        let metas = discover_workflows(&canonical, &config.workflow)
+            .await
+            .context("discovering workflows")?;
+        let Some(meta) = metas.into_iter().find(|m| m.id == workflow_id) else {
+            anyhow::bail!(
+                "workflow '{workflow_id}' not found. Run `tmg workflow list` to see available workflows.",
+            );
+        };
+
+        // 3. Parse it into a canonical WorkflowDef.
+        let workflow = parse_workflow_file(&meta.source_path)
+            .await
+            .with_context(|| format!("parsing {}", meta.source_path.display()))?;
+
+        // 4. Validate inputs against the declared InputDef shape.
+        validate_inputs_shape(&workflow, &inputs)?;
+
+        // 5. Resolve runs_dir / store for any path the executor needs.
+        let runs_dir = resolve_runs_dir(&config.harness, &canonical);
+        let store = Arc::new(RunStore::new(runs_dir));
+
+        match workflow.mode {
+            WorkflowMode::Normal => run_normal(&workflow, inputs, &canonical, config).await,
+            WorkflowMode::LongRunning => {
+                run_long_running(&workflow, inputs, &canonical, &store, config).await
+            }
+            other => anyhow::bail!(
+                "unsupported workflow mode for this CLI: {other:?}. \
+                 The CLI handler may need an update.",
+            ),
+        }
+    })
+}
+
+/// Validate that every required input is present and that no obviously
+/// type-incompatible value was supplied for a declared input.
+///
+/// We accept extras (forward compatibility — see [`tmg_workflow`]'s
+/// `resolve_inputs`). Shape checks are intentionally lenient: the
+/// `type` field is free-form per SPEC §8.10, so we only enforce the
+/// rough "string vs number vs bool vs array vs object vs null" shape
+/// for the well-known type names.
+fn validate_inputs_shape(
+    workflow: &WorkflowDef,
+    inputs: &BTreeMap<String, Value>,
+) -> anyhow::Result<()> {
+    for (name, def) in &workflow.inputs {
+        if !inputs.contains_key(name) && def.required && def.default.is_none() {
+            anyhow::bail!("missing required --input '{name}'");
+        }
+        if let Some(value) = inputs.get(name) {
+            if !value_matches_type(&def.r#type, value) {
+                anyhow::bail!(
+                    "--input '{name}={shown}' does not match declared type '{ty}'",
+                    shown = render_value(value),
+                    ty = def.r#type,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Soft type-check helper. Returns `true` for unknown / loose types
+/// so workflows can declare semantic types like `"path"` without us
+/// rejecting any string.
+fn value_matches_type(ty: &str, value: &Value) -> bool {
+    match ty {
+        "string" => value.is_string(),
+        "integer" => value.is_i64() || value.is_u64(),
+        "number" | "float" => value.is_number(),
+        "boolean" | "bool" => value.is_boolean(),
+        "array" => value.is_array(),
+        "object" => value.is_object(),
+        // Loose types: anything goes.
+        _ => true,
+    }
+}
+
+fn render_value(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Run a `mode: normal` workflow against an ad-hoc engine. This is a
+/// CLI-driven path: we don't have a TUI to render `human` steps, so
+/// any `human` step that the workflow contains will block until
+/// timeout / cancellation. That is acceptable for the SPEC-described
+/// CLI workflows but should be flagged in docs.
+#[expect(
+    clippy::print_stderr,
+    reason = "WorkflowProgress events stream to stderr per SPEC §9.13"
+)]
+async fn run_normal(
+    workflow: &WorkflowDef,
+    inputs: BTreeMap<String, Value>,
+    canonical: &Path,
+    config: &TsumugiConfig,
+) -> anyhow::Result<()> {
+    let llm_pool = Arc::new(
+        tmg_llm::LlmPool::new(
+            &tmg_llm::PoolConfig::single(&config.llm.endpoint),
+            config.llm.model.clone(),
+        )
+        .context("constructing LlmPool")?,
+    );
+    let cancel = CancellationToken::new();
+    {
+        let cancel_for_handler = cancel.clone();
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                cancel_for_handler.cancel();
+            }
+        });
+    }
+    let llm_client = tmg_llm::LlmClient::new(tmg_llm::LlmClientConfig::new(
+        &config.llm.endpoint,
+        &config.llm.model,
+    ))
+    .context("constructing LlmClient")?;
+    let subagent_manager = Arc::new(Mutex::new(tmg_agents::SubagentManager::new(
+        llm_client,
+        cancel.clone(),
+        &config.llm.endpoint,
+        &config.llm.model,
+    )));
+    let sandbox = Arc::new(tmg_sandbox::SandboxContext::new(
+        tmg_sandbox::SandboxConfig::new(canonical)
+            .with_mode(tmg_sandbox::SandboxMode::WorkspaceWrite),
+    ));
+    let registry = Arc::new(tmg_tools::ToolRegistry::new());
+    let engine = WorkflowEngine::new(
+        llm_pool,
+        sandbox,
+        registry,
+        subagent_manager,
+        config.workflow.clone(),
+        Value::Null,
+    );
+
+    let (tx, mut rx) = mpsc::channel::<WorkflowProgress>(64);
+    let stream = async move {
+        while let Some(ev) = rx.recv().await {
+            match ev {
+                WorkflowProgress::StepStarted { step_id, step_type } => {
+                    eprintln!("[step:start] {step_id} ({step_type})");
+                }
+                WorkflowProgress::StepCompleted { step_id, .. } => {
+                    eprintln!("[step:done]  {step_id}");
+                }
+                WorkflowProgress::StepFailed { step_id, error } => {
+                    eprintln!("[step:fail]  {step_id}: {error}");
+                }
+                WorkflowProgress::LoopIteration {
+                    step_id,
+                    iteration,
+                    max,
+                } => {
+                    eprintln!("[loop]       {step_id} iteration {iteration}/{max}");
+                }
+                WorkflowProgress::HumanInputRequired { step_id, .. } => {
+                    eprintln!(
+                        "[human]      {step_id}: waiting for human input (CLI cannot answer; will time out)",
+                    );
+                }
+                WorkflowProgress::WorkflowCompleted { outputs } => {
+                    eprintln!("[workflow:done] {} output(s)", outputs.values.len());
+                }
+                _ => {}
+            }
+        }
+    };
+
+    let exec = engine.run_with_cancel(workflow, inputs, tx, cancel.clone());
+    let (outcome, ()) = tokio::join!(exec, stream);
+    let outputs = outcome.context("workflow execution failed")?;
+    eprintln!("\nworkflow '{}' completed", workflow.id);
+    if !outputs.values.is_empty() {
+        eprintln!("outputs:");
+        for (k, v) in &outputs.values {
+            eprintln!("  {k} = {v}");
+        }
+    }
+    Ok(())
+}
+
+/// Run a `mode: long_running` workflow through [`LongRunningExecutor`].
+///
+/// We synthesize a transient ad-hoc run (the executor will escalate it
+/// to harnessed during the init phase). The chosen workspace is the
+/// CLI's current cwd. This is the SPEC-prescribed bootstrap path for
+/// `tmg workflow run <long-running-id>` invocations from a fresh
+/// project.
+#[expect(clippy::print_stderr, reason = "executor diagnostics stream to stderr")]
+async fn run_long_running(
+    workflow: &WorkflowDef,
+    inputs: BTreeMap<String, Value>,
+    canonical: &Path,
+    store: &Arc<RunStore>,
+    config: &TsumugiConfig,
+) -> anyhow::Result<()> {
+    let cancel = CancellationToken::new();
+    {
+        let cancel_for_handler = cancel.clone();
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                cancel_for_handler.cancel();
+            }
+        });
+    }
+    // Use the latest resumable run for this workspace if one exists,
+    // otherwise create a fresh ad-hoc run. This mirrors the resume
+    // policy of the TUI startup path.
+    let run = match store
+        .latest_resumable(Some(canonical))
+        .context("looking up latest resumable run")?
+    {
+        Some(summary) => store.load(&summary.id).context("loading resumable run")?,
+        None => store
+            .create_ad_hoc(canonical.to_path_buf(), None)
+            .context("creating ad-hoc run for long-running workflow")?,
+    };
+    eprintln!("[long-running] using run {}", run.id.as_str());
+
+    let runner = Arc::new(Mutex::new(RunRunner::new(run, Arc::clone(store))));
+    let llm_pool = Arc::new(
+        tmg_llm::LlmPool::new(
+            &tmg_llm::PoolConfig::single(&config.llm.endpoint),
+            config.llm.model.clone(),
+        )
+        .context("constructing LlmPool")?,
+    );
+    let llm_client = tmg_llm::LlmClient::new(tmg_llm::LlmClientConfig::new(
+        &config.llm.endpoint,
+        &config.llm.model,
+    ))
+    .context("constructing LlmClient")?;
+    let subagent_manager = Arc::new(Mutex::new(tmg_agents::SubagentManager::new(
+        llm_client,
+        cancel.clone(),
+        &config.llm.endpoint,
+        &config.llm.model,
+    )));
+    let sandbox = Arc::new(tmg_sandbox::SandboxContext::new(
+        tmg_sandbox::SandboxConfig::new(canonical)
+            .with_mode(tmg_sandbox::SandboxMode::WorkspaceWrite),
+    ));
+    let registry = Arc::new(tmg_tools::ToolRegistry::new());
+    let engine = Arc::new(WorkflowEngine::new(
+        llm_pool,
+        sandbox,
+        registry,
+        subagent_manager,
+        config.workflow.clone(),
+        Value::Null,
+    ));
+    let executor = LongRunningExecutor::new(Arc::clone(&engine), Arc::clone(&runner));
+    let status = executor
+        .run(workflow, inputs)
+        .await
+        .context("long-running workflow execution failed")?;
+    match status {
+        RunStatus::Completed => eprintln!("[long-running] workflow completed"),
+        RunStatus::Exhausted { reason } => eprintln!("[long-running] exhausted ({reason})"),
+        RunStatus::Failed { error } => {
+            eprintln!("[long-running] failed: {error}");
+            anyhow::bail!("long-running workflow failed");
+        }
+        other => {
+            // The variant is `#[non_exhaustive]`; defensively log
+            // unknown future variants rather than panicking.
+            eprintln!("[long-running] unknown status: {other:?}");
+        }
+    }
+    Ok(())
+}
+
+/// Resolve the runs-dir against the canonical cwd.
+fn resolve_runs_dir(harness: &HarnessConfig, canonical: &Path) -> PathBuf {
+    if harness.runs_dir.is_absolute() {
+        harness.runs_dir.clone()
+    } else {
+        canonical.join(&harness.runs_dir)
+    }
+}
+
+/// Aggregated outcome of `cmd_validate`.
+#[derive(Default)]
+struct ValidationReport {
+    passed: Vec<PathBuf>,
+    failed: Vec<(PathBuf, WorkflowError)>,
+    discovery_error: Option<WorkflowError>,
+}
+
+impl ValidationReport {
+    fn discovery_failed(err: WorkflowError) -> Self {
+        Self {
+            passed: Vec::new(),
+            failed: Vec::new(),
+            discovery_error: Some(err),
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_input_pair_string() {
+        let (k, v) = parse_input_pair("name=hello").unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(k, "name");
+        assert_eq!(v, Value::String("hello".to_owned()));
+    }
+
+    #[test]
+    fn parse_input_pair_integer() {
+        let (k, v) = parse_input_pair("count=42").unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(k, "count");
+        assert_eq!(v.as_i64(), Some(42));
+    }
+
+    #[test]
+    fn parse_input_pair_bool() {
+        let (k, v) = parse_input_pair("flag=true").unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(k, "flag");
+        assert_eq!(v.as_bool(), Some(true));
+    }
+
+    #[test]
+    fn parse_input_pair_json_object() {
+        let (_, v) = parse_input_pair(r#"obj={"a":1}"#).unwrap_or_else(|e| panic!("{e}"));
+        assert!(v.is_object());
+    }
+
+    #[test]
+    fn parse_input_pair_falls_back_to_string_for_invalid_json() {
+        let (_, v) = parse_input_pair("note=hello world").unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(v, Value::String("hello world".to_owned()));
+    }
+
+    #[test]
+    fn parse_input_pair_rejects_missing_eq() {
+        assert!(parse_input_pair("badpair").is_err());
+    }
+
+    #[test]
+    fn parse_input_pair_rejects_empty_key() {
+        assert!(parse_input_pair("=value").is_err());
+    }
+
+    #[test]
+    fn value_matches_string_type() {
+        assert!(value_matches_type("string", &Value::String("x".to_owned())));
+        assert!(!value_matches_type("string", &Value::Bool(true)));
+    }
+
+    #[test]
+    fn value_matches_integer_type() {
+        assert!(value_matches_type("integer", &Value::from(7)));
+        assert!(!value_matches_type(
+            "integer",
+            &Value::String("7".to_owned())
+        ));
+    }
+
+    #[test]
+    fn value_matches_unknown_type_is_lenient() {
+        assert!(value_matches_type(
+            "path",
+            &Value::String("/tmp".to_owned())
+        ));
+    }
+
+    #[test]
+    fn validate_inputs_shape_passes_when_required_supplied() {
+        use std::collections::BTreeMap;
+        use tmg_workflow::InputDef;
+        let mut declared = BTreeMap::new();
+        declared.insert(
+            "name".to_owned(),
+            InputDef {
+                r#type: "string".to_owned(),
+                default: None,
+                required: true,
+                description: None,
+            },
+        );
+        let workflow = tmg_workflow::WorkflowDef::new("wf".to_owned()).with_inputs(declared);
+        let mut supplied = BTreeMap::new();
+        supplied.insert("name".to_owned(), Value::String("alice".to_owned()));
+        validate_inputs_shape(&workflow, &supplied).unwrap_or_else(|e| panic!("{e}"));
+    }
+
+    #[test]
+    fn validate_inputs_shape_rejects_missing_required() {
+        use std::collections::BTreeMap;
+        use tmg_workflow::InputDef;
+        let mut declared = BTreeMap::new();
+        declared.insert(
+            "name".to_owned(),
+            InputDef {
+                r#type: "string".to_owned(),
+                default: None,
+                required: true,
+                description: None,
+            },
+        );
+        let workflow = tmg_workflow::WorkflowDef::new("wf".to_owned()).with_inputs(declared);
+        let supplied: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(validate_inputs_shape(&workflow, &supplied).is_err());
+    }
+
+    #[test]
+    fn validate_inputs_shape_accepts_optional_missing() {
+        use std::collections::BTreeMap;
+        use tmg_workflow::InputDef;
+        let mut declared = BTreeMap::new();
+        declared.insert(
+            "verbose".to_owned(),
+            InputDef {
+                r#type: "boolean".to_owned(),
+                default: Some(Value::Bool(false)),
+                required: false,
+                description: None,
+            },
+        );
+        let workflow = tmg_workflow::WorkflowDef::new("wf".to_owned()).with_inputs(declared);
+        let supplied: BTreeMap<String, Value> = BTreeMap::new();
+        validate_inputs_shape(&workflow, &supplied).unwrap_or_else(|e| panic!("{e}"));
+    }
+}

--- a/tmg-cli/tests/init_and_workflow.rs
+++ b/tmg-cli/tests/init_and_workflow.rs
@@ -1,0 +1,275 @@
+//! End-to-end tests for the `tmg init` and `tmg workflow {list,validate}`
+//! subcommands (issue #44).
+//!
+//! These spawn the compiled `tmg` binary with `cargo` env knobs so we
+//! exercise the full clap → dispatch → tmg-workflow round-trip.
+//!
+//! `tmg workflow run` is exercised separately via the ad-hoc-run path
+//! when an LLM endpoint is reachable; the smoke variant here only
+//! checks the CLI surface (`--help`, `--input k=v` parsing).
+
+#![cfg(test)]
+#![expect(clippy::unwrap_used, reason = "tests")]
+#![expect(clippy::expect_used, reason = "tests")]
+
+use std::path::Path;
+use std::process::Command;
+
+/// Locate the `tmg` binary built by the current `cargo test`
+/// invocation. This lets us drive the binary as a black box without
+/// having to depend on `assert_cmd` or hardcode the target path.
+fn tmg_binary() -> std::path::PathBuf {
+    // Cargo sets CARGO_BIN_EXE_<name> for every binary defined in the
+    // crate under test. See:
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html
+    let path = env!("CARGO_BIN_EXE_tmg");
+    std::path::PathBuf::from(path)
+}
+
+/// Run the `tmg` binary in `cwd` with the given args, returning the
+/// `Output`.
+fn run_tmg(cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(tmg_binary())
+        .args(args)
+        .current_dir(cwd)
+        .env("TMG_LLM_ENDPOINT", "http://127.0.0.1:1") // unreachable; not used by list/validate
+        .output()
+        .expect("running tmg")
+}
+
+#[test]
+fn init_writes_workflow_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = run_tmg(tmp.path(), &["init", "--workflows", "plan,implement"]);
+    assert!(
+        out.status.success(),
+        "tmg init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(tmp.path().join(".tsumugi/workflows/plan.yaml").exists());
+    assert!(
+        tmp.path()
+            .join(".tsumugi/workflows/implement.yaml")
+            .exists()
+    );
+}
+
+#[test]
+fn init_without_force_refuses_to_overwrite() {
+    let tmp = tempfile::tempdir().unwrap();
+    let first = run_tmg(tmp.path(), &["init", "--workflows", "plan"]);
+    assert!(first.status.success());
+
+    // Re-running without --force should fail and not modify the file.
+    let original = std::fs::read(tmp.path().join(".tsumugi/workflows/plan.yaml")).unwrap();
+    let second = run_tmg(tmp.path(), &["init", "--workflows", "plan"]);
+    assert!(!second.status.success(), "second init should fail");
+    let after = std::fs::read(tmp.path().join(".tsumugi/workflows/plan.yaml")).unwrap();
+    assert_eq!(original, after, "init without --force must not overwrite");
+}
+
+#[test]
+fn init_all_force_overwrites_cleanly() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Pre-create one of the targets with custom content.
+    std::fs::create_dir_all(tmp.path().join(".tsumugi/workflows")).unwrap();
+    std::fs::write(tmp.path().join(".tsumugi/workflows/plan.yaml"), "stale").unwrap();
+
+    let out = run_tmg(tmp.path(), &["init", "--all", "--force"]);
+    assert!(
+        out.status.success(),
+        "tmg init --all --force failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let new_content =
+        std::fs::read_to_string(tmp.path().join(".tsumugi/workflows/plan.yaml")).unwrap();
+    assert_ne!(new_content, "stale", "expected --force to overwrite");
+    assert!(new_content.contains("id: plan"));
+
+    // Every other workflow template should also be present.
+    for fname in [
+        "plan.yaml",
+        "implement.yaml",
+        "review.yaml",
+        "refactor.yaml",
+        "build-app.yaml",
+        "migrate-codebase.yaml",
+        "add-feature.yaml",
+        "bug-fix-batch.yaml",
+    ] {
+        assert!(
+            tmp.path().join(".tsumugi/workflows").join(fname).exists(),
+            "missing workflow file {fname}",
+        );
+    }
+    assert!(tmp.path().join(".tsumugi/skills/develop/SKILL.md").exists());
+}
+
+#[test]
+fn workflow_list_finds_builtin_after_init() {
+    let tmp = tempfile::tempdir().unwrap();
+    let init = run_tmg(tmp.path(), &["init", "--all"]);
+    assert!(init.status.success());
+
+    let list = run_tmg(tmp.path(), &["workflow", "list"]);
+    assert!(
+        list.status.success(),
+        "tmg workflow list failed: {}",
+        String::from_utf8_lossy(&list.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    // The id of the plan workflow.
+    assert!(
+        stdout.contains("plan"),
+        "missing plan in list output:\n{stdout}"
+    );
+    // The id of the build_app workflow (note: SPEC uses snake_case ids).
+    assert!(
+        stdout.contains("build_app"),
+        "missing build_app in list output:\n{stdout}",
+    );
+}
+
+#[test]
+fn workflow_validate_passes_on_builtins() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(run_tmg(tmp.path(), &["init", "--all"]).status.success());
+    let out = run_tmg(tmp.path(), &["workflow", "validate"]);
+    assert!(
+        out.status.success(),
+        "validate failed:\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[test]
+fn workflow_validate_reports_broken_workflow() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(
+        run_tmg(tmp.path(), &["init", "--workflows", "plan"])
+            .status
+            .success()
+    );
+    // Inject a broken file alongside the good one.
+    std::fs::write(
+        tmp.path().join(".tsumugi/workflows/broken.yaml"),
+        "id: broken\nthis is not valid yaml: [unclosed\n",
+    )
+    .unwrap();
+    let out = run_tmg(tmp.path(), &["workflow", "validate"]);
+    assert!(
+        !out.status.success(),
+        "validate must fail when a workflow is broken; stdout: {}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("broken.yaml"),
+        "stderr should mention broken.yaml:\n{stderr}",
+    );
+}
+
+#[test]
+fn init_with_unknown_template_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = run_tmg(tmp.path(), &["init", "--workflows", "does-not-exist"]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("unknown template"), "{stderr}");
+}
+
+#[test]
+fn workflow_run_rejects_missing_required_input() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(
+        run_tmg(tmp.path(), &["init", "--workflows", "plan"])
+            .status
+            .success()
+    );
+    // The plan workflow declares `requirements` as required; omitting
+    // it must fail before any LLM call happens.
+    let out = run_tmg(tmp.path(), &["workflow", "run", "plan"]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("missing required") || stderr.contains("requirements"),
+        "stderr should mention missing input:\n{stderr}",
+    );
+}
+
+#[test]
+fn init_help_contains_template_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = run_tmg(tmp.path(), &["init", "--help"]);
+    assert!(out.status.success());
+}
+
+/// `tmg workflow run plan --input requirements="..."` must reach the
+/// engine and emit at least one `StepStarted` event (the engine emits
+/// `StepStarted` before invoking the leaf step's handler, so this
+/// works even when the LLM endpoint is unreachable).
+#[test]
+fn workflow_run_normal_emits_step_started() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(
+        run_tmg(tmp.path(), &["init", "--workflows", "plan"])
+            .status
+            .success()
+    );
+    let out = run_tmg(
+        tmp.path(),
+        &[
+            "workflow",
+            "run",
+            "plan",
+            "--input",
+            "requirements=Add a status command",
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // Don't assert success: the agent step needs an LLM and our test
+    // uses an unreachable endpoint. We only need to see the engine
+    // reach the first step.
+    assert!(
+        stderr.contains("[step:start] explore"),
+        "expected explore step to start; stderr={stderr}",
+    );
+}
+
+/// `tmg workflow run build_app` should dispatch to the long-running
+/// executor based on the workflow's declared `mode: long_running`.
+/// We verify dispatch indirectly by observing the
+/// `[long-running] using run <id>` line that the CLI prints to stderr
+/// before any LLM call. With an unreachable endpoint the executor will
+/// later fail; the existence of the diagnostic line is the thing
+/// that proves we took the long-running branch.
+#[test]
+fn workflow_run_long_running_routes_through_executor() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(
+        run_tmg(tmp.path(), &["init", "--harness", "build-app"])
+            .status
+            .success()
+    );
+    // build-app declares `app_description` as required; supply it so
+    // input validation passes.
+    let out = run_tmg(
+        tmp.path(),
+        &[
+            "workflow",
+            "run",
+            "build_app",
+            "--input",
+            "app_description=demo",
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The CLI must reach the long-running diagnostic, even though the
+    // run will eventually fail because the LLM endpoint is unreachable.
+    assert!(
+        stderr.contains("[long-running]"),
+        "expected long-running diagnostic; stdout={stdout}; stderr={stderr}",
+    );
+}


### PR DESCRIPTION
## Summary

Implements issue #44: the `tmg workflow` subcommand family
(`list`/`validate`/`run`), the `tmg init` scaffolder, and the
built-in workflow / harness / skill template catalogue exposed via
`tmg_workflow::templates`.

- 9 templates (4 workflows, 4 harness, 1 skill) embedded via
  `include_str!` — no new dep, no `build.rs`.
- A CI guard test runs every embedded YAML through
  `parse_workflow_str` so drift between the parser surface and the
  shipped templates is caught at compile-test time.
- `tmg workflow list` reuses the fixed-width table style already
  established by `tmg run list`.
- `tmg workflow validate` parses every discovered workflow and
  groups failures by file with the parser's existing line/col
  diagnostics; exits non-zero on any failure.
- `tmg workflow run <id> --input k=v ...` parses inputs (JSON-first,
  string fallback), validates them against the declared `InputDef`s,
  and dispatches `mode: long_running` workflows through
  `LongRunningExecutor` while keeping `mode: normal` workflows on the
  plain `WorkflowEngine::run_with_cancel` path. Per-step
  `[step:start]` / `[step:done]` / `[step:fail]` lines stream to
  stderr.
- `tmg init` is non-interactive and CI-friendly: it builds the install
  plan up front, refuses on conflicts unless `--force` is passed, and
  surfaces unknown / mis-categorised template names with actionable
  errors.

## Modified / new crates

- `tmg-workflow`: new `templates` module + `templates/` subdirectory
  with the embedded YAML/MD assets.
- `tmg-cli`: new `workflow_commands` and `init_command` modules wired
  into `main.rs` via `Command::Workflow` / `Command::Init`.

## Trade-offs documented in code

- `include_str!` over `include_dir` (smaller dep surface; one-line
  registry update per template).
- Refuse-on-conflict over interactive merge (preserves CI usability).
- Soft type-check on `--input` values (free-form `type:` field per
  SPEC §8.10 means we only enforce the well-known shapes;
  semantic types like `"path"` are accepted as-is).

## Tests

- 4 unit tests in `tmg-workflow::templates::tests` (parse round-trip,
  read-arm coverage, name uniqueness, find round-trip).
- 13 unit tests in `tmg-cli::workflow_commands::tests` covering
  `parse_input_pair`, `value_matches_type`, and
  `validate_inputs_shape`.
- 7 unit tests in `tmg-cli::init_command::tests` covering the
  `build_plan` / `detect_conflicts` algebra.
- 11 integration tests in `tmg-cli/tests/init_and_workflow.rs` that
  spawn the compiled `tmg` binary against a tempdir and exercise:
  - `tmg init --workflows plan,implement` writes both files.
  - `tmg init` without `--force` refuses to overwrite.
  - `tmg init --all --force` overwrites cleanly.
  - `tmg workflow list` finds builtins after `tmg init --all`.
  - `tmg workflow validate` passes on builtins; fails when a
    broken file is injected.
  - `tmg workflow run plan --input requirements="..."` reaches
    the engine and emits `[step:start] explore`.
  - `tmg workflow run build_app` dispatches to
    `LongRunningExecutor`.

## Quality gates

- `cargo build --workspace`: clean
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `cargo test --workspace`: all green

## Runtime Verification

- LLM server: available
- One-shot mode: PASS
  - Events: `Hello!` token + clean `[done]`, no errors.
- `tmg workflow run plan --input requirements=...`: PASS
  - Full run end-to-end through explore -> draft -> audit_loop with
    a real LLM; emitted `[step:start]` / `[step:done]` for each step
    and a final `WorkflowCompleted` with the rendered plan output.
- `tmg init --all` + `tmg workflow list` + `tmg workflow validate`
  on a fresh tempdir: PASS (8 workflows discovered, all validated).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] Manual: `tmg init --all` + `tmg workflow list/validate`
- [x] Manual: `tmg workflow run plan --input requirements=...` against live LLM

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)