### PR TITLE
tmg-tui: scope upgrade banner / /run / /workflows / human prompt UI (#46)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
  "tmg-harness",
  "tmg-llm",
  "tmg-sandbox",
+ "tmg-skills",
  "tmg-tools",
  "tmg-workflow",
  "tokio",

--- a/crates/tmg-skills/src/lib.rs
+++ b/crates/tmg-skills/src/lib.rs
@@ -37,7 +37,7 @@ pub use discovery::{discover_skills, discover_skills_with_config};
 pub use error::SkillError;
 pub use loader::{format_skill_for_tool_result, format_skill_metadata, load_skill};
 pub use parse::parse_skill_md;
-pub use slash::{format_skills_list, parse_slash_command};
+pub use slash::{SlashParseError, SlashParseResult, format_skills_list, parse_slash_command};
 pub use tool::UseSkillTool;
 pub use types::{
     InvocationPolicy, SkillContent, SkillFrontmatter, SkillMeta, SkillName, SkillPath, SkillSource,

--- a/crates/tmg-skills/src/slash.rs
+++ b/crates/tmg-skills/src/slash.rs
@@ -104,6 +104,15 @@ pub fn parse_slash_command(input: &str) -> SlashParseResult {
         None => (rest, None),
     };
 
+    // A leading-whitespace input like "/  foo" splits into
+    // (command = "", args = Some("foo")), which would otherwise be
+    // dispatched as `InvokeSkill { name: "" }`. An empty skill name is
+    // never valid, so fall through to chat (the same path taken by a
+    // bare `/`).
+    if command.is_empty() {
+        return Ok(None);
+    }
+
     // Built-in commands first; the broad-net "any other /foo is a
     // skill invocation" path lives at the bottom so it never shadows
     // a typed command.
@@ -258,6 +267,16 @@ mod tests {
     fn parse_empty_slash() {
         let cmd = parse_slash_command("/").expect("ok");
         assert_eq!(cmd, None);
+    }
+
+    #[test]
+    fn parse_slash_with_leading_whitespace_is_not_skill() {
+        // Inputs like "/  foo" and "/ " must not produce a skill
+        // invocation with an empty name; they should fall through to
+        // chat (Ok(None)).
+        assert_eq!(parse_slash_command("/  foo").expect("ok"), None);
+        assert_eq!(parse_slash_command("/ ").expect("ok"), None);
+        assert_eq!(parse_slash_command("/\t").expect("ok"), None);
     }
 
     #[test]

--- a/crates/tmg-skills/src/slash.rs
+++ b/crates/tmg-skills/src/slash.rs
@@ -1,24 +1,93 @@
-//! Slash command parsing for skill invocation.
+//! Slash command parsing for skill invocation and TUI-level commands.
 //!
 //! Supports:
 //! - `/skills` — list all installed skills
 //! - `/<skill-name>` — invoke a skill explicitly (with optional arguments)
+//! - `/clear`, `/compact`, `/exit`, `/quit`, `/agents`, `/workflows`
+//! - `/run start|resume|list|status|upgrade|downgrade|new-session|pause|abort ...`
+//!
+//! Anything beginning with `/run ` falls through a dedicated parser
+//! that returns either a typed [`SlashCommand`] or a structured
+//! [`SlashParseError`] when the subcommand is unknown / mistyped.
+//! Other slashes (`/skill-name`, `/agents`, ...) parse straight into
+//! their typed variants. Returning an error rather than `None` for
+//! malformed `/run` input lets the TUI surface a precise message.
 
 use std::fmt::Write as _;
 
 use crate::types::{SkillName, SlashCommand};
 
+/// Errors produced by [`parse_slash_command`] for input that *looked*
+/// like a slash command but failed to match any known shape.
+///
+/// The TUI uses the `Display` impl directly to feed `App::set_error`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashParseError {
+    /// `/run` was supplied without a subcommand (or with an unknown
+    /// one). The carried string is the raw remainder after `/run`.
+    UnknownRunSubcommand(String),
+    /// `/run start` requires a workflow id.
+    MissingWorkflowId,
+}
+
+impl std::fmt::Display for SlashParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownRunSubcommand(rest) => {
+                if rest.is_empty() {
+                    write!(
+                        f,
+                        "/run requires a subcommand: start, resume, list, status, \
+                         upgrade, downgrade, new-session, pause, or abort"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "unknown /run subcommand: {rest:?}; expected one of \
+                         start, resume, list, status, upgrade, downgrade, \
+                         new-session, pause, abort"
+                    )
+                }
+            }
+            Self::MissingWorkflowId => {
+                write!(
+                    f,
+                    "/run start requires a workflow id (e.g. /run start build)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SlashParseError {}
+
+/// Outcome of [`parse_slash_command`]:
+///
+/// * `Ok(Some(cmd))` — the input was a recognised slash command.
+/// * `Ok(None)` — the input was not a slash command at all (no leading
+///   `/`, or just `/`). Callers should treat this as ordinary chat
+///   text.
+/// * `Err(SlashParseError)` — the input was a slash command but had a
+///   malformed subcommand. Surface to the user.
+pub type SlashParseResult = Result<Option<SlashCommand>, SlashParseError>;
+
 /// Try to parse user input as a slash command.
 ///
-/// Returns `None` if the input does not start with `/` or is not a
-/// recognized command pattern.
-pub fn parse_slash_command(input: &str) -> Option<SlashCommand> {
+/// Returns:
+/// - `Ok(Some(cmd))` when the input matches a known command.
+/// - `Ok(None)` when the input is not a slash command at all.
+/// - `Err(SlashParseError)` when the input *looked* like a command but
+///   could not be parsed (currently only the `/run` family produces
+///   structured errors).
+pub fn parse_slash_command(input: &str) -> SlashParseResult {
     let trimmed = input.trim();
 
-    let rest = trimmed.strip_prefix('/')?;
+    let Some(rest) = trimmed.strip_prefix('/') else {
+        return Ok(None);
+    };
 
     if rest.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     // Split into command name and optional arguments.
@@ -35,15 +104,82 @@ pub fn parse_slash_command(input: &str) -> Option<SlashCommand> {
         None => (rest, None),
     };
 
-    if command == "skills" {
-        return Some(SlashCommand::ListSkills);
+    // Built-in commands first; the broad-net "any other /foo is a
+    // skill invocation" path lives at the bottom so it never shadows
+    // a typed command.
+    match command {
+        "skills" => return Ok(Some(SlashCommand::ListSkills)),
+        "clear" => return Ok(Some(SlashCommand::Clear)),
+        "compact" => return Ok(Some(SlashCommand::Compact)),
+        "exit" | "quit" => return Ok(Some(SlashCommand::Exit)),
+        "agents" => return Ok(Some(SlashCommand::ListAgents)),
+        "workflows" => return Ok(Some(SlashCommand::ListWorkflows)),
+        "run" => return parse_run_subcommand(args.as_deref()).map(Some),
+        _ => {}
     }
 
     // Any other `/foo` is treated as a skill invocation.
-    Some(SlashCommand::InvokeSkill {
+    Ok(Some(SlashCommand::InvokeSkill {
         name: SkillName::new(command),
         args,
-    })
+    }))
+}
+
+/// Parse the body of a `/run ...` invocation.
+///
+/// `args` is the trimmed remainder after `/run`. The empty / `None`
+/// case maps to [`SlashParseError::UnknownRunSubcommand`] with an empty
+/// remainder so the user sees the full subcommand list.
+fn parse_run_subcommand(args: Option<&str>) -> Result<SlashCommand, SlashParseError> {
+    let body = args.unwrap_or("").trim();
+    if body.is_empty() {
+        return Err(SlashParseError::UnknownRunSubcommand(String::new()));
+    }
+    let (sub, rest) = match body.split_once(char::is_whitespace) {
+        Some((s, r)) => (s, r.trim()),
+        None => (body, ""),
+    };
+    let rest_opt = if rest.is_empty() {
+        None
+    } else {
+        Some(rest.to_owned())
+    };
+
+    match sub {
+        "start" => {
+            // First whitespace-delimited token after `start` is the
+            // workflow id; anything past that becomes the trailing
+            // `args` string for the TUI to pass to the tool.
+            let body_after_start = rest;
+            if body_after_start.is_empty() {
+                return Err(SlashParseError::MissingWorkflowId);
+            }
+            let (workflow, args_after) = match body_after_start.split_once(char::is_whitespace) {
+                Some((w, a)) => (w.to_owned(), {
+                    let trimmed = a.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_owned())
+                    }
+                }),
+                None => (body_after_start.to_owned(), None),
+            };
+            Ok(SlashCommand::RunStart {
+                workflow,
+                args: args_after,
+            })
+        }
+        "resume" => Ok(SlashCommand::RunResume { run_id: rest_opt }),
+        "list" => Ok(SlashCommand::RunList),
+        "status" => Ok(SlashCommand::RunStatus { run_id: rest_opt }),
+        "upgrade" => Ok(SlashCommand::RunUpgrade),
+        "downgrade" => Ok(SlashCommand::RunDowngrade),
+        "new-session" | "new_session" => Ok(SlashCommand::RunNewSession),
+        "pause" => Ok(SlashCommand::RunPause),
+        "abort" => Ok(SlashCommand::RunAbort),
+        other => Err(SlashParseError::UnknownRunSubcommand(other.to_owned())),
+    }
 }
 
 /// Format a list of skills for display (e.g. in TUI).
@@ -73,24 +209,30 @@ impl std::fmt::Display for crate::types::InvocationPolicy {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::match_wildcard_for_single_variants,
+    reason = "tests assert with expect/panic for clarity; the workspace policy denies them in production code"
+)]
 mod tests {
     use super::*;
 
     #[test]
     fn parse_skills_command() {
-        let cmd = parse_slash_command("/skills");
+        let cmd = parse_slash_command("/skills").expect("ok");
         assert_eq!(cmd, Some(SlashCommand::ListSkills));
     }
 
     #[test]
     fn parse_skills_command_with_whitespace() {
-        let cmd = parse_slash_command("  /skills  ");
+        let cmd = parse_slash_command("  /skills  ").expect("ok");
         assert_eq!(cmd, Some(SlashCommand::ListSkills));
     }
 
     #[test]
     fn parse_skill_invocation_no_args() {
-        let cmd = parse_slash_command("/code-review");
+        let cmd = parse_slash_command("/code-review").expect("ok");
         assert_eq!(
             cmd,
             Some(SlashCommand::InvokeSkill {
@@ -102,7 +244,7 @@ mod tests {
 
     #[test]
     fn parse_skill_invocation_with_args() {
-        let cmd = parse_slash_command("/test-runner src/main.rs");
+        let cmd = parse_slash_command("/test-runner src/main.rs").expect("ok");
         assert_eq!(
             cmd,
             Some(SlashCommand::InvokeSkill {
@@ -114,14 +256,140 @@ mod tests {
 
     #[test]
     fn parse_empty_slash() {
-        let cmd = parse_slash_command("/");
+        let cmd = parse_slash_command("/").expect("ok");
         assert_eq!(cmd, None);
     }
 
     #[test]
     fn parse_no_slash() {
-        let cmd = parse_slash_command("hello world");
+        let cmd = parse_slash_command("hello world").expect("ok");
         assert_eq!(cmd, None);
+    }
+
+    #[test]
+    fn parse_clear_compact_exit_quit() {
+        assert_eq!(
+            parse_slash_command("/clear").expect("ok"),
+            Some(SlashCommand::Clear)
+        );
+        assert_eq!(
+            parse_slash_command("/compact").expect("ok"),
+            Some(SlashCommand::Compact)
+        );
+        assert_eq!(
+            parse_slash_command("/exit").expect("ok"),
+            Some(SlashCommand::Exit)
+        );
+        assert_eq!(
+            parse_slash_command("/quit").expect("ok"),
+            Some(SlashCommand::Exit)
+        );
+    }
+
+    #[test]
+    fn parse_agents_workflows() {
+        assert_eq!(
+            parse_slash_command("/agents").expect("ok"),
+            Some(SlashCommand::ListAgents)
+        );
+        assert_eq!(
+            parse_slash_command("/workflows").expect("ok"),
+            Some(SlashCommand::ListWorkflows)
+        );
+    }
+
+    #[test]
+    fn parse_run_start() {
+        assert_eq!(
+            parse_slash_command("/run start build").expect("ok"),
+            Some(SlashCommand::RunStart {
+                workflow: "build".to_owned(),
+                args: None,
+            })
+        );
+        assert_eq!(
+            parse_slash_command("/run start build target=foo").expect("ok"),
+            Some(SlashCommand::RunStart {
+                workflow: "build".to_owned(),
+                args: Some("target=foo".to_owned()),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_run_start_without_workflow_errors() {
+        let err = parse_slash_command("/run start").expect_err("missing workflow id");
+        assert_eq!(err, SlashParseError::MissingWorkflowId);
+    }
+
+    #[test]
+    fn parse_run_subcommands() {
+        assert_eq!(
+            parse_slash_command("/run resume").expect("ok"),
+            Some(SlashCommand::RunResume { run_id: None })
+        );
+        assert_eq!(
+            parse_slash_command("/run resume 1234abcd").expect("ok"),
+            Some(SlashCommand::RunResume {
+                run_id: Some("1234abcd".to_owned()),
+            })
+        );
+        assert_eq!(
+            parse_slash_command("/run list").expect("ok"),
+            Some(SlashCommand::RunList)
+        );
+        assert_eq!(
+            parse_slash_command("/run status").expect("ok"),
+            Some(SlashCommand::RunStatus { run_id: None })
+        );
+        assert_eq!(
+            parse_slash_command("/run status 1234abcd").expect("ok"),
+            Some(SlashCommand::RunStatus {
+                run_id: Some("1234abcd".to_owned()),
+            })
+        );
+        assert_eq!(
+            parse_slash_command("/run upgrade").expect("ok"),
+            Some(SlashCommand::RunUpgrade)
+        );
+        assert_eq!(
+            parse_slash_command("/run downgrade").expect("ok"),
+            Some(SlashCommand::RunDowngrade)
+        );
+        assert_eq!(
+            parse_slash_command("/run new-session").expect("ok"),
+            Some(SlashCommand::RunNewSession)
+        );
+        assert_eq!(
+            parse_slash_command("/run new_session").expect("ok"),
+            Some(SlashCommand::RunNewSession)
+        );
+        assert_eq!(
+            parse_slash_command("/run pause").expect("ok"),
+            Some(SlashCommand::RunPause)
+        );
+        assert_eq!(
+            parse_slash_command("/run abort").expect("ok"),
+            Some(SlashCommand::RunAbort)
+        );
+    }
+
+    #[test]
+    fn parse_run_unknown_subcommand_errors() {
+        let err = parse_slash_command("/run bogus").expect_err("unknown subcommand");
+        match err {
+            SlashParseError::UnknownRunSubcommand(rest) => assert_eq!(rest, "bogus"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_run_without_subcommand_errors() {
+        let err = parse_slash_command("/run").expect_err("missing subcommand");
+        match err {
+            SlashParseError::UnknownRunSubcommand(rest) => assert!(rest.is_empty()),
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/tmg-skills/src/types.rs
+++ b/crates/tmg-skills/src/types.rs
@@ -192,7 +192,14 @@ pub struct SkillContent {
 // ---------------------------------------------------------------------------
 
 /// A parsed slash command from user input.
+///
+/// The variants below cover both skill-related commands (the original
+/// scope of this enum) and TUI-level operations (clear, exit, run-
+/// management, workflow listing) consolidated here in issue #46 so a
+/// single `dispatch_slash` site in `tmg-tui` can route every slash
+/// command through one match.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum SlashCommand {
     /// `/skills` — list all installed skills.
     ListSkills,
@@ -204,4 +211,51 @@ pub enum SlashCommand {
         /// Optional arguments passed after the skill name.
         args: Option<String>,
     },
+
+    // ---- TUI-level commands (issue #46) ----------------------------------
+    /// `/clear` — wipe chat & tool log and reload the prompt files.
+    Clear,
+    /// `/compact` — trigger a context compression turn.
+    Compact,
+    /// `/exit` (or `/quit`) — request the application to exit.
+    Exit,
+    /// `/agents` — show the list of available subagent types and live
+    /// subagent statuses.
+    ListAgents,
+    /// `/workflows` — show the list of discovered workflows.
+    ListWorkflows,
+
+    // ---- /run subcommands (SPEC §9.8) ------------------------------------
+    /// `/run start <workflow> [args]` — start a workflow run.
+    RunStart {
+        /// Workflow id (matches `WorkflowDef::id`).
+        workflow: String,
+        /// Optional remaining arguments string (typically `key=value`
+        /// pairs). The TUI passes this through to the workflow tool.
+        args: Option<String>,
+    },
+    /// `/run resume [<id>]` — resume a paused or backgrounded run.
+    RunResume {
+        /// Optional explicit run id; when `None` the TUI defers to the
+        /// auto-resume policy (most-recent resumable run).
+        run_id: Option<String>,
+    },
+    /// `/run list` — list all runs in the run store.
+    RunList,
+    /// `/run status [<id>]` — show status of a run.
+    RunStatus {
+        /// Optional run id; when `None` the active run is used.
+        run_id: Option<String>,
+    },
+    /// `/run upgrade` — promote the active run to harnessed scope.
+    RunUpgrade,
+    /// `/run downgrade` — demote the active run back to ad-hoc.
+    RunDowngrade,
+    /// `/run new-session` — manually rotate to a fresh session.
+    RunNewSession,
+    /// `/run pause` — flip the active run to `Paused`.
+    RunPause,
+    /// `/run abort` — flip the active run to `Failed { reason: "user
+    /// aborted" }`.
+    RunAbort,
 }

--- a/crates/tmg-tui/Cargo.toml
+++ b/crates/tmg-tui/Cargo.toml
@@ -10,6 +10,7 @@ tmg-core = { workspace = true }
 tmg-llm = { workspace = true }
 tmg-agents = { workspace = true }
 tmg-harness = { workspace = true }
+tmg-skills = { workspace = true }
 tmg-workflow = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -8,7 +8,8 @@ use tmg_agents::{AgentType, CustomAgentDef, SubagentManager, truncate_str};
 use tmg_core::{AgentLoop, CoreError, StreamSink, format_context_usage};
 use tmg_harness::{HarnessStreamSink, RunProgressEvent, RunRunner, RunSummary};
 use tmg_llm::Role;
-use tmg_workflow::WorkflowProgress;
+use tmg_skills::SlashCommand;
+use tmg_workflow::{WorkflowMeta, WorkflowProgress};
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -18,7 +19,24 @@ use crate::activity::{
     ActivityPane, RunHeader, RunProgressSection, ToolActivityEntry as ActivityEntry,
     WorkflowProgressSection,
 };
+use crate::banner::TransientBanner;
 use crate::diff::DiffPreview;
+use crate::human_prompt::HumanPrompt;
+
+/// Outcome of [`App::submit_input`].
+#[derive(Debug)]
+pub enum SubmitDecision {
+    /// The input was empty (or `/`); nothing to do.
+    Nothing,
+    /// Start a regular conversation turn with the carried text.
+    StartTurn(String),
+    /// Dispatch the carried slash command via [`App::dispatch_slash`]
+    /// or the event loop's async dispatcher.
+    SlashCommand(SlashCommand),
+    /// The slash parser surfaced a structured error; surface it to the
+    /// user via the standard error overlay.
+    ParseError(String),
+}
 
 /// Represents a single entry in the chat display.
 #[derive(Debug, Clone)]
@@ -205,6 +223,26 @@ pub struct App {
     /// stray `git log -p` / `cat foo.diff` blobs no longer overwrite a
     /// legitimate `file_write` / `file_patch` preview.
     last_shell_exec_was_git_diff: bool,
+
+    /// Optional transient banner overlaid on the chat pane (SPEC §7.1
+    /// scope-upgrade notification). Cleared by the event loop once
+    /// `is_expired()` returns `true`.
+    transient_banner: Option<TransientBanner>,
+
+    /// Optional in-flight `human` step prompt (SPEC §8.4). When `Some`,
+    /// the chat pane is overlaid with the modal and key events are
+    /// consumed by [`crate::event::handle_human_prompt_key`] until the
+    /// prompt is dismissed.
+    human_prompt: Option<HumanPrompt>,
+
+    /// Discovered workflows for `/workflows` listing. Loaded once at
+    /// startup; the TUI does not refresh this list at runtime.
+    workflows: Vec<WorkflowMeta>,
+
+    /// Pending slash command awaiting async dispatch. Populated by
+    /// [`Self::dispatch_slash`] (`SlashDispatch::Async`) and
+    /// drained by the event loop on the next tick.
+    pending_slash: Option<SlashCommand>,
 }
 
 impl App {
@@ -244,7 +282,83 @@ impl App {
             run_progress_rx: None,
             workflow_progress_rx: None,
             last_shell_exec_was_git_diff: false,
+            transient_banner: None,
+            human_prompt: None,
+            workflows: Vec::new(),
+            pending_slash: None,
         }
+    }
+
+    /// Dequeue any pending async slash command so the event loop can
+    /// dispatch it. Returns `None` when nothing is queued.
+    pub fn take_pending_slash(&mut self) -> Option<SlashCommand> {
+        self.pending_slash.take()
+    }
+
+    /// Enqueue a slash command for async dispatch. Internal helper so
+    /// [`Self::dispatch_slash`] can defer commands without
+    /// owning the runtime.
+    fn enqueue_async_slash(&mut self, cmd: SlashCommand) {
+        self.pending_slash = Some(cmd);
+    }
+
+    /// Replace the discovered workflows list (used by `/workflows`).
+    pub fn set_workflows(&mut self, workflows: Vec<WorkflowMeta>) {
+        self.workflows = workflows;
+    }
+
+    /// Borrow the discovered workflows.
+    #[must_use]
+    pub fn workflows(&self) -> &[WorkflowMeta] {
+        &self.workflows
+    }
+
+    /// Borrow the active transient banner, if any.
+    #[must_use]
+    pub fn transient_banner(&self) -> Option<&TransientBanner> {
+        self.transient_banner.as_ref()
+    }
+
+    /// Set or replace the transient banner.
+    pub fn set_transient_banner(&mut self, banner: TransientBanner) {
+        self.transient_banner = Some(banner);
+    }
+
+    /// Clear the transient banner if it has expired. Returns `true`
+    /// when a banner was cleared (so the event loop can request a
+    /// redraw).
+    pub fn expire_banner_if_due(&mut self) -> bool {
+        if self
+            .transient_banner
+            .as_ref()
+            .is_some_and(TransientBanner::is_expired)
+        {
+            self.transient_banner = None;
+            return true;
+        }
+        false
+    }
+
+    /// Borrow the active human prompt, if any.
+    #[must_use]
+    pub fn human_prompt(&self) -> Option<&HumanPrompt> {
+        self.human_prompt.as_ref()
+    }
+
+    /// Borrow the active human prompt mutably.
+    pub fn human_prompt_mut(&mut self) -> Option<&mut HumanPrompt> {
+        self.human_prompt.as_mut()
+    }
+
+    /// Whether a human prompt modal is currently active.
+    #[must_use]
+    pub fn has_human_prompt(&self) -> bool {
+        self.human_prompt.is_some()
+    }
+
+    /// Take the active human prompt, leaving `None` in its place.
+    pub fn take_human_prompt(&mut self) -> Option<HumanPrompt> {
+        self.human_prompt.take()
     }
 
     /// Attach a workflow progress receiver.
@@ -309,6 +423,13 @@ impl App {
     /// [`HarnessStreamSink`].
     pub fn set_runner(&mut self, runner: Arc<Mutex<RunRunner>>) {
         self.runner = Some(runner);
+    }
+
+    /// Borrow the shared [`RunRunner`] handle, if any. The async slash
+    /// dispatcher uses this to drive `tmg_harness::commands` calls.
+    #[must_use]
+    pub fn runner(&self) -> Option<&Arc<Mutex<RunRunner>>> {
+        self.runner.as_ref()
     }
 
     /// Return the active run, if any.
@@ -491,26 +612,38 @@ impl App {
         self.cursor_pos = self.input.len();
     }
 
-    /// Submit the current input. Returns `Some(text)` if a conversation
-    /// turn should be started, `None` if the input was empty or a slash
-    /// command was handled.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `CoreError` if slash command processing fails.
-    pub fn submit_input(&mut self) -> Result<Option<String>, CoreError> {
+    /// Submit the current input. Returns one of:
+    /// * [`SubmitDecision::StartTurn(text)`] — a regular chat message
+    ///   that the event loop should drive through `start_turn`.
+    /// * [`SubmitDecision::SlashCommand(cmd)`] — a parsed slash command
+    ///   that the event loop should dispatch via the async dispatcher
+    ///   (the event loop's `dispatch_slash_async`). The TUI keeps slash
+    ///   dispatch out of `App` so the async harness/runner calls can
+    ///   live alongside the rest of the event-loop async wiring.
+    /// * [`SubmitDecision::Nothing`] — the input was empty.
+    /// * [`SubmitDecision::ParseError(msg)`] — the slash parser
+    ///   rejected the input. The event loop surfaces the message via
+    ///   the standard error overlay.
+    pub fn submit_input(&mut self) -> SubmitDecision {
         let text = self.input.trim().to_owned();
         self.input.clear();
         self.cursor_pos = 0;
 
         if text.is_empty() {
-            return Ok(None);
+            return SubmitDecision::Nothing;
         }
 
-        // Handle slash commands.
-        if let Some(cmd) = text.strip_prefix('/') {
-            self.handle_slash_command(cmd)?;
-            return Ok(None);
+        // Slash commands: parse here; dispatch in the event loop.
+        if text.starts_with('/') {
+            match tmg_skills::parse_slash_command(&text) {
+                Ok(Some(cmd)) => return SubmitDecision::SlashCommand(cmd),
+                Ok(None) => {
+                    // A bare `/` falls through as ordinary chat input.
+                }
+                Err(e) => {
+                    return SubmitDecision::ParseError(e.to_string());
+                }
+            }
         }
 
         // Add user entry to chat.
@@ -519,7 +652,7 @@ impl App {
             text: text.clone(),
         });
 
-        Ok(Some(text))
+        SubmitDecision::StartTurn(text)
     }
 
     /// Whether the `/compact` command needs to run asynchronously.
@@ -595,13 +728,19 @@ impl App {
         });
     }
 
-    /// Handle a slash command. Returns `Ok(())` if handled.
-    fn handle_slash_command(&mut self, cmd: &str) -> Result<(), CoreError> {
-        match cmd.trim() {
-            "exit" | "quit" => {
+    /// Dispatch a parsed slash command, handling synchronous variants
+    /// in-place and queuing async ones via [`Self::take_pending_slash`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`CoreError`] when `/clear` fails to reload the prompt
+    /// files. Other failure paths surface via `error_message`.
+    pub fn dispatch_slash(&mut self, cmd: SlashCommand) -> Result<(), CoreError> {
+        match cmd {
+            SlashCommand::Exit => {
                 self.should_exit = true;
             }
-            "clear" => {
+            SlashCommand::Clear => {
                 self.chat_entries.clear();
                 self.activity.tool_log.clear();
                 self.activity.diff_preview = None;
@@ -610,7 +749,7 @@ impl App {
                     agent.clear_history(&self.project_root, &self.cwd)?;
                 }
             }
-            "compact" => {
+            SlashCommand::Compact => {
                 if self.agent.is_some() {
                     self.pending_compact = true;
                     self.chat_entries.push(ChatEntry {
@@ -621,11 +760,32 @@ impl App {
                     self.error_message = Some("Cannot compact while a turn is running".to_owned());
                 }
             }
-            "agents" => {
+            SlashCommand::ListAgents => {
                 self.show_agents_list();
             }
+            SlashCommand::ListWorkflows => {
+                self.show_workflows_list();
+            }
+            // The /run family and /<skill> need async work (harness
+            // mutex, workflow tools). Defer to the event loop.
+            other @ (SlashCommand::RunStart { .. }
+            | SlashCommand::RunResume { .. }
+            | SlashCommand::RunList
+            | SlashCommand::RunStatus { .. }
+            | SlashCommand::RunUpgrade
+            | SlashCommand::RunDowngrade
+            | SlashCommand::RunNewSession
+            | SlashCommand::RunPause
+            | SlashCommand::RunAbort
+            | SlashCommand::ListSkills
+            | SlashCommand::InvokeSkill { .. }) => {
+                self.enqueue_async_slash(other);
+            }
+            // `SlashCommand` is `#[non_exhaustive]`. Future variants
+            // surface as a friendly error overlay so the user knows
+            // the command was parsed but not (yet) supported here.
             other => {
-                self.error_message = Some(format!("Unknown command: /{other}"));
+                self.error_message = Some(format!("Unsupported slash command: {other:?}"));
             }
         }
         Ok(())
@@ -679,6 +839,44 @@ impl App {
         self.chat_entries.push(ChatEntry {
             role: Role::System,
             text,
+        });
+    }
+
+    /// Display the list of discovered workflows (`/workflows`).
+    fn show_workflows_list(&mut self) {
+        let mut text = String::from("Available workflows:\n");
+        if self.workflows.is_empty() {
+            text.push_str("  (none discovered)\n");
+            text.push_str(
+                "\nDrop a *.yaml file under `.tsumugi/workflows/` and restart the TUI.\n",
+            );
+        } else {
+            for meta in &self.workflows {
+                match &meta.description {
+                    Some(desc) if !desc.is_empty() => {
+                        let _ = writeln!(text, "  - {} — {}", meta.id, desc);
+                    }
+                    _ => {
+                        let _ = writeln!(text, "  - {}", meta.id);
+                    }
+                }
+            }
+            text.push_str("\nStart with `/run start <workflow>`.\n");
+        }
+        self.chat_entries.push(ChatEntry {
+            role: Role::System,
+            text,
+        });
+    }
+
+    /// Append a system message describing slash-command output (e.g. a
+    /// run summary). Public so the event loop's async dispatcher can
+    /// surface harness-command results without re-implementing the
+    /// chat-entry shape.
+    pub fn push_slash_output(&mut self, text: impl Into<String>) {
+        self.chat_entries.push(ChatEntry {
+            role: Role::System,
+            text: text.into(),
         });
     }
 
@@ -996,6 +1194,10 @@ impl App {
                     if let Some(total) = features_count {
                         progress.features_total = total;
                     }
+                    // SPEC §7.1: surface a transient overlay banner so
+                    // the user sees the scope flip even if they were
+                    // not watching the activity pane.
+                    self.transient_banner = Some(TransientBanner::scope_upgrade(features_count));
                     changed = true;
                 }
                 Ok(RunProgressEvent::SessionEnded { trigger }) => {
@@ -1038,7 +1240,33 @@ impl App {
         loop {
             match rx.try_recv() {
                 Ok(ev) => {
+                    // Snapshot the activity-pane state machine first
+                    // (regardless of variant) so the workflow progress
+                    // section reflects the latest step.
                     self.activity.apply_workflow_event(&ev);
+                    // For human-input events, capture the responder so
+                    // the modal UI can drive the reply.
+                    if let WorkflowProgress::HumanInputRequired {
+                        step_id,
+                        message,
+                        options,
+                        show,
+                        response_tx,
+                    } = ev
+                    {
+                        // If a previous prompt is still alive (engines
+                        // emit one prompt at a time, but a flaky
+                        // observer might double-fire), the new prompt
+                        // wins. The prior responder is dropped, which
+                        // the engine treats as a missing reply.
+                        self.human_prompt = Some(HumanPrompt::new(
+                            step_id,
+                            message,
+                            show,
+                            options,
+                            response_tx,
+                        ));
+                    }
                     changed = true;
                 }
                 Err(mpsc::error::TryRecvError::Empty) => return changed,
@@ -1327,16 +1555,25 @@ mod tests {
     }
 
     #[test]
-    fn slash_command_parsing() {
-        // Test that slash commands are recognized
-        let text = "/clear";
-        assert!(text.strip_prefix('/').is_some());
-
-        let text = "/exit";
-        assert_eq!(text.strip_prefix('/'), Some("exit"));
-
-        let text = "hello";
-        assert!(text.strip_prefix('/').is_none());
+    fn slash_command_parsing_routes_through_shared_parser() {
+        // Sanity-check that the shared parser produces the canonical
+        // SlashCommand for a few well-known inputs. The full parser
+        // contract lives in `tmg-skills::slash`; this test exists so a
+        // future rewire to a TUI-local parser is detected here.
+        use tmg_skills::SlashCommand as Cmd;
+        assert_eq!(
+            tmg_skills::parse_slash_command("/clear").expect("ok"),
+            Some(Cmd::Clear),
+        );
+        assert_eq!(
+            tmg_skills::parse_slash_command("/exit").expect("ok"),
+            Some(Cmd::Exit),
+        );
+        assert_eq!(
+            tmg_skills::parse_slash_command("/run upgrade").expect("ok"),
+            Some(Cmd::RunUpgrade),
+        );
+        assert_eq!(tmg_skills::parse_slash_command("hello").expect("ok"), None,);
     }
 
     #[test]

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -8,7 +8,7 @@ use tmg_agents::{AgentType, CustomAgentDef, SubagentManager, truncate_str};
 use tmg_core::{AgentLoop, CoreError, StreamSink, format_context_usage};
 use tmg_harness::{HarnessStreamSink, RunProgressEvent, RunRunner, RunSummary};
 use tmg_llm::Role;
-use tmg_skills::SlashCommand;
+use tmg_skills::{SkillMeta, SlashCommand};
 use tmg_workflow::{WorkflowMeta, WorkflowProgress};
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -239,6 +239,11 @@ pub struct App {
     /// startup; the TUI does not refresh this list at runtime.
     workflows: Vec<WorkflowMeta>,
 
+    /// Discovered skills for `/skills` listing. Loaded once at startup
+    /// from the same discovery pass that registered `use_skill` tool
+    /// metadata; the TUI does not refresh this list at runtime.
+    skills: Vec<SkillMeta>,
+
     /// Pending slash command awaiting async dispatch. Populated by
     /// [`Self::dispatch_slash`] (`SlashDispatch::Async`) and
     /// drained by the event loop on the next tick.
@@ -285,6 +290,7 @@ impl App {
             transient_banner: None,
             human_prompt: None,
             workflows: Vec::new(),
+            skills: Vec::new(),
             pending_slash: None,
         }
     }
@@ -311,6 +317,17 @@ impl App {
     #[must_use]
     pub fn workflows(&self) -> &[WorkflowMeta] {
         &self.workflows
+    }
+
+    /// Replace the discovered skills list (used by `/skills`).
+    pub fn set_skills(&mut self, skills: Vec<SkillMeta>) {
+        self.skills = skills;
+    }
+
+    /// Borrow the discovered skills.
+    #[must_use]
+    pub fn skills(&self) -> &[SkillMeta] {
+        &self.skills
     }
 
     /// Borrow the active transient banner, if any.
@@ -1251,6 +1268,7 @@ impl App {
                         message,
                         options,
                         show,
+                        revise_target,
                         response_tx,
                     } = ev
                     {
@@ -1259,13 +1277,10 @@ impl App {
                         // observer might double-fire), the new prompt
                         // wins. The prior responder is dropped, which
                         // the engine treats as a missing reply.
-                        self.human_prompt = Some(HumanPrompt::new(
-                            step_id,
-                            message,
-                            show,
-                            options,
-                            response_tx,
-                        ));
+                        self.human_prompt = Some(
+                            HumanPrompt::new(step_id, message, show, options, response_tx)
+                                .with_revise_target(revise_target),
+                        );
                     }
                     changed = true;
                 }

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -378,6 +378,18 @@ impl App {
         self.human_prompt.take()
     }
 
+    /// Re-stash a human prompt into [`Self`].
+    ///
+    /// Used by the event handler when it needs to surface a soft error
+    /// (e.g. a `Revise` selection without a `revise_target`) without
+    /// dismissing the modal — the user may still pick `Approve` or
+    /// `Reject`. Any existing prompt is overwritten; callers should
+    /// only invoke this immediately after [`Self::take_human_prompt`]
+    /// to avoid clobbering a fresh prompt that arrived in the meantime.
+    pub fn set_human_prompt(&mut self, prompt: HumanPrompt) {
+        self.human_prompt = Some(prompt);
+    }
+
     /// Attach a workflow progress receiver.
     ///
     /// Intended use: the CLI / `run_workflow` foreground path forks

--- a/crates/tmg-tui/src/banner.rs
+++ b/crates/tmg-tui/src/banner.rs
@@ -1,0 +1,89 @@
+//! Transient overlay banners (SPEC §7.1 scope-upgrade notification).
+//!
+//! A [`TransientBanner`] is a short-lived message displayed at the top
+//! of the chat pane. The TUI inserts one whenever it observes a
+//! [`tmg_harness::RunProgressEvent::ScopeUpgraded`] event; the renderer
+//! draws it as an overlay until [`TransientBanner::is_expired`]
+//! returns `true`, at which point the App clears the field.
+
+use std::time::{Duration, Instant};
+
+/// Default lifetime for a scope-upgrade banner.
+pub const DEFAULT_BANNER_TTL: Duration = Duration::from_secs(3);
+
+/// A short-lived message overlaid on the chat pane.
+#[derive(Debug, Clone)]
+pub struct TransientBanner {
+    /// Display text. Rendered as a single line.
+    pub text: String,
+    /// Wall-clock time the banner was created.
+    pub started_at: Instant,
+    /// How long the banner should remain visible.
+    pub ttl: Duration,
+}
+
+impl TransientBanner {
+    /// Create a banner with the [default TTL][DEFAULT_BANNER_TTL].
+    #[must_use]
+    pub fn new(text: impl Into<String>) -> Self {
+        Self::with_ttl(text, DEFAULT_BANNER_TTL)
+    }
+
+    /// Create a banner with an explicit TTL.
+    #[must_use]
+    pub fn with_ttl(text: impl Into<String>, ttl: Duration) -> Self {
+        Self {
+            text: text.into(),
+            started_at: Instant::now(),
+            ttl,
+        }
+    }
+
+    /// Whether the banner has outlived its TTL.
+    #[must_use]
+    pub fn is_expired(&self) -> bool {
+        self.started_at.elapsed() >= self.ttl
+    }
+
+    /// Construct the canonical scope-upgrade banner text from the
+    /// optional feature count carried by [`tmg_harness::RunProgressEvent::ScopeUpgraded`].
+    #[must_use]
+    pub fn scope_upgrade(features_count: Option<u32>) -> Self {
+        let text = match features_count {
+            Some(n) => format!("Run upgraded to harnessed ({n} features tracked)"),
+            None => "Run upgraded to harnessed".to_owned(),
+        };
+        Self::new(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_upgrade_text_with_count() {
+        let b = TransientBanner::scope_upgrade(Some(47));
+        assert!(b.text.contains("47 features"));
+    }
+
+    #[test]
+    fn scope_upgrade_text_without_count() {
+        let b = TransientBanner::scope_upgrade(None);
+        assert_eq!(b.text, "Run upgraded to harnessed");
+    }
+
+    #[test]
+    fn fresh_banner_is_not_expired() {
+        let b = TransientBanner::new("hello");
+        assert!(!b.is_expired());
+    }
+
+    #[test]
+    fn zero_ttl_banner_is_immediately_expired() {
+        let b = TransientBanner::with_ttl("hello", Duration::from_nanos(0));
+        // After at least one tick of the clock the banner is expired.
+        std::thread::sleep(Duration::from_millis(1));
+        assert!(b.is_expired());
+    }
+}

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -69,8 +69,21 @@ pub async fn run_event_loop(
         // compact gate so a `/compact` queued from a slash dispatch
         // (none currently, but the path is symmetric) wouldn't be
         // shadowed by an in-flight compact.
+        //
+        // The dispatcher contains `runner.lock().await` calls that can
+        // contend with a long-running tool turn; race it against the
+        // cancellation token so Ctrl+C still breaks the TUI out of a
+        // stuck dispatch (the partial side-effects are tolerable —
+        // we're shutting down anyway).
         if let Some(cmd) = app.take_pending_slash() {
-            dispatch_slash_async(app, cmd).await;
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    app.request_exit();
+                    return Ok(());
+                }
+                () = dispatch_slash_async(app, cmd) => {}
+            }
         }
 
         // Handle pending /compact command as a background task.
@@ -336,20 +349,30 @@ async fn handle_human_prompt_key(app: &mut App, key: KeyEvent) {
 async fn deliver_human_response(app: &mut App, prompt: HumanPrompt) {
     let focused = prompt.focused_option().to_owned();
     let kind = option_kind(&focused);
-    // For revise responses, prefer the workflow's declared
-    // `revise_target`. The TUI does not currently support a free-form
-    // step-id picker; if the workflow author left `revise_target`
-    // unset we fall back to the prompt's own step id (which the engine
-    // may reject — surfaced via the standard error overlay if it
-    // does).
-    let target = match kind {
-        HumanResponseKind::Revise => Some(
-            prompt
-                .revise_target
-                .clone()
-                .unwrap_or_else(|| prompt.step_id.clone()),
-        ),
-        _ => None,
+    // For revise responses we require a `revise_target` declared by the
+    // workflow; without one we cannot pick a meaningful target and
+    // silently falling back to the human-step id would mismatch the
+    // engine's `step_results` map (since the human step has not been
+    // recorded yet) and break the rewind. Surface an error overlay
+    // instead and keep the prompt alive so the user can pick a
+    // different option.
+    let target = if matches!(kind, HumanResponseKind::Revise) {
+        if let Some(t) = prompt.revise_target.clone() {
+            Some(t)
+        } else {
+            let step_id = prompt.step_id.clone();
+            // Drop the responder so the engine observes a missing
+            // reply if the user later cancels the prompt; we do not
+            // consume the prompt itself because the user may wish to
+            // choose Approve/Reject after seeing the error.
+            prompt.take_responder().await;
+            app.set_error(format!(
+                "[human:{step_id}] cannot revise: workflow did not declare `revise_target`",
+            ));
+            return;
+        }
+    } else {
+        None
     };
     let response = HumanResponse { kind, target };
     let label = focused.clone();
@@ -359,7 +382,12 @@ async fn deliver_human_response(app: &mut App, prompt: HumanPrompt) {
         Ok(()) => {
             app.push_slash_output(format!("[human:{step_id}] responded with `{label}`",));
         }
-        Err(()) => {
+        Err(crate::human_prompt::RespondError::AlreadyResponded) => {
+            app.set_error(format!(
+                "[human:{step_id}] failed to deliver `{label}` (already responded)",
+            ));
+        }
+        Err(crate::human_prompt::RespondError::ChannelClosed) => {
             app.set_error(format!(
                 "[human:{step_id}] failed to deliver `{label}` (channel closed)",
             ));
@@ -372,14 +400,20 @@ async fn deliver_human_response(app: &mut App, prompt: HumanPrompt) {
 /// chat entries or error overlays.
 async fn dispatch_slash_async(app: &mut App, cmd: SlashCommand) {
     match cmd {
-        SlashCommand::ListSkills | SlashCommand::InvokeSkill { .. } => {
-            // Skill invocation/listing is not yet wired into the TUI's
-            // async surface (skills run via `use_skill` tool calls
-            // inside an active turn). Surface a friendly message so
-            // the user knows the command was recognised but is a
-            // no-op here.
+        SlashCommand::ListSkills => {
+            // Render the discovered skills list. The same metadata is
+            // used by the agent's `use_skill` tool, so the listing
+            // mirrors the LLM's view of available skills.
+            let text = tmg_skills::format_skills_list(app.skills());
+            app.push_slash_output(text);
+        }
+        SlashCommand::InvokeSkill { .. } => {
+            // Direct skill invocation from the TUI is not wired up:
+            // skills run via the LLM's `use_skill` tool inside a turn.
+            // Surface a friendly hint so the user reaches the canonical
+            // path.
             app.set_error(
-                "Skill commands are dispatched via the agent's tool loop; \
+                "Skill invocation is dispatched via the agent's tool loop; \
                  type your request normally and the agent will pick the right skill"
                     .to_owned(),
             );
@@ -392,9 +426,10 @@ async fn dispatch_slash_async(app: &mut App, cmd: SlashCommand) {
         SlashCommand::RunPause => run_pause(app).await,
         SlashCommand::RunAbort => run_abort(app).await,
         SlashCommand::RunStart { workflow, args } => {
-            // The TUI cannot drive a workflow synchronously: workflows
-            // execute via the LLM's `run_workflow` tool call. Surface
-            // a hint that drives the user to the canonical path.
+            // In-TUI workflow start is tracked in #71. For now, the TUI
+            // cannot drive a workflow synchronously: workflows execute
+            // via the LLM's `run_workflow` tool call. Surface a hint
+            // that drives the user to the canonical path.
             let arg_hint = args.as_deref().unwrap_or("");
             let suffix = if arg_hint.is_empty() {
                 String::new()
@@ -402,17 +437,18 @@ async fn dispatch_slash_async(app: &mut App, cmd: SlashCommand) {
                 format!(" with arguments `{arg_hint}`")
             };
             app.push_slash_output(format!(
-                "Ask the agent: \"run the {workflow} workflow{suffix}\". \
+                "/run start is not yet wired into the TUI (see #71). \
+                 Ask the agent: \"run the {workflow} workflow{suffix}\". \
                  The agent dispatches workflows via the run_workflow tool.",
             ));
         }
         SlashCommand::RunResume { run_id } => {
-            // In-TUI run rotation is not currently supported (the TUI
-            // attaches to a single run for its whole lifetime). Show a
+            // In-TUI run rotation is tracked in #71. The TUI currently
+            // attaches to a single run for its whole lifetime; show a
             // hint pointing at the CLI command.
             let target = run_id.unwrap_or_else(|| "<id>".to_owned());
             app.push_slash_output(format!(
-                "Resuming a different run from inside the TUI is not yet supported. \
+                "/run resume is not yet wired into the TUI (see #71). \
                  Exit and run `tmg run resume {target}` to attach to that run.",
             ));
         }

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -360,15 +360,20 @@ async fn deliver_human_response(app: &mut App, prompt: HumanPrompt) {
         if let Some(t) = prompt.revise_target.clone() {
             Some(t)
         } else {
+            // Without a `revise_target` declared by the workflow we
+            // cannot pick a meaningful rewind target — silently
+            // falling back to the human-step id would mismatch the
+            // engine's `step_results` map (the human step has not been
+            // recorded yet) and break the rewind. Surface an error
+            // overlay and re-stash the prompt so the user can pick
+            // `Approve` or `Reject` instead. The responder is left
+            // intact (we do not call `take_responder`) so the modal
+            // is still actionable.
             let step_id = prompt.step_id.clone();
-            // Drop the responder so the engine observes a missing
-            // reply if the user later cancels the prompt; we do not
-            // consume the prompt itself because the user may wish to
-            // choose Approve/Reject after seeing the error.
-            prompt.take_responder().await;
             app.set_error(format!(
                 "[human:{step_id}] cannot revise: workflow did not declare `revise_target`",
             ));
+            app.set_human_prompt(prompt);
             return;
         }
     } else {

--- a/crates/tmg-tui/src/event.rs
+++ b/crates/tmg-tui/src/event.rs
@@ -6,11 +6,13 @@ use crossterm::event::{
     self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEvent, MouseEventKind,
 };
 use ratatui::DefaultTerminal;
+use tmg_skills::SlashCommand;
+use tmg_workflow::{HumanResponse, HumanResponseKind};
 use tokio_util::sync::CancellationToken;
 
-use crate::app::App;
+use crate::app::{App, SubmitDecision};
 use crate::error::TuiError;
-use crate::ui;
+use crate::human_prompt::{HumanPrompt, option_kind};
 
 /// The main event loop tick interval.
 ///
@@ -59,6 +61,18 @@ pub async fn run_event_loop(
         // run-progress and workflow-progress streams.
         app.drain_app_events();
 
+        // Expire the scope-upgrade banner once its TTL has lapsed.
+        let _ = app.expire_banner_if_due();
+
+        // Drain any queued async slash command produced by the most
+        // recent `App::dispatch_slash` call. This must run BEFORE the
+        // compact gate so a `/compact` queued from a slash dispatch
+        // (none currently, but the path is symmetric) wouldn't be
+        // shadowed by an in-flight compact.
+        if let Some(cmd) = app.take_pending_slash() {
+            dispatch_slash_async(app, cmd).await;
+        }
+
         // Handle pending /compact command as a background task.
         if app.needs_compact() && !app.is_streaming() {
             app.clear_pending_compact();
@@ -73,7 +87,7 @@ pub async fn run_event_loop(
         }
 
         // Draw the current state.
-        terminal.draw(|frame| ui::draw(frame, app))?;
+        terminal.draw(|frame| crate::ui::draw(frame, app))?;
 
         if app.should_exit() {
             return Ok(());
@@ -88,7 +102,7 @@ pub async fn run_event_loop(
             maybe_event = poll_event() => {
                 match maybe_event {
                     Ok(Some(event)) => {
-                        handle_event(app, &event, &cancel);
+                        handle_event(app, &event, &cancel).await;
                     }
                     Ok(None) => {
                         // No event within tick rate, continue
@@ -123,9 +137,9 @@ async fn poll_event() -> Result<Option<Event>, std::io::Error> {
 }
 
 /// Handle a single terminal event.
-fn handle_event(app: &mut App, event: &Event, cancel: &CancellationToken) {
+async fn handle_event(app: &mut App, event: &Event, cancel: &CancellationToken) {
     match event {
-        Event::Key(key_event) => handle_key(app, *key_event, cancel),
+        Event::Key(key_event) => handle_key(app, *key_event, cancel).await,
         Event::Mouse(mouse_event) => handle_mouse(app, *mouse_event),
         // Terminal resize and other events are handled automatically by
         // ratatui on the next draw call.
@@ -146,11 +160,19 @@ fn handle_mouse(app: &mut App, mouse: MouseEvent) {
 }
 
 /// Handle a key event.
-fn handle_key(app: &mut App, key: KeyEvent, cancel: &CancellationToken) {
+async fn handle_key(app: &mut App, key: KeyEvent, cancel: &CancellationToken) {
     // Only process key-press events. With the Kitty keyboard protocol
     // enabled, Release and Repeat events are also reported; ignoring
     // them prevents double-firing and interference with IME composition.
     if key.kind != KeyEventKind::Press {
+        return;
+    }
+
+    // The human-prompt modal takes priority over every other input
+    // path so the user cannot accidentally cancel a pending workflow
+    // step by typing into the chat box.
+    if app.has_human_prompt() {
+        handle_human_prompt_key(app, key).await;
         return;
     }
 
@@ -228,14 +250,367 @@ fn handle_key(app: &mut App, key: KeyEvent, cancel: &CancellationToken) {
 
 /// Submit input and start a background conversation turn.
 fn submit_and_start_turn(app: &mut App, cancel: &CancellationToken) {
-    let user_input = match app.submit_input() {
-        Ok(Some(text)) => text,
-        Ok(None) => return,
-        Err(e) => {
-            app.set_error(e.to_string());
-            return;
+    match app.submit_input() {
+        SubmitDecision::Nothing => {}
+        SubmitDecision::StartTurn(text) => {
+            app.start_turn(text, cancel);
         }
-    };
+        SubmitDecision::SlashCommand(cmd) => {
+            if let Err(e) = app.dispatch_slash(cmd) {
+                app.set_error(e.to_string());
+            }
+        }
+        SubmitDecision::ParseError(msg) => {
+            app.set_error(msg);
+        }
+    }
+}
 
-    app.start_turn(user_input, cancel);
+/// Handle a key event while the human-prompt modal is active.
+///
+/// Routes:
+/// * `Tab` / `Right` / `Down`           → focus next option
+/// * `Shift+Tab` / `Left` / `Up`        → focus previous option
+/// * Letter keys                        → focus by initial
+/// * `Enter`                            → confirm focused option
+/// * `Esc`                              → cancel (drops the responder)
+/// * `Ctrl+C`                           → forward to the standard
+///   cancel path so the user can still abort the TUI
+async fn handle_human_prompt_key(app: &mut App, key: KeyEvent) {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
+            // Drop the responder before requesting exit so the engine
+            // observes the missing reply on its next poll.
+            if let Some(prompt) = app.take_human_prompt() {
+                prompt.take_responder().await;
+            }
+            app.request_exit();
+        }
+        (KeyCode::Esc, _) => {
+            if let Some(prompt) = app.take_human_prompt() {
+                prompt.take_responder().await;
+                app.set_error(format!(
+                    "Cancelled human prompt for step '{}'",
+                    prompt.step_id,
+                ));
+            }
+        }
+        (KeyCode::Tab, m) if !m.contains(KeyModifiers::SHIFT) => {
+            if let Some(p) = app.human_prompt_mut() {
+                p.focus_next();
+            }
+        }
+        (KeyCode::BackTab | KeyCode::Tab, _) if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            if let Some(p) = app.human_prompt_mut() {
+                p.focus_prev();
+            }
+        }
+        (KeyCode::Right | KeyCode::Down, _) => {
+            if let Some(p) = app.human_prompt_mut() {
+                p.focus_next();
+            }
+        }
+        (KeyCode::Left | KeyCode::Up, _) => {
+            if let Some(p) = app.human_prompt_mut() {
+                p.focus_prev();
+            }
+        }
+        (KeyCode::Enter, _) => {
+            if let Some(prompt) = app.take_human_prompt() {
+                deliver_human_response(app, prompt).await;
+            }
+        }
+        (KeyCode::Char(ch), m) if !m.contains(KeyModifiers::CONTROL) => {
+            // Letter keys jump-select an option by initial. Don't fall
+            // through to "type into chat" — the chat input is hidden
+            // while the modal is up.
+            if let Some(p) = app.human_prompt_mut() {
+                p.focus_by_initial(ch);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Send the focused option of a human prompt back to the engine.
+async fn deliver_human_response(app: &mut App, prompt: HumanPrompt) {
+    let focused = prompt.focused_option().to_owned();
+    let kind = option_kind(&focused);
+    // For revise responses, prefer the workflow's declared
+    // `revise_target`. The TUI does not currently support a free-form
+    // step-id picker; if the workflow author left `revise_target`
+    // unset we fall back to the prompt's own step id (which the engine
+    // may reject — surfaced via the standard error overlay if it
+    // does).
+    let target = match kind {
+        HumanResponseKind::Revise => Some(
+            prompt
+                .revise_target
+                .clone()
+                .unwrap_or_else(|| prompt.step_id.clone()),
+        ),
+        _ => None,
+    };
+    let response = HumanResponse { kind, target };
+    let label = focused.clone();
+    let step_id = prompt.step_id.clone();
+    let send_result = prompt.respond(response).await;
+    match send_result {
+        Ok(()) => {
+            app.push_slash_output(format!("[human:{step_id}] responded with `{label}`",));
+        }
+        Err(()) => {
+            app.set_error(format!(
+                "[human:{step_id}] failed to deliver `{label}` (channel closed)",
+            ));
+        }
+    }
+}
+
+/// Drive an async slash command. Routes /run subcommands through
+/// [`tmg_harness::commands`] and surfaces results / errors as system
+/// chat entries or error overlays.
+async fn dispatch_slash_async(app: &mut App, cmd: SlashCommand) {
+    match cmd {
+        SlashCommand::ListSkills | SlashCommand::InvokeSkill { .. } => {
+            // Skill invocation/listing is not yet wired into the TUI's
+            // async surface (skills run via `use_skill` tool calls
+            // inside an active turn). Surface a friendly message so
+            // the user knows the command was recognised but is a
+            // no-op here.
+            app.set_error(
+                "Skill commands are dispatched via the agent's tool loop; \
+                 type your request normally and the agent will pick the right skill"
+                    .to_owned(),
+            );
+        }
+        SlashCommand::RunList => run_list(app).await,
+        SlashCommand::RunStatus { run_id } => run_status(app, run_id.as_deref()).await,
+        SlashCommand::RunUpgrade => run_upgrade(app).await,
+        SlashCommand::RunDowngrade => run_downgrade(app).await,
+        SlashCommand::RunNewSession => run_new_session(app).await,
+        SlashCommand::RunPause => run_pause(app).await,
+        SlashCommand::RunAbort => run_abort(app).await,
+        SlashCommand::RunStart { workflow, args } => {
+            // The TUI cannot drive a workflow synchronously: workflows
+            // execute via the LLM's `run_workflow` tool call. Surface
+            // a hint that drives the user to the canonical path.
+            let arg_hint = args.as_deref().unwrap_or("");
+            let suffix = if arg_hint.is_empty() {
+                String::new()
+            } else {
+                format!(" with arguments `{arg_hint}`")
+            };
+            app.push_slash_output(format!(
+                "Ask the agent: \"run the {workflow} workflow{suffix}\". \
+                 The agent dispatches workflows via the run_workflow tool.",
+            ));
+        }
+        SlashCommand::RunResume { run_id } => {
+            // In-TUI run rotation is not currently supported (the TUI
+            // attaches to a single run for its whole lifetime). Show a
+            // hint pointing at the CLI command.
+            let target = run_id.unwrap_or_else(|| "<id>".to_owned());
+            app.push_slash_output(format!(
+                "Resuming a different run from inside the TUI is not yet supported. \
+                 Exit and run `tmg run resume {target}` to attach to that run.",
+            ));
+        }
+        // The synchronous variants are handled in `App::dispatch_slash`;
+        // they should never reach the async path. Treat as a no-op so
+        // a future extension that re-routes them does not panic.
+        SlashCommand::Clear
+        | SlashCommand::Compact
+        | SlashCommand::Exit
+        | SlashCommand::ListAgents
+        | SlashCommand::ListWorkflows => {}
+        // `SlashCommand` is `#[non_exhaustive]`; future variants land
+        // here as a friendly error overlay until the dispatcher learns
+        // about them.
+        other => {
+            app.set_error(format!("Unsupported async slash command: {other:?}",));
+        }
+    }
+}
+
+async fn run_list(app: &mut App) {
+    let Some(runner) = app.runner().cloned() else {
+        app.set_error("/run list requires an active run store".to_owned());
+        return;
+    };
+    let store = {
+        let guard = runner.lock().await;
+        guard.store().clone()
+    };
+    match tmg_harness::commands::list(&store) {
+        Ok(summaries) => {
+            if summaries.is_empty() {
+                app.push_slash_output("(no runs found)".to_owned());
+                return;
+            }
+            let mut text = String::from("Runs:\n");
+            for s in summaries {
+                use std::fmt::Write as _;
+                // The summary carries the full RunStatus; render it
+                // via Debug for now (the CLI uses the same shape).
+                let _ = writeln!(
+                    text,
+                    "  {} {} {:?} (sessions: {})",
+                    s.short_id(),
+                    s.scope_label,
+                    s.status,
+                    s.session_count,
+                );
+            }
+            app.push_slash_output(text);
+        }
+        Err(e) => {
+            app.set_error(format!("/run list failed: {e}"));
+        }
+    }
+}
+
+async fn run_status(app: &mut App, run_id: Option<&str>) {
+    let Some(runner) = app.runner().cloned() else {
+        app.set_error("/run status requires an active run".to_owned());
+        return;
+    };
+    let (store, default_id) = {
+        let guard = runner.lock().await;
+        (guard.store().clone(), guard.run_id().clone())
+    };
+    let resolved = match run_id {
+        Some(raw) => match tmg_harness::RunId::parse(raw.to_owned()) {
+            Ok(id) => id,
+            Err(e) => {
+                app.set_error(format!("/run status: invalid run id {raw:?}: {e}"));
+                return;
+            }
+        },
+        None => default_id,
+    };
+    match tmg_harness::commands::status(&store, &resolved, 5) {
+        Ok(report) => {
+            use std::fmt::Write as _;
+            let mut text = String::new();
+            let _ = writeln!(
+                text,
+                "Run {} ({})",
+                report.run.id.short(),
+                report.run.scope.label(),
+            );
+            let _ = writeln!(text, "  Status:    {:?}", report.run.status);
+            let _ = writeln!(text, "  Sessions:  {}", report.run.session_count);
+            if let Some(hist) = report.feature_histogram {
+                let _ = writeln!(text, "  Features:  {}/{} passing", hist.passing, hist.total,);
+            }
+            if !report.progress_tail.is_empty() {
+                let _ = writeln!(
+                    text,
+                    "\nprogress.md (last {} lines):\n{}",
+                    report.progress_tail_lines, report.progress_tail,
+                );
+            }
+            app.push_slash_output(text);
+        }
+        Err(e) => {
+            app.set_error(format!("/run status failed: {e}"));
+        }
+    }
+}
+
+async fn run_upgrade(app: &mut App) {
+    let Some(runner) = app.runner().cloned() else {
+        app.set_error("/run upgrade requires an active run".to_owned());
+        return;
+    };
+    let mut guard = runner.lock().await;
+    match tmg_harness::commands::upgrade(&mut guard) {
+        Ok(()) => {
+            let label = guard.run_id().short();
+            app.push_slash_output(format!("Upgraded run {label} -> harnessed"));
+        }
+        Err(e) => {
+            app.set_error(format!("/run upgrade failed: {e}"));
+        }
+    }
+}
+
+async fn run_downgrade(app: &mut App) {
+    let Some(runner) = app.runner().cloned() else {
+        app.set_error("/run downgrade requires an active run".to_owned());
+        return;
+    };
+    let mut guard = runner.lock().await;
+    match tmg_harness::commands::downgrade(&mut guard) {
+        Ok(()) => {
+            let label = guard.run_id().short();
+            app.push_slash_output(format!("Downgraded run {label} -> ad_hoc"));
+        }
+        Err(e) => {
+            app.set_error(format!("/run downgrade failed: {e}"));
+        }
+    }
+}
+
+async fn run_new_session(app: &mut App) {
+    let Some(runner) = app.runner().cloned() else {
+        app.set_error("/run new-session requires an active run".to_owned());
+        return;
+    };
+    let mut guard = runner.lock().await;
+    match tmg_harness::commands::new_session(&mut guard) {
+        Ok(()) => {
+            let label = guard.run_id().short();
+            let session = guard.run().session_count;
+            app.push_slash_output(format!("Rotated run {label} to session #{session}",));
+        }
+        Err(e) => {
+            app.set_error(format!("/run new-session failed: {e}"));
+        }
+    }
+}
+
+async fn run_pause(app: &mut App) {
+    let Some(runner) = app.runner().cloned() else {
+        app.set_error("/run pause requires an active run".to_owned());
+        return;
+    };
+    // The shared `commands::pause` helper refuses to mutate when a
+    // live TUI sentinel is detected. That guard exists to keep an
+    // external `tmg run pause` CLI invocation from racing the live
+    // runner — but we ARE the live runner here, so call the
+    // guard-free `set_status` path directly. The TUI then exits via
+    // request_exit so the user observes a paused run on disk.
+    let mut guard = runner.lock().await;
+    match guard.set_status(tmg_harness::RunStatus::Paused) {
+        Ok(()) => {
+            let label = guard.run_id().short();
+            app.push_slash_output(format!("Paused run {label}; exit the TUI to release it",));
+        }
+        Err(e) => {
+            app.set_error(format!("/run pause failed: {e}"));
+        }
+    }
+}
+
+async fn run_abort(app: &mut App) {
+    let Some(runner) = app.runner().cloned() else {
+        app.set_error("/run abort requires an active run".to_owned());
+        return;
+    };
+    // Same rationale as `/run pause`: bypass the TUI-attached guard
+    // because we *are* the attached TUI.
+    let mut guard = runner.lock().await;
+    match guard.set_status(tmg_harness::RunStatus::Failed {
+        reason: "user aborted (TUI)".to_owned(),
+    }) {
+        Ok(()) => {
+            let label = guard.run_id().short();
+            app.push_slash_output(format!("Aborted run {label} (status=failed)"));
+        }
+        Err(e) => {
+            app.set_error(format!("/run abort failed: {e}"));
+        }
+    }
 }

--- a/crates/tmg-tui/src/human_prompt.rs
+++ b/crates/tmg-tui/src/human_prompt.rs
@@ -21,15 +21,30 @@
 //! ## Response mapping
 //!
 //! The mapping from option-string to [`tmg_workflow::HumanResponseKind`]
-//! is intentionally lenient: any string starting with `app` becomes
-//! `Approve`, any string starting with `rej` becomes `Reject`, any
-//! string starting with `rev` becomes `Revise`. Workflow authors that
-//! deviate from the canonical names will still get a sensible default.
+//! is intentionally lenient (see [`option_kind`] for the full table):
+//! any string starting with `rej`, plus the literals `no` / `deny`,
+//! becomes `Reject`; any string starting with `rev` becomes `Revise`;
+//! everything else (including `app...`, `yes`, `ok`) falls through to
+//! `Approve`.
 
 use std::sync::Arc;
 
+use thiserror::Error;
 use tmg_workflow::{HumanResponder, HumanResponse, HumanResponseKind};
 use tokio::sync::Mutex;
+
+/// Errors returned by [`HumanPrompt::respond`].
+#[derive(Debug, Error)]
+pub enum RespondError {
+    /// The carried `oneshot::Sender` had already been taken (e.g. by a
+    /// prior `respond` call or by [`HumanPrompt::take_responder`]).
+    #[error("human prompt has already been responded to")]
+    AlreadyResponded,
+    /// The receiver was dropped before the response could be delivered.
+    /// The engine treats this the same as a missing reply.
+    #[error("human prompt channel was closed before delivery")]
+    ChannelClosed,
+}
 
 /// State for an in-flight `human` step prompt.
 #[derive(Debug)]
@@ -137,20 +152,23 @@ impl HumanPrompt {
 
     /// Send the carried response and consume the prompt.
     ///
-    /// Returns `Ok(())` on a successful send; `Err(())` when the
-    /// responder was already taken (double-take per the [`HumanResponder`]
-    /// contract). The TUI logs the error and clears the prompt either
-    /// way.
-    pub async fn respond(self, response: HumanResponse) -> Result<(), ()> {
+    /// # Errors
+    ///
+    /// Returns [`RespondError::AlreadyResponded`] when the carried
+    /// sender has already been taken (per the [`HumanResponder`] take-
+    /// once contract). Returns [`RespondError::ChannelClosed`] when the
+    /// engine-side receiver was dropped before delivery. The TUI logs
+    /// the error and clears the prompt either way.
+    pub async fn respond(self, response: HumanResponse) -> Result<(), RespondError> {
         let mut guard = self.responder.lock().await;
         let Some(tx) = guard.take() else {
-            return Err(());
+            return Err(RespondError::AlreadyResponded);
         };
         // Drop the guard before sending so the engine isn't blocked
         // waiting on the mutex in case it tries to read the responder
         // for diagnostics.
         drop(guard);
-        tx.send(response).map_err(|_| ())
+        tx.send(response).map_err(|_| RespondError::ChannelClosed)
     }
 
     /// Take the responder out so the prompt can be dismissed without
@@ -173,18 +191,20 @@ impl HumanPrompt {
 
 /// Map an option string to a response kind.
 ///
-/// Recognised prefixes:
-/// * `app...` → [`HumanResponseKind::Approve`]
-/// * `rej...` → [`HumanResponseKind::Reject`]
-/// * `rev...` → [`HumanResponseKind::Revise`]
+/// Recognised prefixes (ASCII case-insensitive):
+/// * `app...` / `yes` / `ok`        → [`HumanResponseKind::Approve`]
+/// * `rej...` / `no` / `deny`       → [`HumanResponseKind::Reject`]
+/// * `rev...`                        → [`HumanResponseKind::Revise`]
 ///
-/// Anything else falls back to `Approve` so workflow authors using
-/// ad-hoc affirmative options (`yes`, `ok`, ...) still see something
-/// sensible.
+/// Anything else falls back to `Approve` — workflow authors deviating
+/// from the canonical `approve / reject / revise` set are expected to
+/// use one of the affirmative aliases above; truly unrecognised strings
+/// are treated as approve so the modal cannot hard-error on a
+/// well-formed option list.
 #[must_use]
 pub fn option_kind(option: &str) -> HumanResponseKind {
     let lower = option.to_ascii_lowercase();
-    if lower.starts_with("rej") || lower.starts_with("no") {
+    if lower.starts_with("rej") || lower == "no" || lower == "deny" {
         HumanResponseKind::Reject
     } else if lower.starts_with("rev") {
         HumanResponseKind::Revise
@@ -279,7 +299,21 @@ mod tests {
         let mut guard = handle.lock().await;
         let _ = guard.take();
         drop(guard);
-        let err = prompt.respond(HumanResponse::approve()).await;
-        assert!(err.is_err());
+        let err = prompt
+            .respond(HumanResponse::approve())
+            .await
+            .expect_err("double-respond should fail");
+        assert!(matches!(err, RespondError::AlreadyResponded));
+    }
+
+    #[tokio::test]
+    async fn respond_after_receiver_dropped_returns_channel_closed() {
+        let (prompt, rx) = make_prompt(vec!["approve"]);
+        drop(rx);
+        let err = prompt
+            .respond(HumanResponse::approve())
+            .await
+            .expect_err("send to closed channel should fail");
+        assert!(matches!(err, RespondError::ChannelClosed));
     }
 }

--- a/crates/tmg-tui/src/human_prompt.rs
+++ b/crates/tmg-tui/src/human_prompt.rs
@@ -1,0 +1,285 @@
+//! Modal UI for `human` workflow steps (SPEC §8.4 / issue #46).
+//!
+//! When the engine emits [`tmg_workflow::WorkflowProgress::HumanInputRequired`]
+//! the TUI captures the event into a [`HumanPrompt`] and renders it as
+//! an overlay over the chat pane until the user picks an option. The
+//! response is sent back through the carried one-shot channel so the
+//! workflow engine can resume.
+//!
+//! ## Selection model
+//!
+//! The prompt lists the engine-provided `options` (typically `approve`
+//! / `reject` / `revise`). Selection is driven by:
+//! * `Tab` / `Right` / `Down` and `Shift+Tab` / `Left` / `Up` — cycle
+//!   focus through the option list.
+//! * The first letter of each option (`a`, `r`, `v` for the canonical
+//!   set) — jump-select that option.
+//! * `Enter` — confirm the focused option and dispatch the response.
+//! * `Esc` — cancel the prompt; the carried responder is dropped which
+//!   the engine treats as a "no response" failure.
+//!
+//! ## Response mapping
+//!
+//! The mapping from option-string to [`tmg_workflow::HumanResponseKind`]
+//! is intentionally lenient: any string starting with `app` becomes
+//! `Approve`, any string starting with `rej` becomes `Reject`, any
+//! string starting with `rev` becomes `Revise`. Workflow authors that
+//! deviate from the canonical names will still get a sensible default.
+
+use std::sync::Arc;
+
+use tmg_workflow::{HumanResponder, HumanResponse, HumanResponseKind};
+use tokio::sync::Mutex;
+
+/// State for an in-flight `human` step prompt.
+#[derive(Debug)]
+pub struct HumanPrompt {
+    /// Step id from the engine (used to address `revise` targets).
+    pub step_id: String,
+    /// Prompt body shown above the option list.
+    pub message: String,
+    /// Optional pre-rendered `show:` payload (e.g. the previous step's
+    /// stdout).
+    pub show: Option<String>,
+    /// Allowed response keywords as the engine declared them. Each
+    /// entry maps via [`option_kind`] to a typed response kind.
+    pub options: Vec<String>,
+    /// Currently focused option index. Always within
+    /// `0..options.len()` while the prompt is alive.
+    pub focused: usize,
+    /// One-shot responder. Wrapped in `Arc<Mutex<Option<...>>>` per
+    /// the [`HumanResponder`] contract; calling [`Self::respond`]
+    /// `take()`s the inner sender.
+    responder: HumanResponder,
+    /// Optional `revise_target` provided by the workflow definition.
+    /// When present and the user picks a `revise` option, the response
+    /// carries this target.
+    pub revise_target: Option<String>,
+}
+
+impl HumanPrompt {
+    /// Build a prompt from a [`tmg_workflow::WorkflowProgress::HumanInputRequired`]
+    /// event's fields.
+    #[must_use]
+    pub fn new(
+        step_id: String,
+        message: String,
+        show: Option<String>,
+        options: Vec<String>,
+        responder: HumanResponder,
+    ) -> Self {
+        // Default focus on the first entry so a plain `Enter` picks
+        // something deterministic. Empty option lists are rare in
+        // practice (the workflow validator requires at least one),
+        // but we still tolerate them by leaving `focused` at 0.
+        Self {
+            step_id,
+            message,
+            show,
+            options,
+            focused: 0,
+            responder,
+            revise_target: None,
+        }
+    }
+
+    /// Attach a `revise_target` parsed from the workflow definition.
+    #[must_use]
+    pub fn with_revise_target(mut self, target: Option<String>) -> Self {
+        self.revise_target = target;
+        self
+    }
+
+    /// Move focus to the next option (wrap-around).
+    pub fn focus_next(&mut self) {
+        if self.options.is_empty() {
+            return;
+        }
+        self.focused = (self.focused + 1) % self.options.len();
+    }
+
+    /// Move focus to the previous option (wrap-around).
+    pub fn focus_prev(&mut self) {
+        if self.options.is_empty() {
+            return;
+        }
+        if self.focused == 0 {
+            self.focused = self.options.len() - 1;
+        } else {
+            self.focused -= 1;
+        }
+    }
+
+    /// Try to focus an option by its first character.
+    ///
+    /// Returns `true` when a match was found and focus was updated.
+    /// Comparison is ASCII case-insensitive.
+    pub fn focus_by_initial(&mut self, ch: char) -> bool {
+        let target = ch.to_ascii_lowercase();
+        for (i, opt) in self.options.iter().enumerate() {
+            if let Some(first) = opt.chars().next()
+                && first.to_ascii_lowercase() == target
+            {
+                self.focused = i;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Borrow the focused option string. Returns the empty string when
+    /// the option list is empty (defensive — the caller should never
+    /// see this).
+    #[must_use]
+    pub fn focused_option(&self) -> &str {
+        self.options.get(self.focused).map_or("", String::as_str)
+    }
+
+    /// Send the carried response and consume the prompt.
+    ///
+    /// Returns `Ok(())` on a successful send; `Err(())` when the
+    /// responder was already taken (double-take per the [`HumanResponder`]
+    /// contract). The TUI logs the error and clears the prompt either
+    /// way.
+    pub async fn respond(self, response: HumanResponse) -> Result<(), ()> {
+        let mut guard = self.responder.lock().await;
+        let Some(tx) = guard.take() else {
+            return Err(());
+        };
+        // Drop the guard before sending so the engine isn't blocked
+        // waiting on the mutex in case it tries to read the responder
+        // for diagnostics.
+        drop(guard);
+        tx.send(response).map_err(|_| ())
+    }
+
+    /// Take the responder out so the prompt can be dismissed without
+    /// sending anything (e.g. on `Esc`). The engine will observe a
+    /// missing response and fail the step.
+    pub async fn take_responder(&self) {
+        let mut guard = self.responder.lock().await;
+        let _ = guard.take();
+    }
+
+    /// Convenience: build a default approval response targeted at the
+    /// prompt's step. Used by tests.
+    #[must_use]
+    pub fn responder_handle(
+        &self,
+    ) -> Arc<Mutex<Option<tokio::sync::oneshot::Sender<HumanResponse>>>> {
+        Arc::clone(&self.responder)
+    }
+}
+
+/// Map an option string to a response kind.
+///
+/// Recognised prefixes:
+/// * `app...` → [`HumanResponseKind::Approve`]
+/// * `rej...` → [`HumanResponseKind::Reject`]
+/// * `rev...` → [`HumanResponseKind::Revise`]
+///
+/// Anything else falls back to `Approve` so workflow authors using
+/// ad-hoc affirmative options (`yes`, `ok`, ...) still see something
+/// sensible.
+#[must_use]
+pub fn option_kind(option: &str) -> HumanResponseKind {
+    let lower = option.to_ascii_lowercase();
+    if lower.starts_with("rej") || lower.starts_with("no") {
+        HumanResponseKind::Reject
+    } else if lower.starts_with("rev") {
+        HumanResponseKind::Revise
+    } else {
+        HumanResponseKind::Approve
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests assert with expect")]
+mod tests {
+    use super::*;
+    use tokio::sync::oneshot;
+
+    fn make_prompt(options: Vec<&str>) -> (HumanPrompt, oneshot::Receiver<HumanResponse>) {
+        let (tx, rx) = oneshot::channel();
+        let responder: HumanResponder = Arc::new(Mutex::new(Some(tx)));
+        let prompt = HumanPrompt::new(
+            "review".to_owned(),
+            "approve?".to_owned(),
+            None,
+            options.into_iter().map(str::to_owned).collect(),
+            responder,
+        );
+        (prompt, rx)
+    }
+
+    #[test]
+    fn focus_cycles_forward_and_backward() {
+        let (mut prompt, _rx) = make_prompt(vec!["approve", "reject", "revise"]);
+        assert_eq!(prompt.focused, 0);
+        prompt.focus_next();
+        assert_eq!(prompt.focused, 1);
+        prompt.focus_next();
+        prompt.focus_next();
+        assert_eq!(prompt.focused, 0);
+        prompt.focus_prev();
+        assert_eq!(prompt.focused, 2);
+    }
+
+    #[test]
+    fn focus_by_initial_jumps() {
+        // Use distinct first characters so jump-by-initial is
+        // unambiguous. The TUI's canonical options are
+        // approve / reject / revise — both reject & revise start with
+        // 'r'. The intended UX is that pressing `r` selects the first
+        // 'r' option encountered (reject) and the user can `Tab` to
+        // revise; mapping a single key to a single option is the only
+        // contract `focus_by_initial` makes.
+        let (mut prompt, _rx) = make_prompt(vec!["approve", "build", "cancel"]);
+        assert!(prompt.focus_by_initial('B'));
+        assert_eq!(prompt.focused, 1);
+        assert!(prompt.focus_by_initial('c'));
+        assert_eq!(prompt.focused, 2);
+        assert!(prompt.focus_by_initial('a'));
+        assert_eq!(prompt.focused, 0);
+        assert!(!prompt.focus_by_initial('x'));
+    }
+
+    #[test]
+    fn focus_by_initial_picks_first_match() {
+        // When multiple options share an initial, the first one wins.
+        let (mut prompt, _rx) = make_prompt(vec!["approve", "reject", "revise"]);
+        prompt.focus_next(); // jump off the first match so the test isn't trivial
+        assert!(prompt.focus_by_initial('r'));
+        assert_eq!(prompt.focused, 1, "first 'r' option should win");
+    }
+
+    #[test]
+    fn option_kind_maps_canonical_strings() {
+        assert_eq!(option_kind("approve"), HumanResponseKind::Approve);
+        assert_eq!(option_kind("Approve"), HumanResponseKind::Approve);
+        assert_eq!(option_kind("reject"), HumanResponseKind::Reject);
+        assert_eq!(option_kind("revise"), HumanResponseKind::Revise);
+        assert_eq!(option_kind("no"), HumanResponseKind::Reject);
+        assert_eq!(option_kind("yes"), HumanResponseKind::Approve);
+    }
+
+    #[tokio::test]
+    async fn respond_delivers_through_oneshot() {
+        let (prompt, rx) = make_prompt(vec!["approve", "reject", "revise"]);
+        prompt.respond(HumanResponse::approve()).await.expect("ok");
+        let resp = rx.await.expect("response received");
+        assert_eq!(resp.kind, HumanResponseKind::Approve);
+    }
+
+    #[tokio::test]
+    async fn double_respond_returns_err() {
+        let (prompt, _rx) = make_prompt(vec!["approve"]);
+        let handle = prompt.responder_handle();
+        // Manually drain so the second respond observes the empty slot.
+        let mut guard = handle.lock().await;
+        let _ = guard.take();
+        drop(guard);
+        let err = prompt.respond(HumanResponse::approve()).await;
+        assert!(err.is_err());
+    }
+}

--- a/crates/tmg-tui/src/human_prompt.rs
+++ b/crates/tmg-tui/src/human_prompt.rs
@@ -192,15 +192,17 @@ impl HumanPrompt {
 /// Map an option string to a response kind.
 ///
 /// Recognised prefixes (ASCII case-insensitive):
-/// * `app...` / `yes` / `ok`        → [`HumanResponseKind::Approve`]
+/// * `app...` (and `yes` / `ok` via the default arm) →
+///   [`HumanResponseKind::Approve`]
 /// * `rej...` / `no` / `deny`       → [`HumanResponseKind::Reject`]
 /// * `rev...`                        → [`HumanResponseKind::Revise`]
 ///
 /// Anything else falls back to `Approve` — workflow authors deviating
 /// from the canonical `approve / reject / revise` set are expected to
-/// use one of the affirmative aliases above; truly unrecognised strings
-/// are treated as approve so the modal cannot hard-error on a
-/// well-formed option list.
+/// use one of the affirmative aliases above (`yes` / `ok` reach
+/// `Approve` via this default arm rather than a special case); truly
+/// unrecognised strings are treated as approve so the modal cannot
+/// hard-error on a well-formed option list.
 #[must_use]
 pub fn option_kind(option: &str) -> HumanResponseKind {
     let lower = option.to_ascii_lowercase();

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -5,17 +5,21 @@
 
 pub mod activity;
 pub mod app;
+pub mod banner;
 pub mod diff;
 pub mod error;
 pub mod event;
+pub mod human_prompt;
 pub mod ui;
 
 pub use activity::{
     ActivityPane, RunHeader, RunProgressSection, ToolActivityEntry, WorkflowProgressSection,
 };
 pub use app::App;
+pub use banner::TransientBanner;
 pub use diff::DiffPreview;
 pub use error::TuiError;
+pub use human_prompt::HumanPrompt;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -28,7 +32,7 @@ use crossterm::execute;
 use tmg_agents::{CustomAgentDef, SubagentManager};
 use tmg_core::AgentLoop;
 use tmg_harness::{RunProgressReceiver, RunRunner, RunSummary};
-use tmg_workflow::WorkflowProgress;
+use tmg_workflow::{WorkflowMeta, WorkflowProgress};
 use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 
@@ -61,6 +65,8 @@ use tokio_util::sync::CancellationToken;
 ///   [`tmg_workflow::register_workflow_tools_with_observer`]); the
 ///   activity pane drains it every tick to surface live workflow
 ///   progress events.
+/// * `workflows` - Discovered workflows for the `/workflows` slash
+///   command listing. Empty vec disables that listing.
 ///
 /// # Errors
 ///
@@ -82,6 +88,7 @@ pub async fn run(
     runner: Option<Arc<Mutex<RunRunner>>>,
     run_progress_rx: Option<RunProgressReceiver>,
     workflow_progress_rx: Option<mpsc::Receiver<WorkflowProgress>>,
+    workflows: Vec<WorkflowMeta>,
 ) -> Result<(), TuiError> {
     // Pre-warm the syntect bundle off the rendering thread. Loading
     // `SyntaxSet::load_defaults_newlines` + `ThemeSet::load_defaults`
@@ -148,6 +155,10 @@ pub async fn run(
 
     if let Some(rx) = workflow_progress_rx {
         app.set_workflow_progress_rx(rx);
+    }
+
+    if !workflows.is_empty() {
+        app.set_workflows(workflows);
     }
 
     let result = event::run_event_loop(&mut terminal, &mut app, cancel).await;

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -32,6 +32,7 @@ use crossterm::execute;
 use tmg_agents::{CustomAgentDef, SubagentManager};
 use tmg_core::AgentLoop;
 use tmg_harness::{RunProgressReceiver, RunRunner, RunSummary};
+use tmg_skills::SkillMeta;
 use tmg_workflow::{WorkflowMeta, WorkflowProgress};
 use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
@@ -67,6 +68,8 @@ use tokio_util::sync::CancellationToken;
 ///   progress events.
 /// * `workflows` - Discovered workflows for the `/workflows` slash
 ///   command listing. Empty vec disables that listing.
+/// * `skills` - Discovered skills for the `/skills` slash command
+///   listing. Empty vec disables that listing.
 ///
 /// # Errors
 ///
@@ -89,6 +92,7 @@ pub async fn run(
     run_progress_rx: Option<RunProgressReceiver>,
     workflow_progress_rx: Option<mpsc::Receiver<WorkflowProgress>>,
     workflows: Vec<WorkflowMeta>,
+    skills: Vec<SkillMeta>,
 ) -> Result<(), TuiError> {
     // Pre-warm the syntect bundle off the rendering thread. Loading
     // `SyntaxSet::load_defaults_newlines` + `ThemeSet::load_defaults`
@@ -159,6 +163,10 @@ pub async fn run(
 
     if !workflows.is_empty() {
         app.set_workflows(workflows);
+    }
+
+    if !skills.is_empty() {
+        app.set_skills(skills);
     }
 
     let result = event::run_event_loop(&mut terminal, &mut app, cancel).await;

--- a/crates/tmg-tui/src/ui.rs
+++ b/crates/tmg-tui/src/ui.rs
@@ -33,10 +33,144 @@ pub fn draw(frame: &mut Frame, app: &App) {
     draw_main_area(frame, app, vertical[1]);
     draw_input_area(frame, app, vertical[2]);
 
+    // Draw the transient scope-upgrade banner overlay (SPEC §7.1).
+    // Uses the chat-pane region so it sits above the conversation.
+    if let Some(banner) = app.transient_banner() {
+        draw_transient_banner(frame, banner, vertical[1]);
+    }
+
+    // Draw the human-prompt modal (SPEC §8.4) on top of everything
+    // so it dominates the screen until dismissed.
+    if let Some(prompt) = app.human_prompt() {
+        draw_human_prompt(frame, prompt, size);
+    }
+
     // Draw error overlay if present.
     if let Some(err) = app.error_message() {
         draw_error_overlay(frame, err, size);
     }
+}
+
+/// Draw the transient scope-upgrade banner at the top of the chat
+/// pane.
+fn draw_transient_banner(frame: &mut Frame, banner: &crate::TransientBanner, area: Rect) {
+    let banner_height: u16 = 3;
+    if area.height < banner_height {
+        return;
+    }
+    // Position: top edge of the supplied region (typically the main
+    // area); width spans the full pane minus a small inset so it
+    // doesn't cover the activity pane border.
+    let banner_area = Rect {
+        x: area.x + 1,
+        y: area.y,
+        width: area.width.saturating_sub(2),
+        height: banner_height,
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Notice ")
+        .style(Style::default().fg(Color::Yellow));
+    let text = Paragraph::new(Span::styled(
+        format!("⚡ {}", banner.text),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    ))
+    .block(block)
+    .wrap(Wrap { trim: true });
+    frame.render_widget(
+        Block::default().style(Style::default().bg(Color::Black)),
+        banner_area,
+    );
+    frame.render_widget(text, banner_area);
+}
+
+/// Draw the human-prompt modal centred on the screen.
+fn draw_human_prompt(frame: &mut Frame, prompt: &crate::HumanPrompt, area: Rect) {
+    // Centre a box that's 60% of the screen wide and at most 16 lines
+    // tall (smaller for short messages).
+    let modal_width =
+        u16::try_from((u32::from(area.width) * 60 / 100).clamp(40, 100)).unwrap_or(u16::MAX);
+    let body_lines: u16 = u16::try_from(prompt.message.lines().count()).unwrap_or(u16::MAX);
+    let show_lines: u16 = prompt
+        .show
+        .as_ref()
+        .map_or(0, |s| u16::try_from(s.lines().count()).unwrap_or(u16::MAX));
+    let options_lines: u16 = u16::try_from(prompt.options.len().max(1)).unwrap_or(u16::MAX);
+    // Header (1) + message + show + spacer (1) + options + footer (1) + borders (2).
+    let modal_height = (3 + body_lines + show_lines + options_lines + 1).min(area.height);
+
+    if area.width < modal_width || area.height < modal_height {
+        return;
+    }
+
+    let modal_area = Rect {
+        x: area.x + (area.width.saturating_sub(modal_width)) / 2,
+        y: area.y + (area.height.saturating_sub(modal_height)) / 2,
+        width: modal_width,
+        height: modal_height,
+    };
+
+    // Clear behind the modal so the underlying chat doesn't bleed through.
+    frame.render_widget(
+        Block::default().style(Style::default().bg(Color::Black)),
+        modal_area,
+    );
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Human input — {} ", prompt.step_id))
+        .style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(modal_area);
+    frame.render_widget(block, modal_area);
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+    for ml in prompt.message.lines() {
+        lines.push(Line::from(Span::styled(
+            ml.to_owned(),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )));
+    }
+    if let Some(show) = &prompt.show {
+        lines.push(Line::from(""));
+        for s in show.lines() {
+            lines.push(Line::from(Span::styled(
+                s.to_owned(),
+                Style::default().fg(Color::Gray),
+            )));
+        }
+    }
+    lines.push(Line::from(""));
+    let mut opt_spans: Vec<Span<'_>> = Vec::new();
+    for (idx, opt) in prompt.options.iter().enumerate() {
+        let focused = idx == prompt.focused;
+        let style = if focused {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Yellow)
+        };
+        let label = if focused {
+            format!(" › {opt} ")
+        } else {
+            format!("   {opt} ")
+        };
+        opt_spans.push(Span::styled(label, style));
+    }
+    lines.push(Line::from(opt_spans));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Tab/←→: focus | Enter: confirm | a/r/v: jump | Esc: cancel",
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let p = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
+    frame.render_widget(p, inner);
 }
 
 /// Draw the header bar: model name, context usage, run header

--- a/crates/tmg-tui/src/ui.rs
+++ b/crates/tmg-tui/src/ui.rs
@@ -98,8 +98,13 @@ fn draw_human_prompt(frame: &mut Frame, prompt: &crate::HumanPrompt, area: Rect)
         .as_ref()
         .map_or(0, |s| u16::try_from(s.lines().count()).unwrap_or(u16::MAX));
     let options_lines: u16 = u16::try_from(prompt.options.len().max(1)).unwrap_or(u16::MAX);
-    // Header (1) + message + show + spacer (1) + options + footer (1) + borders (2).
-    let modal_height = (3 + body_lines + show_lines + options_lines + 1).min(area.height);
+    // Layout: top border (1) + message (body_lines) + spacer-before-options (1)
+    //       + options (options_lines) + spacer-before-footer (1) + footer (1)
+    //       + bottom border (1) = 5 + body + show + options.
+    // The `show` block (when present) inserts an extra leading spacer
+    // and `show_lines` content rows; the spacer is folded into
+    // `show_lines` when show is empty (saves one row in that case).
+    let modal_height = (5 + body_lines + show_lines + options_lines).min(area.height);
 
     if area.width < modal_width || area.height < modal_height {
         return;

--- a/crates/tmg-tui/src/ui.rs
+++ b/crates/tmg-tui/src/ui.rs
@@ -97,14 +97,24 @@ fn draw_human_prompt(frame: &mut Frame, prompt: &crate::HumanPrompt, area: Rect)
         .show
         .as_ref()
         .map_or(0, |s| u16::try_from(s.lines().count()).unwrap_or(u16::MAX));
+    // `options_lines` is an upper bound — the renderer collapses every
+    // option into a single ratatui `Line` (see `lines.push(Line::from(opt_spans))`
+    // below), so the actual height contribution is 1 row regardless of
+    // option count. We keep the per-option count here as a generous
+    // upper bound for narrow terminals where wrap can cause overflow,
+    // and clamp the final value to `area.height` regardless.
     let options_lines: u16 = u16::try_from(prompt.options.len().max(1)).unwrap_or(u16::MAX);
-    // Layout: top border (1) + message (body_lines) + spacer-before-options (1)
-    //       + options (options_lines) + spacer-before-footer (1) + footer (1)
-    //       + bottom border (1) = 5 + body + show + options.
-    // The `show` block (when present) inserts an extra leading spacer
-    // and `show_lines` content rows; the spacer is folded into
-    // `show_lines` when show is empty (saves one row in that case).
-    let modal_height = (5 + body_lines + show_lines + options_lines).min(area.height);
+    // Rendered rows (upper bound, clamped to `area.height`):
+    //   borders (2) + body + spacer-before-options (1) + options (1)
+    //   + spacer-before-footer (1) + footer (1)                = body + 6
+    //   plus, when `show` is present:
+    //       spacer-before-show (1) + show_lines                = show + 1
+    // The formula below sums those plus `options_lines` (an upper
+    // bound — see comment above) so it can over-estimate by
+    // `options_lines - 1` rows; `min(area.height)` papers over both
+    // the over- and under-estimate in practice.
+    let show_block = if show_lines > 0 { show_lines + 1 } else { 0 };
+    let modal_height = (6 + body_lines + show_block + options_lines).min(area.height);
 
     if area.width < modal_width || area.height < modal_height {
         return;

--- a/crates/tmg-workflow/src/progress.rs
+++ b/crates/tmg-workflow/src/progress.rs
@@ -85,6 +85,11 @@ pub enum WorkflowProgress {
         options: Vec<String>,
         /// Optional rendered `show:` payload.
         show: Option<String>,
+        /// Optional `revise_target` declared on the human step. The TUI
+        /// uses this to populate `HumanResponse::target` when the user
+        /// picks `revise`; without it, a `revise` choice cannot be
+        /// satisfied and the TUI surfaces an error.
+        revise_target: Option<String>,
         /// One-shot reply channel (see type docs for the
         /// take-once contract).
         response_tx: HumanResponder,

--- a/crates/tmg-workflow/src/steps/human.rs
+++ b/crates/tmg-workflow/src/steps/human.rs
@@ -76,6 +76,7 @@ pub(crate) async fn execute(
             message: rendered_message,
             options: options.clone(),
             show: rendered_show,
+            revise_target: revise_target.clone(),
             response_tx: Arc::clone(&responder),
         })
         .await;

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -259,6 +259,7 @@ fn main() -> anyhow::Result<()> {
                     &config.harness,
                     &config.sandbox,
                     &config.workflow,
+                    &config.skills,
                     None,
                 )
             }
@@ -340,6 +341,7 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
                 &config.harness,
                 &config.sandbox,
                 &config.workflow,
+                &config.skills,
                 resolved.as_ref(),
             )
         }
@@ -494,6 +496,7 @@ fn run_tui(
     harness_config: &HarnessConfig,
     sandbox_config: &SandboxConfigSection,
     workflow_config: &tmg_workflow::WorkflowConfig,
+    skills_config: &tmg_skills::SkillsConfig,
     explicit_run_id: Option<&tmg_harness::RunId>,
 ) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
@@ -814,6 +817,21 @@ fn run_tui(
             Some(guard.progress_channel())
         };
 
+        // Skill discovery for the `/skills` slash command listing.
+        // Failure is non-fatal: the TUI starts with an empty list and
+        // `/skills` simply reports no skills installed.
+        let skill_metas =
+            match tmg_skills::discover_skills_with_config(&project_root, skills_config).await {
+                Ok(list) => list,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "skill discovery failed; /skills will report an empty list",
+                    );
+                    Vec::new()
+                }
+            };
+
         let tui_cancel = cancel.clone();
         let tui_result = tmg_tui::run(
             agent,
@@ -829,6 +847,7 @@ fn run_tui(
             run_progress_rx,
             workflow_progress_rx,
             workflow_metas.clone(),
+            skill_metas,
         )
         .await;
 

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -828,6 +828,7 @@ fn run_tui(
             Some(Arc::clone(&runner)),
             run_progress_rx,
             workflow_progress_rx,
+            workflow_metas.clone(),
         )
         .await;
 


### PR DESCRIPTION
## Summary

- Extends `tmg-skills::SlashCommand` with the TUI-level commands listed in SPEC §7.3 / §9.8 (`/clear`, `/compact`, `/exit`, `/agents`, `/workflows`, full `/run *` family) and a structured `SlashParseError` so malformed `/run` input surfaces a precise message.
- Routes every TUI slash command through a single `App::dispatch_slash` with a sync/async split — synchronous variants execute in place; `/run *` and skills are queued for `dispatch_slash_async`, which calls `tmg_harness::commands` and renders results as system chat entries.
- Adds a transient scope-upgrade banner overlay (SPEC §7.1) driven by `RunProgressEvent::ScopeUpgraded`, with a 3-second TTL.
- Adds the SPEC §8.4 human-step modal (`HumanPrompt`) — Tab/arrow focus, letter jumps, Enter-confirm, Esc/Ctrl+C cancel — wired into `WorkflowProgress::HumanInputRequired` and delivering responses via the carried oneshot.
- Pipes discovered `WorkflowMeta` into the TUI so `/workflows` enumerates available workflows.

## Crates touched

- `tmg-skills` — extended `SlashCommand` enum, added `SlashParseError`, rewrote `parse_slash_command`.
- `tmg-tui` — new `banner.rs` and `human_prompt.rs` modules; `app.rs`/`event.rs`/`ui.rs` updated for overlay rendering, the modal key handler, the async slash dispatcher, and the workflow listing.
- `tmg-cli` — passes the discovered `WorkflowMeta` list into `tmg_tui::run`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (added 12 new unit tests across `tmg-skills::slash` and `tmg-tui::{banner, human_prompt}`)

## Runtime Verification

- LLM server: available
- One-shot mode: PASS
  - Events: 1 token, 0 tool calls, 0 errors, done event present (via `--prompt "Say hello in one word"`)
- TUI mode: SKIP
  - `expect`/`script` harnesses cannot reliably drive ratatui's raw-mode + Kitty-keyboard input (sends are absorbed before the TUI's `event::poll` loop sees them); the binary launches and renders cleanly per the captured terminal stream and the `--event-log` file is created at the configured path. Manual smoke-testing recommended: run `tmg`, type `/workflows`, `/run status`, `/run upgrade`, then issue a regular chat to confirm streaming + the new overlay paths.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)