### PR TITLE
tmg-llm / 設定: EndpointResolver + count_tokens_or_estimate + tracing wiring (#50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1042,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1092,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1675,6 +1699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +1910,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1991,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -1979,6 +2022,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2033,6 +2077,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -2307,6 +2352,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2462,6 +2537,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ anyhow = "1"
 
 # Logging / diagnostics
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Random
 rand = "0.9"

--- a/crates/tmg-agents/Cargo.toml
+++ b/crates/tmg-agents/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { workspace = true, features = ["sync", "fs"] }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 dirs = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tmg-agents/src/endpoint_resolver.rs
+++ b/crates/tmg-agents/src/endpoint_resolver.rs
@@ -1,0 +1,476 @@
+//! Centralised `(endpoint, model)` resolution for subagent spawns.
+//!
+//! Replaces the ad-hoc precedence ladder previously implemented inline
+//! in `SubagentManager`. Issue #50 moved the rules into this module so
+//! the SPEC §10.1 / §9.10 / §9.3 precedence is one self-contained,
+//! well-tested unit:
+//!
+//! 1. `AgentKind::Custom`: the `CustomAgentDef`'s `endpoint` /
+//!    `model` win when set (non-empty after the `from_strings`
+//!    normalisation). Missing fields fall back to the next layer.
+//! 2. `AgentKind::Builtin(AgentType::Escalator)`: the
+//!    [`EscalatorOverrides`] win when set. Missing fields fall through
+//!    to step 4 (the escalator never routes through the pool — see
+//!    SPEC §9.10).
+//! 3. Every other `AgentKind::Builtin`: the [`tmg_llm::LlmPool`] picks
+//!    an endpoint when one is configured with two or more endpoints
+//!    (single-endpoint pools are skipped so the `main` fallback
+//!    always wins). The model is always inherited from `main` because
+//!    the pool only varies the URL.
+//! 4. Final fallback: the main `(endpoint, model)` pair.
+//!
+//! The resolver is `Send + Sync` so the
+//! [`SubagentManager`](crate::manager::SubagentManager) can hand a
+//! `&self` reference to the spawn closure without an extra
+//! `Arc<Mutex<_>>`. Pool selection is async (the pool's read lock
+//! lives in tokio); the resolver therefore exposes
+//! [`EndpointResolver::resolve`] as an `async fn`.
+
+use std::sync::Arc;
+
+use tmg_llm::LlmPool;
+
+use crate::config::{AgentKind, AgentType};
+use crate::manager::EscalatorOverrides;
+
+/// The provenance label written to the event log when an endpoint is
+/// resolved. Centralised here so the `--event-log` reader has a stable
+/// vocabulary to filter on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolutionSource {
+    /// A [`CustomAgentDef`] supplied an explicit endpoint and/or model.
+    Custom,
+    /// An [`EscalatorOverrides`] entry took precedence (escalator only).
+    EscalatorOverride,
+    /// A multi-endpoint [`LlmPool`] picked an endpoint.
+    Pool,
+    /// The main `(endpoint, model)` pair was used (default fallback).
+    Main,
+}
+
+impl ResolutionSource {
+    /// The string emitted into `event_log` records.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ResolutionSource::Custom => "custom",
+            ResolutionSource::EscalatorOverride => "escalator_override",
+            ResolutionSource::Pool => "pool",
+            ResolutionSource::Main => "main",
+        }
+    }
+}
+
+/// One resolved `(endpoint, model)` pair plus the source that
+/// produced it.
+///
+/// The endpoint is intentionally kept as `String` rather than `Url` to
+/// avoid pulling the `url` crate as a direct dependency: every
+/// downstream caller (`LlmClientConfig`, `LlmPool`, the event log)
+/// already accepts a `String`. SPEC-compliant URL validation lives in
+/// [`tmg_llm::PoolConfig::validate`] and the CLI config validator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedEndpoint {
+    /// The base URL that the spawn should route to.
+    pub endpoint: String,
+    /// The model name to embed in chat-completion requests.
+    pub model: String,
+    /// Which precedence rule produced this pair.
+    pub source: ResolutionSource,
+}
+
+/// Resolves the `(endpoint, model)` pair for a subagent spawn.
+///
+/// Constructed once per [`SubagentManager`](crate::manager::SubagentManager)
+/// and consulted on every [`SubagentManager::spawn`] /
+/// [`SubagentManager::spawn_with_notify`] call.
+#[derive(Debug, Clone)]
+pub struct EndpointResolver {
+    main_endpoint: String,
+    main_model: String,
+    pool: Option<Arc<LlmPool>>,
+    escalator_override: EscalatorOverrides,
+}
+
+impl EndpointResolver {
+    /// Build a resolver with only the main `(endpoint, model)` pair.
+    /// Equivalent to "no pool, no escalator overrides".
+    #[must_use]
+    pub fn new(main_endpoint: impl Into<String>, main_model: impl Into<String>) -> Self {
+        Self {
+            main_endpoint: main_endpoint.into(),
+            main_model: main_model.into(),
+            pool: None,
+            escalator_override: EscalatorOverrides::default(),
+        }
+    }
+
+    /// Install (or replace) the [`LlmPool`] used at step 3 of the
+    /// precedence ladder. A single-endpoint pool is silently skipped
+    /// because the resolver would just produce the same URL the
+    /// `main` fallback does.
+    #[must_use]
+    pub fn with_pool(mut self, pool: Option<Arc<LlmPool>>) -> Self {
+        self.pool = pool;
+        self
+    }
+
+    /// Install (or replace) the [`EscalatorOverrides`] consulted at
+    /// step 2 of the precedence ladder.
+    #[must_use]
+    pub fn with_escalator_overrides(mut self, overrides: EscalatorOverrides) -> Self {
+        self.escalator_override = overrides;
+        self
+    }
+
+    /// Borrow the main endpoint URL so the manager can decide whether
+    /// to reuse its shared `LlmClient` (when the resolved URL matches)
+    /// or construct a per-spawn client.
+    #[must_use]
+    pub fn main_endpoint(&self) -> &str {
+        &self.main_endpoint
+    }
+
+    /// Borrow the main model name for the same reason as
+    /// [`Self::main_endpoint`].
+    #[must_use]
+    pub fn main_model(&self) -> &str {
+        &self.main_model
+    }
+
+    /// Borrow the currently-installed escalator overrides. The
+    /// manager reads `disabled` to short-circuit before allocating a
+    /// subagent ID.
+    #[must_use]
+    pub fn escalator_overrides(&self) -> &EscalatorOverrides {
+        &self.escalator_override
+    }
+
+    /// Resolve the `(endpoint, model)` pair for the supplied
+    /// [`AgentKind`].
+    ///
+    /// See the module docs for the precedence rules. This is `async`
+    /// because step 3 may need to acquire the pool's read lock.
+    pub async fn resolve(&self, kind: &AgentKind) -> ResolvedEndpoint {
+        // Step 1: custom agent overrides.
+        if let AgentKind::Custom(def) = kind {
+            // Custom agents may set either field independently. We
+            // resolve them separately so a custom agent that only sets
+            // `endpoint` still picks up `main_model`.
+            let endpoint = def
+                .endpoint()
+                .map_or_else(|| self.main_endpoint.clone(), str::to_owned);
+            let model = def
+                .model()
+                .map_or_else(|| self.main_model.clone(), str::to_owned);
+            // Source is `Custom` whenever at least one field came from
+            // the def; this matches the operator's mental model of
+            // "the custom agent overrode the main config".
+            let any_override = def.endpoint().is_some() || def.model().is_some();
+            let source = if any_override {
+                ResolutionSource::Custom
+            } else {
+                ResolutionSource::Main
+            };
+            tracing::debug!(
+                agent = %kind.name(),
+                endpoint = %endpoint,
+                model = %model,
+                source = source.as_str(),
+                "endpoint resolved",
+            );
+            return ResolvedEndpoint {
+                endpoint,
+                model,
+                source,
+            };
+        }
+
+        // Step 2: escalator overrides win for the escalator builtin.
+        if matches!(kind, AgentKind::Builtin(AgentType::Escalator)) {
+            let endpoint = self
+                .escalator_override
+                .endpoint
+                .clone()
+                .unwrap_or_else(|| self.main_endpoint.clone());
+            let model = self
+                .escalator_override
+                .model
+                .clone()
+                .unwrap_or_else(|| self.main_model.clone());
+            let source = if self.escalator_override.endpoint.is_some()
+                || self.escalator_override.model.is_some()
+            {
+                ResolutionSource::EscalatorOverride
+            } else {
+                ResolutionSource::Main
+            };
+            tracing::debug!(
+                agent = %kind.name(),
+                endpoint = %endpoint,
+                model = %model,
+                source = source.as_str(),
+                "endpoint resolved",
+            );
+            return ResolvedEndpoint {
+                endpoint,
+                model,
+                source,
+            };
+        }
+
+        // Step 3: try the pool for any other builtin. We only consult
+        // multi-endpoint pools so a single-endpoint pool reuses the
+        // main fallback (avoids redundant logging and a needless lock
+        // acquisition).
+        if let Some(pool) = self.pool.as_ref() {
+            match pool.pick_endpoint_url().await {
+                Ok(Some(picked)) => {
+                    tracing::debug!(
+                        agent = %kind.name(),
+                        endpoint = %picked,
+                        model = %self.main_model,
+                        source = ResolutionSource::Pool.as_str(),
+                        "endpoint resolved",
+                    );
+                    return ResolvedEndpoint {
+                        endpoint: picked,
+                        model: self.main_model.clone(),
+                        source: ResolutionSource::Pool,
+                    };
+                }
+                Ok(None) => {
+                    // Single-endpoint pool: fall through to main.
+                }
+                Err(e) => {
+                    // Pool selection failure (e.g. all endpoints
+                    // unhealthy) — log and fall back to main so the
+                    // subagent still has a chance to run.
+                    tracing::warn!(
+                        agent = %kind.name(),
+                        error = %e,
+                        "pool endpoint selection failed; falling back to main",
+                    );
+                }
+            }
+        }
+
+        // Step 4: main fallback.
+        tracing::debug!(
+            agent = %kind.name(),
+            endpoint = %self.main_endpoint,
+            model = %self.main_model,
+            source = ResolutionSource::Main.as_str(),
+            "endpoint resolved",
+        );
+        ResolvedEndpoint {
+            endpoint: self.main_endpoint.clone(),
+            model: self.main_model.clone(),
+            source: ResolutionSource::Main,
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(clippy::panic, reason = "test assertions")]
+#[expect(
+    clippy::similar_names,
+    reason = "tests intentionally pair `resolver` (the under-test value) with `resolved` (its output) for readability"
+)]
+mod tests {
+    use super::*;
+    use tmg_llm::{LoadBalanceStrategy, PoolConfig};
+
+    fn main_resolver() -> EndpointResolver {
+        EndpointResolver::new("http://main:8080", "main-model")
+    }
+
+    #[tokio::test]
+    async fn builtin_resolves_to_main_with_no_pool_no_overrides() {
+        let resolver = main_resolver();
+        let resolved = resolver
+            .resolve(&AgentKind::Builtin(AgentType::Explore))
+            .await;
+        assert_eq!(resolved.endpoint, "http://main:8080");
+        assert_eq!(resolved.model, "main-model");
+        assert_eq!(resolved.source, ResolutionSource::Main);
+    }
+
+    #[tokio::test]
+    async fn escalator_uses_overrides_when_set() {
+        let resolver = main_resolver().with_escalator_overrides(EscalatorOverrides::from_strings(
+            "http://escalator.invalid".to_owned(),
+            "lite".to_owned(),
+            false,
+        ));
+        let resolved = resolver
+            .resolve(&AgentKind::Builtin(AgentType::Escalator))
+            .await;
+        assert_eq!(resolved.endpoint, "http://escalator.invalid");
+        assert_eq!(resolved.model, "lite");
+        assert_eq!(resolved.source, ResolutionSource::EscalatorOverride);
+    }
+
+    #[tokio::test]
+    async fn escalator_falls_back_to_main_when_overrides_empty() {
+        let resolver = main_resolver().with_escalator_overrides(EscalatorOverrides::from_strings(
+            String::new(),
+            String::new(),
+            false,
+        ));
+        let resolved = resolver
+            .resolve(&AgentKind::Builtin(AgentType::Escalator))
+            .await;
+        assert_eq!(resolved.endpoint, "http://main:8080");
+        assert_eq!(resolved.model, "main-model");
+        assert_eq!(resolved.source, ResolutionSource::Main);
+    }
+
+    #[tokio::test]
+    async fn escalator_does_not_route_through_pool() {
+        // Even when a multi-endpoint pool is installed, the escalator
+        // must not be load-balanced (SPEC §9.10 cost-control).
+        let pool = Arc::new(
+            LlmPool::new(
+                &PoolConfig {
+                    endpoints: vec![
+                        "http://pool-a:8080".to_owned(),
+                        "http://pool-b:8080".to_owned(),
+                    ],
+                    strategy: LoadBalanceStrategy::RoundRobin,
+                },
+                "main-model",
+            )
+            .expect("pool"),
+        );
+        let resolver = main_resolver().with_pool(Some(pool));
+        let resolved = resolver
+            .resolve(&AgentKind::Builtin(AgentType::Escalator))
+            .await;
+        assert_eq!(resolved.endpoint, "http://main:8080");
+        assert_eq!(resolved.source, ResolutionSource::Main);
+    }
+
+    #[tokio::test]
+    async fn builtin_routes_through_multi_endpoint_pool() {
+        let pool = Arc::new(
+            LlmPool::new(
+                &PoolConfig {
+                    endpoints: vec![
+                        "http://pool-a:8080".to_owned(),
+                        "http://pool-b:8080".to_owned(),
+                    ],
+                    strategy: LoadBalanceStrategy::RoundRobin,
+                },
+                "main-model",
+            )
+            .expect("pool"),
+        );
+        let resolver = main_resolver().with_pool(Some(pool));
+        let resolved = resolver
+            .resolve(&AgentKind::Builtin(AgentType::Explore))
+            .await;
+        // The pool starts with all endpoints in `Unknown` health, so
+        // the round-robin counter picks `pool-a` first.
+        assert_eq!(resolved.endpoint, "http://pool-a:8080");
+        assert_eq!(resolved.model, "main-model");
+        assert_eq!(resolved.source, ResolutionSource::Pool);
+    }
+
+    #[tokio::test]
+    async fn builtin_skips_single_endpoint_pool() {
+        // A single-endpoint pool is a no-op: it would just yield the
+        // same URL as the main fallback, so the resolver should record
+        // the main source rather than `pool` to keep event-log
+        // semantics meaningful.
+        let pool = Arc::new(
+            LlmPool::new(&PoolConfig::single("http://main:8080"), "main-model").expect("pool"),
+        );
+        let resolver = main_resolver().with_pool(Some(pool));
+        let resolved = resolver
+            .resolve(&AgentKind::Builtin(AgentType::Worker))
+            .await;
+        assert_eq!(resolved.endpoint, "http://main:8080");
+        assert_eq!(resolved.source, ResolutionSource::Main);
+    }
+
+    #[tokio::test]
+    async fn custom_agent_overrides_main() {
+        let toml = r#"
+name = "reviewer"
+description = "test"
+instructions = "do things"
+endpoint = "http://custom:7777"
+model = "custom-model"
+
+[tools]
+allow = ["file_read"]
+"#;
+        let def = crate::custom::CustomAgentDef::from_toml(toml, "test.toml")
+            .unwrap_or_else(|e| panic!("{e}"));
+        let kind = AgentKind::Custom(Arc::new(def));
+        let resolver = main_resolver();
+        let resolved = resolver.resolve(&kind).await;
+        assert_eq!(resolved.endpoint, "http://custom:7777");
+        assert_eq!(resolved.model, "custom-model");
+        assert_eq!(resolved.source, ResolutionSource::Custom);
+    }
+
+    #[tokio::test]
+    async fn custom_agent_with_partial_override_inherits_main_for_missing_field() {
+        let toml = r#"
+name = "reviewer"
+description = "test"
+instructions = "do things"
+endpoint = "http://custom:7777"
+
+[tools]
+allow = ["file_read"]
+"#;
+        let def = crate::custom::CustomAgentDef::from_toml(toml, "test.toml")
+            .unwrap_or_else(|e| panic!("{e}"));
+        let kind = AgentKind::Custom(Arc::new(def));
+        let resolver = main_resolver();
+        let resolved = resolver.resolve(&kind).await;
+        assert_eq!(resolved.endpoint, "http://custom:7777");
+        assert_eq!(resolved.model, "main-model");
+        assert_eq!(resolved.source, ResolutionSource::Custom);
+    }
+
+    #[tokio::test]
+    async fn custom_agent_overrides_take_precedence_over_pool() {
+        // SPEC §10.1: custom-agent overrides bypass the pool entirely.
+        let pool = Arc::new(
+            LlmPool::new(
+                &PoolConfig {
+                    endpoints: vec![
+                        "http://pool-a:8080".to_owned(),
+                        "http://pool-b:8080".to_owned(),
+                    ],
+                    strategy: LoadBalanceStrategy::RoundRobin,
+                },
+                "main-model",
+            )
+            .expect("pool"),
+        );
+        let toml = r#"
+name = "reviewer"
+description = "test"
+instructions = "do things"
+endpoint = "http://custom:7777"
+model = "custom-model"
+
+[tools]
+allow = ["file_read"]
+"#;
+        let def = crate::custom::CustomAgentDef::from_toml(toml, "test.toml")
+            .unwrap_or_else(|e| panic!("{e}"));
+        let kind = AgentKind::Custom(Arc::new(def));
+        let resolver = main_resolver().with_pool(Some(pool));
+        let resolved = resolver.resolve(&kind).await;
+        assert_eq!(resolved.endpoint, "http://custom:7777");
+        assert_eq!(resolved.model, "custom-model");
+        assert_eq!(resolved.source, ResolutionSource::Custom);
+    }
+}

--- a/crates/tmg-agents/src/endpoint_resolver.rs
+++ b/crates/tmg-agents/src/endpoint_resolver.rs
@@ -123,6 +123,15 @@ impl EndpointResolver {
         self
     }
 
+    /// Replace the [`EscalatorOverrides`] in-place.
+    ///
+    /// Useful for callers that already own a mutable reference to the
+    /// resolver (e.g. [`SubagentManager::set_escalator_overrides`])
+    /// and want to avoid cloning the resolver just to swap one field.
+    pub fn set_escalator_overrides(&mut self, overrides: EscalatorOverrides) {
+        self.escalator_override = overrides;
+    }
+
     /// Borrow the main endpoint URL so the manager can decide whether
     /// to reuse its shared `LlmClient` (when the resolved URL matches)
     /// or construct a per-spawn client.
@@ -151,6 +160,12 @@ impl EndpointResolver {
     ///
     /// See the module docs for the precedence rules. This is `async`
     /// because step 3 may need to acquire the pool's read lock.
+    ///
+    /// Allocates three `String`s on every call (one per resolved
+    /// field). The cost is dwarfed by the spawn / LLM-client
+    /// construction the caller does next, so the allocation is
+    /// intentionally not optimised away.
+    #[must_use = "the resolved endpoint is the only output; ignoring it would make the call pointless"]
     pub async fn resolve(&self, kind: &AgentKind) -> ResolvedEndpoint {
         // Step 1: custom agent overrides.
         if let AgentKind::Custom(def) = kind {
@@ -436,6 +451,86 @@ allow = ["file_read"]
         assert_eq!(resolved.endpoint, "http://custom:7777");
         assert_eq!(resolved.model, "main-model");
         assert_eq!(resolved.source, ResolutionSource::Custom);
+    }
+
+    /// Two sequential resolves on a 2-endpoint pool must yield two
+    /// different URLs, proving the round-robin counter advances on
+    /// every call. Regression for issue #50 review: previously only
+    /// single-call resolves were tested.
+    #[tokio::test]
+    async fn pool_round_robin_advances_across_two_resolves() {
+        let pool = Arc::new(
+            LlmPool::new(
+                &PoolConfig {
+                    endpoints: vec![
+                        "http://pool-a:8080".to_owned(),
+                        "http://pool-b:8080".to_owned(),
+                    ],
+                    strategy: LoadBalanceStrategy::RoundRobin,
+                },
+                "main-model",
+            )
+            .expect("pool"),
+        );
+        let resolver = main_resolver().with_pool(Some(pool));
+        let kind = AgentKind::Builtin(AgentType::Worker);
+        let first = resolver.resolve(&kind).await;
+        let second = resolver.resolve(&kind).await;
+        assert_eq!(first.source, ResolutionSource::Pool);
+        assert_eq!(second.source, ResolutionSource::Pool);
+        assert_ne!(
+            first.endpoint, second.endpoint,
+            "round-robin must advance: first={}, second={}",
+            first.endpoint, second.endpoint,
+        );
+    }
+
+    /// Concurrent resolves on a 3-endpoint pool must each pick a
+    /// distinct URL when the counter is incremented atomically. The
+    /// `tokio::join!` schedules both futures on the same runtime, so
+    /// any non-atomic increment would surface as a duplicate URL with
+    /// reasonable frequency under stress; the deterministic assertion
+    /// here is the strongest guarantee we can make without adding a
+    /// fuzz harness.
+    #[tokio::test]
+    async fn pool_round_robin_handles_concurrent_resolves() {
+        let pool = Arc::new(
+            LlmPool::new(
+                &PoolConfig {
+                    endpoints: vec![
+                        "http://pool-a:8080".to_owned(),
+                        "http://pool-b:8080".to_owned(),
+                        "http://pool-c:8080".to_owned(),
+                    ],
+                    strategy: LoadBalanceStrategy::RoundRobin,
+                },
+                "main-model",
+            )
+            .expect("pool"),
+        );
+        let resolver = main_resolver().with_pool(Some(pool));
+        let kind = AgentKind::Builtin(AgentType::Worker);
+
+        // Three concurrent resolves should produce a permutation of
+        // the three endpoint URLs (the round-robin counter starts at 0
+        // and increments atomically). We collect into a `HashSet` to
+        // assert uniqueness; any drop in the count proves the
+        // `AtomicUsize` did not behave under contention.
+        let (a, b, c) = tokio::join!(
+            resolver.resolve(&kind),
+            resolver.resolve(&kind),
+            resolver.resolve(&kind),
+        );
+        let urls: std::collections::HashSet<String> =
+            [a.endpoint, b.endpoint, c.endpoint].into_iter().collect();
+        assert_eq!(
+            urls.len(),
+            3,
+            "concurrent resolves must each pick a distinct URL; got {urls:?}",
+        );
+        assert!(urls.contains("http://pool-a:8080"));
+        assert!(urls.contains("http://pool-b:8080"));
+        assert!(urls.contains("http://pool-c:8080"));
     }
 
     #[tokio::test]

--- a/crates/tmg-agents/src/lib.rs
+++ b/crates/tmg-agents/src/lib.rs
@@ -29,8 +29,8 @@ pub use endpoint_resolver::{EndpointResolver, ResolutionSource, ResolvedEndpoint
 pub use error::AgentError;
 pub use escalator::{EscalatorVerdict, ParseError as EscalatorParseError, parse_verdict};
 pub use manager::{
-    EndpointResolvedHook, EscalatorOverrides, SubagentId, SubagentManager, SubagentSummary,
-    derive_sandbox,
+    EndpointResolvedEvent, EndpointResolvedHook, EscalatorOverrides, SubagentId, SubagentManager,
+    SubagentSummary, derive_sandbox,
 };
 pub use runner::SubagentRunner;
 pub use status::{SubagentStatus, truncate_str};

--- a/crates/tmg-agents/src/lib.rs
+++ b/crates/tmg-agents/src/lib.rs
@@ -10,6 +10,7 @@ pub mod builtins;
 pub mod config;
 pub mod custom;
 pub mod discovery;
+pub mod endpoint_resolver;
 pub mod error;
 pub mod escalator;
 pub mod manager;
@@ -24,10 +25,12 @@ pub use builtins::{
 pub use config::{AgentKind, AgentType, SubagentConfig};
 pub use custom::{AgentSource, CustomAgentDef, CustomAgentMeta};
 pub use discovery::discover_custom_agents;
+pub use endpoint_resolver::{EndpointResolver, ResolutionSource, ResolvedEndpoint};
 pub use error::AgentError;
 pub use escalator::{EscalatorVerdict, ParseError as EscalatorParseError, parse_verdict};
 pub use manager::{
-    EscalatorOverrides, SubagentId, SubagentManager, SubagentSummary, derive_sandbox,
+    EndpointResolvedHook, EscalatorOverrides, SubagentId, SubagentManager, SubagentSummary,
+    derive_sandbox,
 };
 pub use runner::SubagentRunner;
 pub use status::{SubagentStatus, truncate_str};

--- a/crates/tmg-agents/src/manager.rs
+++ b/crates/tmg-agents/src/manager.rs
@@ -6,25 +6,21 @@
 //!
 //! ## Endpoint / model resolution
 //!
-//! Each spawn picks an `(endpoint, model)` pair using the precedence
-//! rules in [`SubagentManager::resolve_endpoint`]:
+//! Each spawn picks an `(endpoint, model)` pair via an
+//! [`EndpointResolver`](crate::endpoint_resolver::EndpointResolver)
+//! installed at construction time. The resolver applies SPEC §10.1 /
+//! §9.10 / §9.3 precedence:
 //!
-//! - [`AgentKind::Custom`]: a non-empty `endpoint` / `model` on the
-//!   custom-agent definition wins; missing fields fall back to the
-//!   manager defaults.
-//! - [`AgentKind::Builtin`] of [`AgentType::Escalator`]: non-empty
-//!   values from [`EscalatorOverrides`] win; missing fields fall back
-//!   to the manager defaults so the escalator can transparently share
-//!   the main endpoint until a dedicated lightweight model is
-//!   configured.
-//! - All other built-in agents always run on the manager defaults.
+//! 1. `AgentKind::Custom`: the custom def's endpoint/model win.
+//! 2. `AgentKind::Builtin(AgentType::Escalator)`: the
+//!    [`EscalatorOverrides`] win; the escalator never routes through
+//!    the pool (cost-control).
+//! 3. Other `AgentKind::Builtin`: a multi-endpoint
+//!    [`tmg_llm::LlmPool`] picks an endpoint when configured.
+//! 4. Otherwise the main `(endpoint, model)` pair is used.
 //!
-//! TODO(SPEC §10.1 `[llm.subagent_pool]`): when load-balanced subagent
-//! endpoints land, the round-robin pool MUST NOT route the escalator;
-//! the escalator owns its dedicated endpoint so its cost stays
-//! predictable (SPEC §9.10). Keep that wiring out of
-//! `resolve_endpoint` for the escalator branch even after the pool
-//! exists.
+//! See [`crate::endpoint_resolver`] for the canonical implementation
+//! and tests of these rules.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -41,9 +37,20 @@ use crate::builtins::{
     RunToolProvider, registry_for_agent_kind, registry_for_agent_kind_with_run_provider,
 };
 use crate::config::{AgentKind, AgentType, SubagentConfig};
+use crate::endpoint_resolver::{EndpointResolver, ResolvedEndpoint};
 use crate::error::AgentError;
 use crate::runner::SubagentRunner;
 use crate::status::SubagentStatus;
+
+/// Boxed observer the manager invokes whenever an
+/// [`EndpointResolver`] resolves a spawn target.
+///
+/// The hook is intentionally string-shaped (and synchronous) so the
+/// manager does not need a direct dependency on
+/// [`tmg_core::EventLogWriter`]; the CLI's TUI startup wires this up to
+/// `event_log.write_endpoint_resolved` when an `--event-log` path was
+/// supplied. Issue #50.
+pub type EndpointResolvedHook = Arc<dyn Fn(&str, &str, &str, &str) + Send + Sync + 'static>;
 
 /// Optional overrides for the escalator subagent's `(endpoint, model)`
 /// pair plus an explicit disable switch (SPEC §9.10 / §10.1
@@ -129,14 +136,16 @@ struct SubagentInstance {
 /// tasks are tracked and can be shut down together via
 /// [`SubagentManager::shutdown`].
 pub struct SubagentManager {
-    /// The LLM client shared with all subagents.
+    /// The LLM client shared with all subagents whose resolved
+    /// endpoint matches the resolver's main `(endpoint, model)` pair.
     client: LlmClient,
 
-    /// Default endpoint URL (used when a custom agent does not override it).
-    default_endpoint: String,
-
-    /// Default model name (used when a custom agent does not override it).
-    default_model: String,
+    /// Centralised endpoint / model resolver. Owns the main fallback,
+    /// the escalator overrides, and (optionally) a multi-endpoint
+    /// pool. Issue #50 moved the precedence rules out of this struct
+    /// into [`EndpointResolver`] so the rules live in one well-tested
+    /// module.
+    resolver: EndpointResolver,
 
     /// The parent cancellation token.
     parent_cancel: CancellationToken,
@@ -164,12 +173,6 @@ pub struct SubagentManager {
     /// behaviour for Run-less code paths.
     run_tool_provider: Option<Arc<dyn RunToolProvider>>,
 
-    /// Optional overrides for the escalator's endpoint / model and
-    /// the operator's disable switch. Defaults to "no overrides, not
-    /// disabled" so manager construction stays a single positional
-    /// call until a `[harness.escalator]` section is present.
-    escalator_overrides: EscalatorOverrides,
-
     /// Parent [`SandboxContext`] from which each spawn derives its
     /// per-subagent sandbox.
     ///
@@ -180,6 +183,13 @@ pub struct SubagentManager {
     /// [`SubagentManager::new`], so production callers cannot
     /// silently fall back to an unrestricted default.
     parent_sandbox: Arc<SandboxContext>,
+
+    /// Optional observer fired on every successful endpoint
+    /// resolution. The CLI wires this up to
+    /// [`tmg_core::EventLogWriter::write_endpoint_resolved`] so the
+    /// `--event-log` debug stream records the precedence rule that
+    /// fired. Issue #50.
+    resolved_hook: Option<EndpointResolvedHook>,
 }
 
 /// Derive a per-subagent [`SandboxContext`] from a parent context and
@@ -205,36 +215,51 @@ pub fn derive_sandbox(parent: &SandboxContext, mode: SandboxMode) -> SandboxCont
 impl SubagentManager {
     /// Create a new subagent manager.
     ///
-    /// The `default_endpoint` and `default_model` are used when a custom
-    /// agent does not specify its own endpoint/model overrides.
-    /// The escalator overrides default to "no overrides, not disabled";
-    /// install them with [`Self::with_escalator_overrides`] when a
-    /// `[harness.escalator]` section is configured.
+    /// The `resolver` is the centralised
+    /// [`EndpointResolver`] that picks an `(endpoint, model)` pair
+    /// for every spawn following SPEC §10.1 / §9.10 / §9.3 precedence.
+    /// Existing callers that only have a `(endpoint, model)` pair to
+    /// hand can construct one with [`EndpointResolver::new`]; callers
+    /// that have a configured `[llm.subagent_pool]` should attach it
+    /// via [`EndpointResolver::with_pool`].
     ///
     /// The `parent_sandbox` argument is **required**: it is the
     /// [`SandboxContext`] from which every spawned subagent derives
     /// its own sandbox. Making it a constructor argument prevents
     /// callers from accidentally spawning subagents under an
     /// unrestricted default (issue #47 follow-up).
+    ///
+    /// Issue #50 made `resolver` a constructor argument (replacing the
+    /// `default_endpoint` / `default_model` strings). To install
+    /// escalator overrides, call
+    /// [`EndpointResolver::with_escalator_overrides`] before passing
+    /// the resolver in, or use the in-place setter
+    /// [`Self::set_escalator_overrides`].
     pub fn new(
         client: LlmClient,
         parent_cancel: CancellationToken,
-        default_endpoint: impl Into<String>,
-        default_model: impl Into<String>,
+        resolver: EndpointResolver,
         parent_sandbox: Arc<SandboxContext>,
     ) -> Self {
         Self {
             client,
-            default_endpoint: default_endpoint.into(),
-            default_model: default_model.into(),
+            resolver,
             parent_cancel,
             join_set: JoinSet::new(),
             instances: Arc::new(Mutex::new(BTreeMap::new())),
             next_id: 1,
             run_tool_provider: None,
-            escalator_overrides: EscalatorOverrides::default(),
             parent_sandbox,
+            resolved_hook: None,
         }
+    }
+
+    /// Install (or replace) the [`EndpointResolvedHook`] used to
+    /// surface resolved spawn targets to an external sink (typically
+    /// the CLI's `--event-log` writer). Pass `None` to clear a hook
+    /// that was previously installed.
+    pub fn set_endpoint_resolved_hook(&mut self, hook: Option<EndpointResolvedHook>) {
+        self.resolved_hook = hook;
     }
 
     /// Replace the parent [`SandboxContext`] in-place.
@@ -260,16 +285,19 @@ impl SubagentManager {
     /// Builder-style consuming method so the call site reads:
     ///
     /// ```ignore
-    /// let manager = SubagentManager::new(client, cancel, ep, model, parent_sandbox)
+    /// let manager = SubagentManager::new(client, cancel, resolver, parent_sandbox)
     ///     .with_escalator_overrides(EscalatorOverrides::from_strings(
     ///         cfg.endpoint.clone(),
     ///         cfg.model.clone(),
     ///         cfg.disable,
     ///     ));
     /// ```
+    ///
+    /// Internally re-installs the overrides on the
+    /// [`EndpointResolver`] so the precedence ladder picks them up.
     #[must_use]
     pub fn with_escalator_overrides(mut self, overrides: EscalatorOverrides) -> Self {
-        self.escalator_overrides = overrides;
+        self.resolver = self.resolver.with_escalator_overrides(overrides);
         self
     }
 
@@ -279,13 +307,19 @@ impl SubagentManager {
     /// and the escalator config changes after construction (e.g. a
     /// future config-reload path).
     pub fn set_escalator_overrides(&mut self, overrides: EscalatorOverrides) {
-        self.escalator_overrides = overrides;
+        self.resolver = self.resolver.clone().with_escalator_overrides(overrides);
     }
 
     /// Borrow the currently-installed escalator overrides.
     #[must_use]
     pub fn escalator_overrides(&self) -> &EscalatorOverrides {
-        &self.escalator_overrides
+        self.resolver.escalator_overrides()
+    }
+
+    /// Borrow the active [`EndpointResolver`].
+    #[must_use]
+    pub fn resolver(&self) -> &EndpointResolver {
+        &self.resolver
     }
 
     /// Install (or replace) the [`RunToolProvider`] used for spawning
@@ -304,54 +338,24 @@ impl SubagentManager {
         self.run_tool_provider.as_ref()
     }
 
-    /// Resolve the `(endpoint, model)` pair for a given [`AgentKind`].
-    ///
-    /// Precedence rules (see the module-level docs for context):
-    ///
-    /// - [`AgentKind::Custom`]: a non-empty `endpoint` / `model` on
-    ///   the custom-agent definition wins; missing fields fall back
-    ///   to the manager defaults.
-    /// - [`AgentKind::Builtin`] of [`AgentType::Escalator`]: non-empty
-    ///   values from [`EscalatorOverrides`] win; missing fields fall
-    ///   back to the manager defaults.
-    /// - All other built-in agents always run on the manager defaults.
-    ///
-    /// Exposed so the spawn path (and the dedicated test
-    /// [`Self::resolved_endpoint_for_kind`]) share a single source of
-    /// truth for the precedence rules.
-    fn resolve_endpoint(&self, kind: &AgentKind) -> (String, String) {
-        match kind {
-            AgentKind::Custom(def) => {
-                let endpoint = def.endpoint().unwrap_or(&self.default_endpoint).to_owned();
-                let model = def.model().unwrap_or(&self.default_model).to_owned();
-                (endpoint, model)
-            }
-            AgentKind::Builtin(AgentType::Escalator) => {
-                let endpoint = self
-                    .escalator_overrides
-                    .endpoint
-                    .clone()
-                    .unwrap_or_else(|| self.default_endpoint.clone());
-                let model = self
-                    .escalator_overrides
-                    .model
-                    .clone()
-                    .unwrap_or_else(|| self.default_model.clone());
-                (endpoint, model)
-            }
-            AgentKind::Builtin(_) => (self.default_endpoint.clone(), self.default_model.clone()),
-        }
-    }
-
-    /// Test/inspection helper that returns the `(endpoint, model)`
-    /// pair a hypothetical spawn of `kind` would receive.
+    /// Test/inspection helper that returns the resolved
+    /// `(endpoint, model)` pair a hypothetical spawn of `kind` would
+    /// receive.
     ///
     /// Bypasses LLM-client construction so test code (and future
     /// diagnostics commands) can verify the precedence rules without
-    /// a live llama-server.
-    #[must_use]
-    pub fn resolved_endpoint_for_kind(&self, kind: &AgentKind) -> (String, String) {
-        self.resolve_endpoint(kind)
+    /// a live llama-server. Delegates to [`EndpointResolver::resolve`]
+    /// so the resolver is the single source of truth.
+    pub async fn resolved_endpoint_for_kind(&self, kind: &AgentKind) -> (String, String) {
+        let r = self.resolver.resolve(kind).await;
+        (r.endpoint, r.model)
+    }
+
+    /// Test/inspection helper that returns the full
+    /// [`ResolvedEndpoint`] including its [`ResolutionSource`]
+    /// label.
+    pub async fn resolve_for_kind(&self, kind: &AgentKind) -> ResolvedEndpoint {
+        self.resolver.resolve(kind).await
     }
 
     /// Spawn a subagent and return its ID immediately.
@@ -398,7 +402,7 @@ impl SubagentManager {
         // expects the auto-promotion path to treat this as "do not
         // escalate" rather than as a generic LLM/tool failure.
         if matches!(config.agent_kind, AgentKind::Builtin(AgentType::Escalator))
-            && self.escalator_overrides.disabled
+            && self.resolver.escalator_overrides().disabled
         {
             return Err(AgentError::EscalatorDisabled);
         }
@@ -421,21 +425,27 @@ impl SubagentManager {
             instances.insert(id, instance);
         }
 
-        // Resolve the endpoint / model with the centralised precedence
-        // rules (see `resolve_endpoint`). When the resolved pair
-        // matches the manager defaults we keep the shared `self.client`
-        // to avoid constructing a redundant `LlmClient`; otherwise we
-        // spin up a dedicated client. This reuse keeps the common
-        // built-in path allocation-free while still letting custom
-        // agents and the escalator land on a different endpoint.
-        let (resolved_endpoint, resolved_model) = self.resolve_endpoint(&config.agent_kind);
-        let client =
-            if resolved_endpoint == self.default_endpoint && resolved_model == self.default_model {
-                self.client.clone()
-            } else {
-                let llm_config = tmg_llm::LlmClientConfig::new(&resolved_endpoint, &resolved_model);
-                tmg_llm::LlmClient::new(llm_config).map_err(AgentError::Llm)?
-            };
+        // Resolve the endpoint / model via the centralised resolver.
+        // When the resolved pair matches the manager's main fallback
+        // we reuse `self.client` to avoid constructing a redundant
+        // `LlmClient`; otherwise we spin up a dedicated client.
+        let resolved = self.resolver.resolve(&config.agent_kind).await;
+        if let Some(hook) = &self.resolved_hook {
+            hook(
+                config.agent_kind.name(),
+                &resolved.endpoint,
+                &resolved.model,
+                resolved.source.as_str(),
+            );
+        }
+        let client = if resolved.endpoint == self.resolver.main_endpoint()
+            && resolved.model == self.resolver.main_model()
+        {
+            self.client.clone()
+        } else {
+            let llm_config = tmg_llm::LlmClientConfig::new(&resolved.endpoint, &resolved.model);
+            tmg_llm::LlmClient::new(llm_config).map_err(AgentError::Llm)?
+        };
 
         let agent_kind = config.agent_kind.clone();
         let task = config.task.clone();
@@ -620,8 +630,7 @@ mod tests {
         let mut manager = SubagentManager::new(
             client,
             cancel.clone(),
-            "http://localhost:9999",
-            "test",
+            EndpointResolver::new("http://localhost:9999", "test"),
             Arc::new(SandboxContext::test_default()),
         );
 
@@ -664,8 +673,7 @@ mod tests {
         let mut manager = SubagentManager::new(
             client,
             cancel.clone(),
-            "http://localhost:9999",
-            "test",
+            EndpointResolver::new("http://localhost:9999", "test"),
             Arc::new(SandboxContext::test_default()),
         );
 
@@ -697,8 +705,7 @@ mod tests {
         Some(SubagentManager::new(
             client,
             CancellationToken::new(),
-            "http://main:8080",
-            "main-model",
+            EndpointResolver::new("http://main:8080", "main-model"),
             Arc::new(SandboxContext::test_default()),
         ))
     }
@@ -723,8 +730,8 @@ mod tests {
         assert!(overrides.disabled);
     }
 
-    #[test]
-    fn resolved_endpoint_for_builtin_uses_main_defaults() {
+    #[tokio::test]
+    async fn resolved_endpoint_for_builtin_uses_main_defaults() {
         let Some(manager) = make_manager_for_resolution_tests() else {
             return;
         };
@@ -736,7 +743,7 @@ mod tests {
             AgentKind::Builtin(AgentType::Tester),
             AgentKind::Builtin(AgentType::Qa),
         ] {
-            let (ep, model) = manager.resolved_endpoint_for_kind(&kind);
+            let (ep, model) = manager.resolved_endpoint_for_kind(&kind).await;
             assert_eq!(ep, "http://main:8080", "wrong endpoint for {}", kind.name());
             assert_eq!(model, "main-model", "wrong model for {}", kind.name());
         }
@@ -747,8 +754,8 @@ mod tests {
     /// dropped. We verify this via the public
     /// [`SubagentManager::resolved_endpoint_for_kind`] helper rather
     /// than a mock `LlmClient` so the test stays unit-scoped.
-    #[test]
-    fn resolved_endpoint_for_escalator_uses_overrides() {
+    #[tokio::test]
+    async fn resolved_endpoint_for_escalator_uses_overrides() {
         let Some(manager) = make_manager_for_resolution_tests() else {
             return;
         };
@@ -758,15 +765,17 @@ mod tests {
             false,
         ));
 
-        let (ep, model) =
-            manager.resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Escalator));
+        let (ep, model) = manager
+            .resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Escalator))
+            .await;
         assert_eq!(ep, "http://escalator.invalid");
         assert_eq!(model, "lite");
 
         // Other built-ins must keep using the main endpoint even when
         // escalator overrides are installed.
-        let (ep, model) =
-            manager.resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Explore));
+        let (ep, model) = manager
+            .resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Explore))
+            .await;
         assert_eq!(ep, "http://main:8080");
         assert_eq!(model, "main-model");
     }
@@ -774,8 +783,8 @@ mod tests {
     /// Regression: an empty `[harness.escalator] endpoint = ""` must
     /// fall back to the main endpoint instead of trying to talk to a
     /// blank URL.
-    #[test]
-    fn resolved_endpoint_for_escalator_falls_back_to_main_when_empty() {
+    #[tokio::test]
+    async fn resolved_endpoint_for_escalator_falls_back_to_main_when_empty() {
         let Some(manager) = make_manager_for_resolution_tests() else {
             return;
         };
@@ -785,16 +794,17 @@ mod tests {
             false,
         ));
 
-        let (ep, model) =
-            manager.resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Escalator));
+        let (ep, model) = manager
+            .resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Escalator))
+            .await;
         assert_eq!(ep, "http://main:8080");
         assert_eq!(model, "main-model");
     }
 
     /// Partial overrides: only `endpoint` set, `model` empty -> the
     /// model inherits the main config while the endpoint is honoured.
-    #[test]
-    fn resolved_endpoint_for_escalator_mixes_override_and_default() {
+    #[tokio::test]
+    async fn resolved_endpoint_for_escalator_mixes_override_and_default() {
         let Some(manager) = make_manager_for_resolution_tests() else {
             return;
         };
@@ -804,14 +814,15 @@ mod tests {
             false,
         ));
 
-        let (ep, model) =
-            manager.resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Escalator));
+        let (ep, model) = manager
+            .resolved_endpoint_for_kind(&AgentKind::Builtin(AgentType::Escalator))
+            .await;
         assert_eq!(ep, "http://escalator.invalid");
         assert_eq!(model, "main-model");
     }
 
-    #[test]
-    fn resolved_endpoint_for_custom_uses_def_overrides() {
+    #[tokio::test]
+    async fn resolved_endpoint_for_custom_uses_def_overrides() {
         let Some(manager) = make_manager_for_resolution_tests() else {
             return;
         };
@@ -829,7 +840,7 @@ allow = ["file_read"]
         let def = crate::custom::CustomAgentDef::from_toml(toml, "test.toml")
             .unwrap_or_else(|e| panic!("{e}"));
         let kind = AgentKind::Custom(Arc::new(def));
-        let (ep, model) = manager.resolved_endpoint_for_kind(&kind);
+        let (ep, model) = manager.resolved_endpoint_for_kind(&kind).await;
         assert_eq!(ep, "http://custom:7777");
         assert_eq!(model, "custom-model");
     }
@@ -844,8 +855,7 @@ allow = ["file_read"]
         let mut manager = SubagentManager::new(
             client,
             cancel.clone(),
-            "http://main:8080",
-            "main-model",
+            EndpointResolver::new("http://main:8080", "main-model"),
             Arc::new(SandboxContext::test_default()),
         )
         .with_escalator_overrides(EscalatorOverrides::from_strings(
@@ -894,8 +904,7 @@ allow = ["file_read"]
         let mut manager = SubagentManager::new(
             client,
             cancel.clone(),
-            "http://main:8080",
-            "main-model",
+            EndpointResolver::new("http://main:8080", "main-model"),
             Arc::new(SandboxContext::test_default()),
         );
 

--- a/crates/tmg-agents/src/manager.rs
+++ b/crates/tmg-agents/src/manager.rs
@@ -42,6 +42,27 @@ use crate::error::AgentError;
 use crate::runner::SubagentRunner;
 use crate::status::SubagentStatus;
 
+/// Borrowed payload handed to an [`EndpointResolvedHook`] each time the
+/// [`EndpointResolver`] picks a spawn target.
+///
+/// Bundling the four strings into a struct (rather than passing them as
+/// positional arguments) prevents argument-swap bugs at the hook
+/// boundary: the CLI's `--event-log` writer can name each field
+/// explicitly when forwarding the event, and adding a future field
+/// (e.g. resolved provenance metadata) is non-breaking. Issue #50.
+#[derive(Debug, Clone, Copy)]
+pub struct EndpointResolvedEvent<'a> {
+    /// The agent kind's display name (e.g. `"explore"`, `"reviewer"`).
+    pub agent_kind: &'a str,
+    /// The resolved base URL the spawn will route to.
+    pub endpoint: &'a str,
+    /// The resolved model name.
+    pub model: &'a str,
+    /// The precedence rule that produced the pair (e.g. `"main"`,
+    /// `"pool"`, `"escalator_override"`, `"custom"`).
+    pub source: &'a str,
+}
+
 /// Boxed observer the manager invokes whenever an
 /// [`EndpointResolver`] resolves a spawn target.
 ///
@@ -50,7 +71,7 @@ use crate::status::SubagentStatus;
 /// [`tmg_core::EventLogWriter`]; the CLI's TUI startup wires this up to
 /// `event_log.write_endpoint_resolved` when an `--event-log` path was
 /// supplied. Issue #50.
-pub type EndpointResolvedHook = Arc<dyn Fn(&str, &str, &str, &str) + Send + Sync + 'static>;
+pub type EndpointResolvedHook = Arc<dyn Fn(&EndpointResolvedEvent<'_>) + Send + Sync + 'static>;
 
 /// Optional overrides for the escalator subagent's `(endpoint, model)`
 /// pair plus an explicit disable switch (SPEC §9.10 / §10.1
@@ -305,9 +326,10 @@ impl SubagentManager {
     ///
     /// Useful when the manager already lives behind an `Arc<Mutex<_>>`
     /// and the escalator config changes after construction (e.g. a
-    /// future config-reload path).
+    /// future config-reload path). Mutates the resolver in place
+    /// without cloning the entire struct (issue #50 review feedback).
     pub fn set_escalator_overrides(&mut self, overrides: EscalatorOverrides) {
-        self.resolver = self.resolver.clone().with_escalator_overrides(overrides);
+        self.resolver.set_escalator_overrides(overrides);
     }
 
     /// Borrow the currently-installed escalator overrides.
@@ -431,12 +453,13 @@ impl SubagentManager {
         // `LlmClient`; otherwise we spin up a dedicated client.
         let resolved = self.resolver.resolve(&config.agent_kind).await;
         if let Some(hook) = &self.resolved_hook {
-            hook(
-                config.agent_kind.name(),
-                &resolved.endpoint,
-                &resolved.model,
-                resolved.source.as_str(),
-            );
+            let event = EndpointResolvedEvent {
+                agent_kind: config.agent_kind.name(),
+                endpoint: &resolved.endpoint,
+                model: &resolved.model,
+                source: resolved.source.as_str(),
+            };
+            hook(&event);
         }
         let client = if resolved.endpoint == self.resolver.main_endpoint()
             && resolved.model == self.resolver.main_model()
@@ -889,6 +912,85 @@ allow = ["file_read"]
             .spawn(cfg_explore)
             .await
             .unwrap_or_else(|e| panic!("non-escalator spawn must still succeed: {e}"));
+
+        cancel.cancel();
+        manager.shutdown().await;
+    }
+
+    /// One observed [`EndpointResolvedEvent`] flattened to owned
+    /// strings so the test thread can inspect it after the
+    /// `Fn(&EndpointResolvedEvent<'_>)` hook returns. The named
+    /// fields keep the assertion site readable and avoid the
+    /// `clippy::type_complexity` warning a four-tuple triggered.
+    #[derive(Clone)]
+    struct CapturedEvent {
+        agent_kind: String,
+        endpoint: String,
+        model: String,
+        source: String,
+    }
+
+    /// Issue #50 review: the
+    /// [`SubagentManager::set_endpoint_resolved_hook`] surface is the
+    /// only published seam between the resolver and the CLI's
+    /// `--event-log` writer; when `spawn` resolves an endpoint it
+    /// must fire the installed hook with the
+    /// [`EndpointResolvedEvent`] for the spawn target. Without this
+    /// test the wiring claim in the PR description was unverifiable
+    /// at unit-test scope.
+    #[tokio::test]
+    async fn endpoint_resolved_hook_fires_on_spawn() {
+        use std::sync::Mutex as StdMutex;
+
+        let config = tmg_llm::LlmClientConfig::new("http://main:8080", "main-model");
+        let Ok(client) = tmg_llm::LlmClient::new(config) else {
+            return;
+        };
+        let cancel = CancellationToken::new();
+        let mut manager = SubagentManager::new(
+            client,
+            cancel.clone(),
+            EndpointResolver::new("http://main:8080", "main-model"),
+            Arc::new(SandboxContext::test_default()),
+        );
+        // Capture every call into a thread-safe vec so the test can
+        // observe the precedence rule that fired.
+        let captured: Arc<StdMutex<Vec<CapturedEvent>>> = Arc::new(StdMutex::new(Vec::new()));
+        let captured_for_hook = Arc::clone(&captured);
+        manager.set_endpoint_resolved_hook(Some(Arc::new(
+            move |ev: &EndpointResolvedEvent<'_>| {
+                if let Ok(mut g) = captured_for_hook.lock() {
+                    g.push(CapturedEvent {
+                        agent_kind: ev.agent_kind.to_owned(),
+                        endpoint: ev.endpoint.to_owned(),
+                        model: ev.model.to_owned(),
+                        source: ev.source.to_owned(),
+                    });
+                }
+            },
+        )));
+
+        let cfg = SubagentConfig {
+            agent_kind: AgentKind::Builtin(AgentType::Explore),
+            task: "exercise the hook".to_owned(),
+            background: true,
+        };
+        manager
+            .spawn(cfg)
+            .await
+            .unwrap_or_else(|e| panic!("spawn must succeed for explore: {e}"));
+
+        // Snapshot the captured events under a short-lived guard so
+        // the std mutex is released before any subsequent .await.
+        let snapshot: Vec<CapturedEvent> = {
+            let guard = captured.lock().unwrap_or_else(|e| panic!("{e}"));
+            guard.clone()
+        };
+        assert_eq!(snapshot.len(), 1, "hook must fire exactly once per spawn");
+        assert_eq!(snapshot[0].agent_kind, "explore");
+        assert_eq!(snapshot[0].endpoint, "http://main:8080");
+        assert_eq!(snapshot[0].model, "main-model");
+        assert_eq!(snapshot[0].source, "main");
 
         cancel.cancel();
         manager.shutdown().await;

--- a/crates/tmg-agents/src/tools/spawn_agent.rs
+++ b/crates/tmg-agents/src/tools/spawn_agent.rs
@@ -285,8 +285,7 @@ mod tests {
         let manager = SubagentManager::new(
             client,
             CancellationToken::new(),
-            "http://127.0.0.1:1",
-            "test-model",
+            crate::endpoint_resolver::EndpointResolver::new("http://127.0.0.1:1", "test-model"),
             Arc::new(SandboxContext::test_default()),
         );
         Some(SpawnAgentTool::new(Arc::new(Mutex::new(manager))))

--- a/crates/tmg-core/src/context.rs
+++ b/crates/tmg-core/src/context.rs
@@ -147,6 +147,11 @@ impl TokenCounter {
     ///
     /// Spawns a background task to count tokens via the LLM server.
     /// The result updates `cached_count` when complete. Does not block.
+    ///
+    /// Delegates to [`tmg_llm::count_tokens_or_estimate`] (issue #50)
+    /// so the chars/4 fallback and the rate-limited
+    /// `tracing::warn!` on failure are shared with every other caller
+    /// in the workspace.
     pub async fn request_update(&self, messages: &[Message]) {
         // Serialize all messages into a single string for counting.
         let content = serialize_messages_for_counting(messages);
@@ -158,13 +163,7 @@ impl TokenCounter {
         tasks.abort_all();
         while tasks.join_next().await.is_some() {}
         tasks.spawn(async move {
-            let count = match client.tokenize(&content).await {
-                Ok(count) => count,
-                Err(_) => {
-                    // Fall back to heuristic estimation on API failure.
-                    content.len() / 4
-                }
-            };
+            let count = tmg_llm::count_tokens_or_estimate(&client, &content).await;
             // Token counts always fit in u64.
             cached.store(count as u64, Ordering::Relaxed);
         });
@@ -172,11 +171,12 @@ impl TokenCounter {
 
     /// Estimate token count using a simple heuristic (characters / 4).
     ///
-    /// Useful when the tokenize API is unavailable.
+    /// Useful when the tokenize API is unavailable. Forwarder for
+    /// [`tmg_llm::estimate_tokens_heuristic`] kept here for source
+    /// compatibility with existing callers (`session_bootstrap` etc.).
     #[must_use]
     pub fn estimate_tokens(text: &str) -> usize {
-        // Integer division: 4 chars per token heuristic.
-        (text.len() / 4).max(1)
+        tmg_llm::estimate_tokens_heuristic(text)
     }
 }
 

--- a/crates/tmg-core/src/event_log.rs
+++ b/crates/tmg-core/src/event_log.rs
@@ -45,6 +45,30 @@ enum EventKind {
     },
     #[serde(rename = "warning")]
     Warning { message: String },
+    /// Records the `(endpoint, model)` pair an [`EndpointResolver`]
+    /// selected for a subagent spawn, plus the precedence rule that
+    /// fired (e.g. `"custom"`, `"escalator_override"`, `"pool"`,
+    /// `"main"`). Issue #50.
+    #[serde(rename = "endpoint_resolved")]
+    EndpointResolved {
+        agent_kind: String,
+        endpoint: String,
+        model: String,
+        source: String,
+    },
+    /// Records that a request was routed to a specific pool endpoint
+    /// (only emitted when the pool is in multi-endpoint mode). Issue #50.
+    #[serde(rename = "pool_selected")]
+    PoolSelected { endpoint: String, strategy: String },
+    /// Records a tokenize failure that fell back to the chars/4
+    /// heuristic. Issue #50.
+    #[serde(rename = "tokenize_failure")]
+    TokenizeFailure {
+        endpoint: String,
+        text_len: usize,
+        estimate: usize,
+        error: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +143,53 @@ impl EventLogWriter {
     /// Log a done event.
     pub fn write_done(&mut self) {
         self.write_event(&EventKind::Done);
+    }
+
+    /// Log an endpoint-resolution event for a subagent spawn (issue #50).
+    ///
+    /// `source` should be one of `"custom"`, `"escalator_override"`,
+    /// `"pool"`, or `"main"` so the log reader can recover the
+    /// precedence rule that fired without re-running the resolver.
+    pub fn write_endpoint_resolved(
+        &mut self,
+        agent_kind: &str,
+        endpoint: &str,
+        model: &str,
+        source: &str,
+    ) {
+        let event = EventKind::EndpointResolved {
+            agent_kind: agent_kind.to_owned(),
+            endpoint: endpoint.to_owned(),
+            model: model.to_owned(),
+            source: source.to_owned(),
+        };
+        self.write_event(&event);
+    }
+
+    /// Log a pool selection event (issue #50).
+    pub fn write_pool_selected(&mut self, endpoint: &str, strategy: &str) {
+        let event = EventKind::PoolSelected {
+            endpoint: endpoint.to_owned(),
+            strategy: strategy.to_owned(),
+        };
+        self.write_event(&event);
+    }
+
+    /// Log a tokenize fallback event (issue #50).
+    pub fn write_tokenize_failure(
+        &mut self,
+        endpoint: &str,
+        text_len: usize,
+        estimate: usize,
+        error: &str,
+    ) {
+        let event = EventKind::TokenizeFailure {
+            endpoint: endpoint.to_owned(),
+            text_len,
+            estimate,
+            error: error.to_owned(),
+        };
+        self.write_event(&event);
     }
 
     /// Write one event record as a JSON line. Flushes immediately for

--- a/crates/tmg-llm/Cargo.toml
+++ b/crates/tmg-llm/Cargo.toml
@@ -15,6 +15,7 @@ pin-project-lite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 rand = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tmg-llm/src/lib.rs
+++ b/crates/tmg-llm/src/lib.rs
@@ -16,7 +16,10 @@ pub use prompt_tool_calling::{
     ParseError, ToolCallingMode, build_tool_calling_prompt, format_compressed_tool_defs,
     parse_tool_calls,
 };
-pub use tokenize::{count_tokens_or_estimate, estimate_tokens_heuristic};
+pub use tokenize::{
+    TokenizeFailureHook, count_tokens_or_estimate, estimate_tokens_heuristic,
+    set_tokenize_failure_hook,
+};
 pub use types::{
     ChatMessage, ChatRequest, ChatResponse, FunctionCall, FunctionDefinition, Role, StreamEvent,
     TokenizeResponse, ToolCall, ToolCallAccumulator, ToolCallIndexError, ToolDefinition, ToolKind,

--- a/crates/tmg-llm/src/lib.rs
+++ b/crates/tmg-llm/src/lib.rs
@@ -5,16 +5,18 @@ pub mod error;
 pub mod pool;
 pub mod pool_config;
 pub mod prompt_tool_calling;
+pub mod tokenize;
 pub mod types;
 
 pub use client::{ChatStream, LlmClient, LlmClientConfig};
 pub use error::LlmError;
 pub use pool::{EndpointHealth, LlmPool};
-pub use pool_config::{LoadBalanceStrategy, PoolConfig, PoolConfigError};
+pub use pool_config::{LoadBalanceStrategy, PoolConfig, PoolConfigError, ValidationReport};
 pub use prompt_tool_calling::{
     ParseError, ToolCallingMode, build_tool_calling_prompt, format_compressed_tool_defs,
     parse_tool_calls,
 };
+pub use tokenize::{count_tokens_or_estimate, estimate_tokens_heuristic};
 pub use types::{
     ChatMessage, ChatRequest, ChatResponse, FunctionCall, FunctionDefinition, Role, StreamEvent,
     TokenizeResponse, ToolCall, ToolCallAccumulator, ToolCallIndexError, ToolDefinition, ToolKind,

--- a/crates/tmg-llm/src/pool.rs
+++ b/crates/tmg-llm/src/pool.rs
@@ -173,14 +173,24 @@ impl LlmPool {
     #[must_use = "the acquired client must be used to make requests"]
     pub async fn acquire(&self) -> Result<LlmClient, LlmError> {
         match &self.inner {
-            PoolInner::Single { client, .. } => Ok(client.clone()),
+            PoolInner::Single { url, client } => {
+                tracing::debug!(url, "pool acquired single endpoint");
+                Ok(client.clone())
+            }
             PoolInner::Multi {
                 state,
                 strategy,
                 round_robin_counter,
             } => {
                 let pool_state = state.read().await;
-                select_endpoint(&pool_state, *strategy, round_robin_counter)
+                let (client, picked_url) =
+                    select_endpoint_with_url(&pool_state, *strategy, round_robin_counter)?;
+                tracing::debug!(
+                    url = %picked_url,
+                    ?strategy,
+                    "pool selected multi endpoint",
+                );
+                Ok(client)
             }
         }
     }
@@ -239,6 +249,33 @@ impl LlmPool {
         }
     }
 
+    /// Pick the next endpoint URL using the configured strategy without
+    /// constructing or returning a full [`LlmClient`].
+    ///
+    /// Used by [`tmg_agents::EndpointResolver`] (and the broader
+    /// subagent endpoint-resolution path) when only the resolved URL
+    /// is needed — the caller will construct its own `LlmClient` (or
+    /// reuse the manager's). Returns `None` for empty / single-only
+    /// pools where there is no genuine selection to make.
+    ///
+    /// Note: this method holds the read lock for the duration of the
+    /// pick so the snapshot of endpoint health observed by selection
+    /// is internally consistent.
+    pub async fn pick_endpoint_url(&self) -> Result<Option<String>, LlmError> {
+        match &self.inner {
+            PoolInner::Single { .. } => Ok(None),
+            PoolInner::Multi {
+                state,
+                strategy,
+                round_robin_counter,
+            } => {
+                let pool_state = state.read().await;
+                let idx = pick_endpoint_index(&pool_state, *strategy, round_robin_counter)?;
+                Ok(Some(pool_state.endpoints[idx].url.clone()))
+            }
+        }
+    }
+
     /// Return health status of all endpoints.
     ///
     /// For single-endpoint pools, returns a single-element vec with
@@ -260,16 +297,47 @@ impl LlmPool {
     }
 }
 
-/// Select an endpoint from the pool based on the given strategy.
-///
-/// Prefers healthy endpoints. Falls back to unknown endpoints if no
-/// healthy ones are available. Returns [`LlmError::AllEndpointsDown`]
-/// when all endpoints are confirmed unhealthy.
+/// Same as [`select_endpoint`] but also returns the picked URL so the
+/// caller can emit a `tracing::debug!` line. Splitting the helpers
+/// keeps the existing tests (which only need the client) compiling
+/// without churn while letting [`LlmPool::acquire`] log the selection.
+fn select_endpoint_with_url(
+    state: &PoolState,
+    strategy: LoadBalanceStrategy,
+    round_robin_counter: &AtomicUsize,
+) -> Result<(LlmClient, String), LlmError> {
+    let idx = pick_endpoint_index(state, strategy, round_robin_counter)?;
+    let ep = &state.endpoints[idx];
+    Ok((ep.client.clone(), ep.url.clone()))
+}
+
+/// Select an endpoint client from the pool based on the given
+/// strategy. Used by the in-tree tests (the live `acquire` path now
+/// goes through [`select_endpoint_with_url`] so it can log the picked
+/// URL).
+#[cfg(test)]
 fn select_endpoint(
     state: &PoolState,
     strategy: LoadBalanceStrategy,
     round_robin_counter: &AtomicUsize,
 ) -> Result<LlmClient, LlmError> {
+    let idx = pick_endpoint_index(state, strategy, round_robin_counter)?;
+    Ok(state.endpoints[idx].client.clone())
+}
+
+/// Pure index-picking helper shared by [`select_endpoint_with_url`]
+/// and [`LlmPool::pick_endpoint_url`]. Centralising the logic ensures
+/// the healthy-vs-unknown precedence and round-robin-with-fallback
+/// behaviour stay in one place.
+///
+/// Prefers healthy endpoints. Falls back to unknown endpoints if no
+/// healthy ones are available. Returns [`LlmError::AllEndpointsDown`]
+/// when all endpoints are confirmed unhealthy.
+fn pick_endpoint_index(
+    state: &PoolState,
+    strategy: LoadBalanceStrategy,
+    round_robin_counter: &AtomicUsize,
+) -> Result<usize, LlmError> {
     let len = state.endpoints.len();
     if len == 0 {
         return Err(LlmError::PoolEmpty);
@@ -326,7 +394,7 @@ fn select_endpoint(
         }
     };
 
-    Ok(state.endpoints[selected].client.clone())
+    Ok(selected)
 }
 
 /// Background health check loop.

--- a/crates/tmg-llm/src/pool.rs
+++ b/crates/tmg-llm/src/pool.rs
@@ -237,6 +237,21 @@ impl LlmPool {
         }
     }
 
+    /// Return the configured load-balancing strategy.
+    ///
+    /// Single-endpoint pools report
+    /// [`LoadBalanceStrategy::default`] because no balancing actually
+    /// runs. The strategy is part of the public surface so the
+    /// `--event-log` writer can stamp `pool_selected` events with the
+    /// rule that picked the endpoint (issue #50).
+    #[must_use = "the strategy is the only output"]
+    pub fn strategy(&self) -> LoadBalanceStrategy {
+        match &self.inner {
+            PoolInner::Single { .. } => LoadBalanceStrategy::default(),
+            PoolInner::Multi { strategy, .. } => *strategy,
+        }
+    }
+
     /// Return the number of endpoints in the pool.
     #[must_use = "this returns the count without side effects"]
     pub async fn endpoint_count(&self) -> usize {

--- a/crates/tmg-llm/src/pool_config.rs
+++ b/crates/tmg-llm/src/pool_config.rs
@@ -30,7 +30,7 @@ pub enum LoadBalanceStrategy {
 /// endpoints = ["http://localhost:8081", "http://localhost:8082"]
 /// strategy = "round_robin"
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolConfig {
     /// List of llama-server endpoint URLs for subagent requests.
     pub endpoints: Vec<String>,
@@ -62,6 +62,27 @@ pub enum PoolConfigError {
         /// The invalid URL string.
         url: String,
     },
+}
+
+/// Outcome of [`PoolConfig::validate_relaxed`].
+///
+/// Captures the operator-friendly invariants for `[llm.subagent_pool]`:
+/// an empty `endpoints` list is **not** an error (it is the explicit
+/// way to disable the pool), and duplicate URLs are deduped with a
+/// warning rather than rejected. Malformed URLs and empty / whitespace
+/// strings are still hard errors so a typo is reported at load time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationReport {
+    /// Endpoints after dedupe, preserving the original order of the
+    /// first occurrence.
+    pub deduped_endpoints: Vec<String>,
+    /// Duplicate URLs that were collapsed (each entry appears once
+    /// even if it was repeated more than twice).
+    pub duplicates: Vec<String>,
+    /// `true` when `endpoints` was empty after deserialization,
+    /// signalling the pool is disabled and the caller should fall back
+    /// to the main endpoint.
+    pub disabled: bool,
 }
 
 impl PoolConfig {
@@ -103,6 +124,69 @@ impl PoolConfig {
         }
 
         Ok(())
+    }
+
+    /// Operator-friendly validation that matches the SPEC §10.1
+    /// `[llm.subagent_pool]` policy:
+    ///
+    /// - An empty `endpoints` list is **not** an error: it means "pool
+    ///   disabled, route every subagent to the main endpoint".
+    /// - Duplicate URLs are deduped (first occurrence wins) and
+    ///   surfaced through [`ValidationReport::duplicates`] so the
+    ///   caller can warn / log without aborting the run.
+    /// - Empty / whitespace-only strings and malformed URLs remain
+    ///   hard errors — these almost always indicate a typo and should
+    ///   surface at config-load time rather than at first request.
+    ///
+    /// The strategy enum is already validated by `serde` at
+    /// deserialize time, so out-of-range values cannot reach this
+    /// path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PoolConfigError::EmptyEndpointString`] or
+    /// [`PoolConfigError::MalformedUrl`] for the first offending entry.
+    /// Empty endpoints lists never produce an error here.
+    pub fn validate_relaxed(&self) -> Result<ValidationReport, PoolConfigError> {
+        if self.endpoints.is_empty() {
+            return Ok(ValidationReport {
+                deduped_endpoints: Vec::new(),
+                duplicates: Vec::new(),
+                disabled: true,
+            });
+        }
+
+        for (index, url) in self.endpoints.iter().enumerate() {
+            let trimmed = url.trim();
+            if trimmed.is_empty() {
+                return Err(PoolConfigError::EmptyEndpointString { index });
+            }
+            if !trimmed.starts_with("http://") && !trimmed.starts_with("https://") {
+                return Err(PoolConfigError::MalformedUrl {
+                    index,
+                    url: url.clone(),
+                });
+            }
+        }
+
+        // Stable dedupe: preserve the first occurrence's position so
+        // the round-robin order matches the operator's intent.
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut deduped: Vec<String> = Vec::with_capacity(self.endpoints.len());
+        let mut duplicates: Vec<String> = Vec::new();
+        for url in &self.endpoints {
+            if seen.insert(url.clone()) {
+                deduped.push(url.clone());
+            } else if !duplicates.contains(url) {
+                duplicates.push(url.clone());
+            }
+        }
+
+        Ok(ValidationReport {
+            deduped_endpoints: deduped,
+            duplicates,
+            disabled: false,
+        })
     }
 }
 
@@ -196,6 +280,70 @@ mod tests {
         assert!(matches!(
             config.validate(),
             Err(PoolConfigError::MalformedUrl { index: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn validate_relaxed_empty_endpoints_disables_pool() {
+        let config = PoolConfig {
+            endpoints: vec![],
+            strategy: LoadBalanceStrategy::RoundRobin,
+        };
+        let report = config.validate_relaxed().expect("relaxed validate ok");
+        assert!(report.disabled, "empty endpoints must disable the pool");
+        assert!(report.deduped_endpoints.is_empty());
+        assert!(report.duplicates.is_empty());
+    }
+
+    #[test]
+    fn validate_relaxed_dedupes_duplicates() {
+        let config = PoolConfig {
+            endpoints: vec![
+                "http://a:8080".to_owned(),
+                "http://b:8080".to_owned(),
+                "http://a:8080".to_owned(),
+                "http://c:8080".to_owned(),
+                "http://b:8080".to_owned(),
+            ],
+            strategy: LoadBalanceStrategy::RoundRobin,
+        };
+        let report = config.validate_relaxed().expect("relaxed validate ok");
+        assert!(!report.disabled);
+        assert_eq!(
+            report.deduped_endpoints,
+            vec![
+                "http://a:8080".to_owned(),
+                "http://b:8080".to_owned(),
+                "http://c:8080".to_owned(),
+            ],
+        );
+        assert_eq!(
+            report.duplicates,
+            vec!["http://a:8080".to_owned(), "http://b:8080".to_owned()],
+        );
+    }
+
+    #[test]
+    fn validate_relaxed_rejects_malformed_url() {
+        let config = PoolConfig {
+            endpoints: vec!["http://ok".to_owned(), "not-a-url".to_owned()],
+            strategy: LoadBalanceStrategy::RoundRobin,
+        };
+        assert!(matches!(
+            config.validate_relaxed(),
+            Err(PoolConfigError::MalformedUrl { index: 1, .. })
+        ));
+    }
+
+    #[test]
+    fn validate_relaxed_rejects_empty_string() {
+        let config = PoolConfig {
+            endpoints: vec!["http://ok".to_owned(), "  ".to_owned()],
+            strategy: LoadBalanceStrategy::RoundRobin,
+        };
+        assert!(matches!(
+            config.validate_relaxed(),
+            Err(PoolConfigError::EmptyEndpointString { index: 1 })
         ));
     }
 }

--- a/crates/tmg-llm/src/pool_config.rs
+++ b/crates/tmg-llm/src/pool_config.rs
@@ -19,6 +19,20 @@ pub enum LoadBalanceStrategy {
     Random,
 }
 
+impl LoadBalanceStrategy {
+    /// Stable string representation used in `--event-log` records and
+    /// other external sinks. The strings match the `serde` rename
+    /// (`snake_case`) so the log vocabulary lines up with the TOML
+    /// surface. Issue #50.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LoadBalanceStrategy::RoundRobin => "round_robin",
+            LoadBalanceStrategy::Random => "random",
+        }
+    }
+}
+
 /// Configuration for the subagent connection pool.
 ///
 /// Corresponds to the `[llm.subagent_pool]` section of `tsumugi.toml`.
@@ -71,13 +85,33 @@ pub enum PoolConfigError {
 /// way to disable the pool), and duplicate URLs are deduped with a
 /// warning rather than rejected. Malformed URLs and empty / whitespace
 /// strings are still hard errors so a typo is reported at load time.
+///
+/// # Dedupe semantics
+///
+/// Duplicate detection treats two URLs as equal when their normalised
+/// form matches. The normaliser:
+///
+/// 1. trims trailing `/` characters so `http://x:8080` and
+///    `http://x:8080/` collapse,
+/// 2. trims leading and trailing whitespace,
+/// 3. lowercases the scheme and host (e.g. `HTTP://Example.COM` and
+///    `http://example.com` collapse).
+///
+/// The original (un-normalised) string is preserved in
+/// [`Self::deduped_endpoints`] so the caller's logs and the pool's
+/// runtime behaviour use exactly the URL the operator typed. Only the
+/// dedupe key is normalised. Lowercasing of path / query is **not**
+/// performed because llama-server treats those as case-sensitive.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidationReport {
     /// Endpoints after dedupe, preserving the original order of the
-    /// first occurrence.
+    /// first occurrence and the operator's original casing /
+    /// punctuation.
     pub deduped_endpoints: Vec<String>,
     /// Duplicate URLs that were collapsed (each entry appears once
-    /// even if it was repeated more than twice).
+    /// even if it was repeated more than twice). Reports the first
+    /// non-canonical occurrence for each collision so logs show the
+    /// operator the form they typed.
     pub duplicates: Vec<String>,
     /// `true` when `endpoints` was empty after deserialization,
     /// signalling the pool is disabled and the caller should fall back
@@ -170,14 +204,24 @@ impl PoolConfig {
         }
 
         // Stable dedupe: preserve the first occurrence's position so
-        // the round-robin order matches the operator's intent.
-        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // the round-robin order matches the operator's intent. The
+        // dedupe *key* is the normalised URL (see
+        // [`normalize_for_dedupe`]); we keep the original string in
+        // `deduped_endpoints` so the live pool routes to exactly the
+        // URL the operator typed. The `seen_duplicates` set keeps the
+        // duplicate-detection O(n) (the prior `Vec::contains` made it
+        // O(n²)).
+        let mut seen: std::collections::HashSet<String> =
+            std::collections::HashSet::with_capacity(self.endpoints.len());
+        let mut seen_duplicates: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         let mut deduped: Vec<String> = Vec::with_capacity(self.endpoints.len());
         let mut duplicates: Vec<String> = Vec::new();
         for url in &self.endpoints {
-            if seen.insert(url.clone()) {
+            let key = normalize_for_dedupe(url);
+            if seen.insert(key.clone()) {
                 deduped.push(url.clone());
-            } else if !duplicates.contains(url) {
+            } else if seen_duplicates.insert(key) {
                 duplicates.push(url.clone());
             }
         }
@@ -187,6 +231,35 @@ impl PoolConfig {
             duplicates,
             disabled: false,
         })
+    }
+}
+
+/// Normalise a URL string for dedupe-key comparison.
+///
+/// Applied only to the dedupe key, never to the stored string. The
+/// rules are documented on [`ValidationReport`]; in summary: trim
+/// surrounding whitespace, drop trailing `/`, and lowercase the scheme
+/// + host so trivially-different spellings collapse.
+fn normalize_for_dedupe(url: &str) -> String {
+    let trimmed = url.trim().trim_end_matches('/');
+    // Split scheme://rest into ("scheme", "rest"). If the URL is
+    // malformed (no `://`), fall back to lower-casing the whole thing
+    // so dedupe still catches whitespace-only variants. Malformed URLs
+    // are caught by the validator above, so this branch is defensive.
+    if let Some((scheme, rest)) = trimmed.split_once("://") {
+        // Within `rest`, the host is everything up to the next `/` or
+        // `?` (whichever comes first). Lowercasing only the host
+        // preserves path / query case sensitivity.
+        let host_end = rest.find(['/', '?']);
+        let (host, tail) = host_end.map_or((rest, ""), |idx| rest.split_at(idx));
+        let mut out = String::with_capacity(trimmed.len());
+        out.push_str(&scheme.to_ascii_lowercase());
+        out.push_str("://");
+        out.push_str(&host.to_ascii_lowercase());
+        out.push_str(tail);
+        out
+    } else {
+        trimmed.to_ascii_lowercase()
     }
 }
 
@@ -321,6 +394,38 @@ mod tests {
             report.duplicates,
             vec!["http://a:8080".to_owned(), "http://b:8080".to_owned()],
         );
+    }
+
+    /// Issue #50 review: dedupe must collapse `http://x:8080` and
+    /// `http://x:8080/` so the operator does not get a "two-endpoint"
+    /// pool that is really one endpoint pointed at twice. The
+    /// scheme/host casing is also normalised so a trivially-cased
+    /// variant collapses with its lowercase twin. The first
+    /// non-canonical occurrence is recorded once in `duplicates` even
+    /// when several spellings collide on the same key.
+    #[test]
+    fn validate_relaxed_dedupes_normalised_variants() {
+        let config = PoolConfig {
+            endpoints: vec![
+                "http://x:8080".to_owned(),
+                "http://x:8080/".to_owned(),
+                "http://X:8080/".to_owned(),
+                "http://y:8080".to_owned(),
+            ],
+            strategy: LoadBalanceStrategy::RoundRobin,
+        };
+        let report = config.validate_relaxed().expect("relaxed validate ok");
+        assert!(!report.disabled);
+        assert_eq!(
+            report.deduped_endpoints,
+            vec!["http://x:8080".to_owned(), "http://y:8080".to_owned()],
+            "dedupe must collapse trailing-slash and case variants while \
+             preserving the first occurrence's spelling",
+        );
+        // All three duplicate spellings map to the same normalised key
+        // (`http://x:8080`), so the first non-canonical spelling is
+        // recorded exactly once.
+        assert_eq!(report.duplicates, vec!["http://x:8080/".to_owned()]);
     }
 
     #[test]

--- a/crates/tmg-llm/src/tokenize.rs
+++ b/crates/tmg-llm/src/tokenize.rs
@@ -1,0 +1,121 @@
+//! Shared tokenize helpers for the rest of the workspace.
+//!
+//! [`count_tokens_or_estimate`] is the canonical entry point for any
+//! caller that wants an "exact tokenize, fall back to a heuristic on
+//! failure" count. The original implementation lived in two places
+//! (`tmg-core::TokenCounter::request_update` and the harness
+//! `session_bootstrap` helper); centralising it here gives us:
+//!
+//! - one place to apply the chars/4 heuristic,
+//! - one place to emit a `tracing::warn!` on the first tokenize
+//!   failure (and `tracing::debug!` for subsequent failures so the
+//!   logs do not spam when the LLM server is genuinely down),
+//! - one place that downstream call sites can depend on without
+//!   reaching into `LlmClient::tokenize` directly.
+//!
+//! The heuristic budget is a deliberate `chars / 4` integer divide
+//! with a `.max(1)` floor so a non-empty string never reports zero
+//! tokens. This matches the pre-existing
+//! [`crate::estimate_tokens_heuristic`] helper used by callers that
+//! cannot be made async.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::client::LlmClient;
+
+/// Tracks whether we have already emitted a `warn!` for a tokenize
+/// failure. The first failure is loud; subsequent failures drop to
+/// `debug!` so the agent loop is not flooded when the LLM endpoint is
+/// genuinely down. This is a process-wide latch — re-arming would
+/// require a more nuanced policy than the SPEC currently mandates.
+static TOKENIZE_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// Estimate the token count of `text` using a `chars / 4` heuristic.
+///
+/// Returns `1` for the empty string so the caller never has to
+/// special-case zero-budget paths.
+#[must_use]
+pub fn estimate_tokens_heuristic(text: &str) -> usize {
+    (text.len() / 4).max(1)
+}
+
+/// Count the tokens in `text` using the LLM server's `POST /tokenize`
+/// endpoint, falling back to [`estimate_tokens_heuristic`] on failure.
+///
+/// The first failure is logged at `warn!`; subsequent failures land at
+/// `debug!`. The caller never sees an error: a heuristic estimate is
+/// returned instead so token-budget decisions can keep flowing even
+/// when the server is unreachable.
+///
+/// # Cancel safety
+///
+/// This call is cancel-safe: dropping the future after it has issued
+/// the HTTP request simply discards the response. The fallback path is
+/// pure CPU and cannot be cancelled, but it returns instantly.
+pub async fn count_tokens_or_estimate(client: &LlmClient, text: &str) -> usize {
+    match client.tokenize(text).await {
+        Ok(count) => {
+            tracing::trace!(
+                token_count = count,
+                text_len = text.len(),
+                "tokenize succeeded",
+            );
+            count
+        }
+        Err(e) => {
+            let estimate = estimate_tokens_heuristic(text);
+            // Compare-and-swap so only the first racing caller emits
+            // the loud warning. All subsequent (and concurrent)
+            // failures land at debug.
+            if TOKENIZE_WARNED
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                tracing::warn!(
+                    error = %e,
+                    text_len = text.len(),
+                    estimate,
+                    "tokenize failed; using chars/4 heuristic (further failures will be logged at debug level)",
+                );
+            } else {
+                tracing::debug!(
+                    error = %e,
+                    text_len = text.len(),
+                    estimate,
+                    "tokenize failed; using chars/4 heuristic",
+                );
+            }
+            estimate
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn estimate_tokens_heuristic_floor_one() {
+        assert_eq!(estimate_tokens_heuristic(""), 1);
+        assert_eq!(estimate_tokens_heuristic("a"), 1);
+        assert_eq!(estimate_tokens_heuristic("abcd"), 1);
+        assert_eq!(estimate_tokens_heuristic("abcde"), 1);
+        assert_eq!(estimate_tokens_heuristic(&"a".repeat(8)), 2);
+        assert_eq!(estimate_tokens_heuristic(&"a".repeat(400)), 100);
+    }
+
+    /// When the LLM endpoint is unreachable, [`count_tokens_or_estimate`]
+    /// must surface the heuristic estimate rather than an error. We
+    /// deliberately point at a closed loopback port so the request
+    /// fails fast.
+    #[tokio::test]
+    async fn falls_back_to_estimate_on_unreachable_endpoint() {
+        let cfg = crate::client::LlmClientConfig::new("http://127.0.0.1:1", "test");
+        let Ok(client) = crate::client::LlmClient::new(cfg) else {
+            return;
+        };
+        let text = "hello world";
+        let n = count_tokens_or_estimate(&client, text).await;
+        assert_eq!(n, estimate_tokens_heuristic(text));
+    }
+}

--- a/crates/tmg-llm/src/tokenize.rs
+++ b/crates/tmg-llm/src/tokenize.rs
@@ -19,6 +19,9 @@
 //! [`crate::estimate_tokens_heuristic`] helper used by callers that
 //! cannot be made async.
 
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::client::LlmClient;
@@ -26,9 +29,47 @@ use crate::client::LlmClient;
 /// Tracks whether we have already emitted a `warn!` for a tokenize
 /// failure. The first failure is loud; subsequent failures drop to
 /// `debug!` so the agent loop is not flooded when the LLM endpoint is
-/// genuinely down. This is a process-wide latch — re-arming would
-/// require a more nuanced policy than the SPEC currently mandates.
+/// genuinely down. The latch re-arms the moment a tokenize call
+/// succeeds again so the next outage produces a fresh warning instead
+/// of being silent forever (issue #50 review feedback).
 static TOKENIZE_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// Synchronous observer fired on every tokenize fallback.
+///
+/// The hook is intentionally lightweight (one call site, four
+/// arguments) so the CLI's `--event-log` writer can subscribe without
+/// pulling `tmg-core` into the `tmg-llm` dependency graph. Issue #50.
+///
+/// Arguments: `endpoint`, `text_len`, `estimate`, `error`.
+pub type TokenizeFailureHook = Arc<dyn Fn(&str, usize, usize, &str) + Send + Sync + 'static>;
+
+/// Process-wide slot for the [`TokenizeFailureHook`]. The CLI installs
+/// one when an `--event-log` path is supplied; tests / library users
+/// leave it unset.
+static TOKENIZE_FAILURE_HOOK: OnceLock<Mutex<Option<TokenizeFailureHook>>> = OnceLock::new();
+
+/// Install (or replace) the global [`TokenizeFailureHook`].
+///
+/// Calling with `None` clears any previously-installed hook. The hook
+/// is process-wide because the underlying tokenize helper is also
+/// process-wide; the CLI is the only caller and it installs the hook
+/// once at startup.
+pub fn set_tokenize_failure_hook(hook: Option<TokenizeFailureHook>) {
+    let slot = TOKENIZE_FAILURE_HOOK.get_or_init(|| Mutex::new(None));
+    if let Ok(mut guard) = slot.lock() {
+        *guard = hook;
+    }
+}
+
+/// Borrow the currently-installed [`TokenizeFailureHook`], if any.
+fn current_tokenize_failure_hook() -> Option<TokenizeFailureHook> {
+    TOKENIZE_FAILURE_HOOK
+        .get()?
+        .lock()
+        .ok()?
+        .as_ref()
+        .map(Arc::clone)
+}
 
 /// Estimate the token count of `text` using a `chars / 4` heuristic.
 ///
@@ -60,6 +101,12 @@ pub async fn count_tokens_or_estimate(client: &LlmClient, text: &str) -> usize {
                 text_len = text.len(),
                 "tokenize succeeded",
             );
+            // Re-arm the warning latch on every recovery so the next
+            // outage produces a fresh `warn!` instead of being silent
+            // forever (issue #50 review feedback). `Relaxed` is fine
+            // — losing a recovery to a racing failure just means the
+            // next failure logs at `debug!`, which is acceptable.
+            TOKENIZE_WARNED.store(false, Ordering::Relaxed);
             count
         }
         Err(e) => {
@@ -85,12 +132,24 @@ pub async fn count_tokens_or_estimate(client: &LlmClient, text: &str) -> usize {
                     "tokenize failed; using chars/4 heuristic",
                 );
             }
+            // Notify any installed observer (typically the CLI's
+            // `--event-log` writer). Hook invocation runs on the same
+            // task as the agent loop; installations should be cheap.
+            if let Some(hook) = current_tokenize_failure_hook() {
+                let err_str = e.to_string();
+                hook(client.endpoint(), text.len(), estimate, &err_str);
+            }
             estimate
         }
     }
 }
 
 #[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+#[expect(
+    clippy::type_complexity,
+    reason = "the captured-tuple type is local to one test and wrapping it in a `type` alias would obscure what each field means in the assertion site"
+)]
 mod tests {
     use super::*;
 
@@ -117,5 +176,50 @@ mod tests {
         let text = "hello world";
         let n = count_tokens_or_estimate(&client, text).await;
         assert_eq!(n, estimate_tokens_heuristic(text));
+    }
+
+    /// Issue #50 review: a failure path must fire the installed
+    /// [`TokenizeFailureHook`] so the CLI's `--event-log` writer can
+    /// observe tokenize fallbacks. The hook stores the captured
+    /// arguments in a shared `Vec` so the test can assert on them.
+    #[tokio::test]
+    async fn failure_hook_observes_fallback() {
+        // Reset the hook slot before the test in case another test
+        // installed one. (Tests run on a single tokio runtime; the
+        // process-wide slot is shared.)
+        set_tokenize_failure_hook(None);
+
+        let captured: Arc<Mutex<Vec<(String, usize, usize, String)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let captured_for_hook = Arc::clone(&captured);
+        set_tokenize_failure_hook(Some(Arc::new(
+            move |endpoint: &str, len: usize, estimate: usize, err: &str| {
+                if let Ok(mut g) = captured_for_hook.lock() {
+                    g.push((endpoint.to_owned(), len, estimate, err.to_owned()));
+                }
+            },
+        )));
+
+        let cfg = crate::client::LlmClientConfig::new("http://127.0.0.1:1", "test");
+        let Ok(client) = crate::client::LlmClient::new(cfg) else {
+            set_tokenize_failure_hook(None);
+            return;
+        };
+        let _ = count_tokens_or_estimate(&client, "hello world").await;
+
+        let events = captured.lock().expect("hook lock");
+        assert!(
+            !events.is_empty(),
+            "tokenize failure hook must fire on unreachable endpoint",
+        );
+        let (endpoint, len, estimate, _err) = &events[0];
+        assert_eq!(endpoint, "http://127.0.0.1:1");
+        assert_eq!(*len, "hello world".len());
+        assert_eq!(*estimate, estimate_tokens_heuristic("hello world"));
+        drop(events);
+
+        // Cleanup: clear the hook so subsequent tests do not observe
+        // stale state.
+        set_tokenize_failure_hook(None);
     }
 }

--- a/crates/tmg-tui/tests/workflow_progress_wiring.rs
+++ b/crates/tmg-tui/tests/workflow_progress_wiring.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
 use tmg_tools::{Tool, ToolRegistry};
@@ -52,8 +52,7 @@ fn build_engine(
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        "http://localhost:9999",
-        "test-model",
+        EndpointResolver::new("http://localhost:9999", "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/crates/tmg-workflow/tests/agent_inject_files.rs
+++ b/crates/tmg-workflow/tests/agent_inject_files.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
 use tmg_tools::ToolRegistry;
@@ -37,8 +37,7 @@ fn build_engine(workspace: &Path) -> WorkflowEngine {
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        endpoint,
-        "test-model",
+        EndpointResolver::new(endpoint, "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/crates/tmg-workflow/tests/agent_isolation.rs
+++ b/crates/tmg-workflow/tests/agent_isolation.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
 use tmg_tools::ToolRegistry;
@@ -63,8 +63,7 @@ async fn agent_step_routes_through_subagent_manager() {
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        endpoint,
-        "test-model",
+        EndpointResolver::new(endpoint, "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));
@@ -134,8 +133,7 @@ async fn unknown_subagent_name_is_step_failure() {
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        endpoint,
-        "test-model",
+        EndpointResolver::new(endpoint, "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/crates/tmg-workflow/tests/agent_two_step_isolation.rs
+++ b/crates/tmg-workflow/tests/agent_two_step_isolation.rs
@@ -21,7 +21,7 @@ use tokio::sync::{Mutex, mpsc};
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
 use tmg_tools::ToolRegistry;
@@ -162,8 +162,7 @@ async fn two_sequential_agent_steps_have_isolated_histories() {
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        &endpoint,
-        "mock-model",
+        EndpointResolver::new(&endpoint, "mock-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/crates/tmg-workflow/tests/control_flow.rs
+++ b/crates/tmg-workflow/tests/control_flow.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
 use tmg_tools::ToolRegistry;
@@ -45,8 +45,7 @@ fn build_engine(workspace: &Path, max_parallel_agents: u32) -> WorkflowEngine {
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        "http://localhost:9999",
-        "test-model",
+        EndpointResolver::new("http://localhost:9999", "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/crates/tmg-workflow/tests/engine_sequential.rs
+++ b/crates/tmg-workflow/tests/engine_sequential.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
 use tmg_tools::ToolRegistry;
@@ -39,8 +39,7 @@ fn build_engine(workspace: &Path) -> WorkflowEngine {
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        "http://localhost:9999",
-        "test-model",
+        EndpointResolver::new("http://localhost:9999", "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/crates/tmg-workflow/tests/long_running.rs
+++ b/crates/tmg-workflow/tests/long_running.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_harness::{Run, RunRunner, RunStore};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
@@ -59,8 +59,7 @@ fn build_harness(
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        "http://localhost:9999",
-        "test-model",
+        EndpointResolver::new("http://localhost:9999", "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/crates/tmg-workflow/tests/pipeline.rs
+++ b/crates/tmg-workflow/tests/pipeline.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
 use tmg_tools::ToolRegistry;
@@ -46,8 +46,7 @@ fn build_engine(
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        "http://localhost:9999",
-        "test-model",
+        EndpointResolver::new("http://localhost:9999", "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/crates/tmg-workflow/tests/run_workflow_tool.rs
+++ b/crates/tmg-workflow/tests/run_workflow_tool.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
 use tmg_tools::{Tool, ToolRegistry};
@@ -57,8 +57,7 @@ fn build_engine(
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        "http://localhost:9999",
-        "test-model",
+        EndpointResolver::new("http://localhost:9999", "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/crates/tmg-workflow/tests/tui_progress_wiring.rs
+++ b/crates/tmg-workflow/tests/tui_progress_wiring.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 
-use tmg_agents::SubagentManager;
+use tmg_agents::{EndpointResolver, SubagentManager};
 use tmg_llm::{LlmPool, PoolConfig};
 use tmg_sandbox::{SandboxConfig, SandboxContext, SandboxMode};
 use tmg_tools::ToolRegistry;
@@ -40,8 +40,7 @@ fn build_engine(workspace: &Path) -> WorkflowEngine {
     let manager = SubagentManager::new(
         llm_client,
         cancel,
-        "http://localhost:9999",
-        "test-model",
+        EndpointResolver::new("http://localhost:9999", "test-model"),
         Arc::clone(&sandbox),
     );
     let subagent_manager = Arc::new(Mutex::new(manager));

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -24,6 +24,7 @@ tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 tmg-agents = { workspace = true }
 tmg-core = { workspace = true }
 tmg-harness = { workspace = true }

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -38,6 +38,12 @@ struct PartialLlmConfig {
     /// via tree-sitter signature extraction. Issue #49.
     pub signature_threshold_tokens: Option<usize>,
     pub tool_calling: Option<ToolCallingMode>,
+    /// `[llm.subagent_pool]` configuration. SPEC §10.1 / issue #50.
+    /// When present, the pool's endpoints are used to load-balance
+    /// non-escalator subagent spawns. An empty `endpoints` list is
+    /// **not** an error: it means "pool disabled".
+    #[serde(default)]
+    pub subagent_pool: Option<tmg_llm::PoolConfig>,
 }
 
 impl PartialLlmConfig {
@@ -64,6 +70,9 @@ impl PartialLlmConfig {
         if other.tool_calling.is_some() {
             self.tool_calling = other.tool_calling;
         }
+        if other.subagent_pool.is_some() {
+            self.subagent_pool.clone_from(&other.subagent_pool);
+        }
     }
 
     /// Convert to final `LlmConfig`, filling in defaults for unset fields.
@@ -84,6 +93,7 @@ impl PartialLlmConfig {
                 .signature_threshold_tokens
                 .unwrap_or(default_signature_threshold_tokens()),
             tool_calling: self.tool_calling.unwrap_or_default(),
+            subagent_pool: self.subagent_pool,
         }
     }
 }
@@ -898,6 +908,13 @@ pub struct LlmConfig {
 
     /// Tool calling mode.
     pub tool_calling: ToolCallingMode,
+
+    /// `[llm.subagent_pool]` configuration. SPEC §10.1 / issue #50.
+    /// `None` means "no pool section in the TOML"; `Some` with empty
+    /// endpoints means "pool disabled" (validated through
+    /// [`tmg_llm::PoolConfig::validate_relaxed`]).
+    #[serde(default)]
+    pub subagent_pool: Option<tmg_llm::PoolConfig>,
 }
 
 fn default_endpoint() -> String {
@@ -934,6 +951,7 @@ impl Default for LlmConfig {
             max_tool_result_tokens: default_max_tool_result_tokens(),
             signature_threshold_tokens: default_signature_threshold_tokens(),
             tool_calling: ToolCallingMode::default(),
+            subagent_pool: None,
         }
     }
 }
@@ -1302,6 +1320,36 @@ impl TsumugiConfig {
                 value: self.llm.compression_threshold.to_string(),
                 reason: "must be between 0.0 and 1.0".to_owned(),
             });
+        }
+
+        // Validate `[llm.subagent_pool]` (SPEC §10.1 / issue #50).
+        // Uses the relaxed validator so:
+        //   - empty `endpoints = []` is treated as "pool disabled",
+        //   - duplicate URLs are deduped with a `tracing::warn!`,
+        //   - malformed URLs / empty strings remain hard errors.
+        if let Some(pool) = self.llm.subagent_pool.as_ref() {
+            match pool.validate_relaxed() {
+                Ok(report) => {
+                    if !report.duplicates.is_empty() {
+                        tracing::warn!(
+                            duplicates = ?report.duplicates,
+                            "[llm.subagent_pool] endpoints contained duplicate URLs; deduping",
+                        );
+                    }
+                    if report.disabled {
+                        tracing::debug!(
+                            "[llm.subagent_pool] endpoints empty; subagent pool disabled",
+                        );
+                    }
+                }
+                Err(e) => {
+                    return Err(ConfigError::InvalidValue {
+                        field: "llm.subagent_pool".to_owned(),
+                        value: format!("{:?}", pool.endpoints),
+                        reason: e.to_string(),
+                    });
+                }
+            }
         }
 
         // No need to validate tool_calling or sandbox.mode -- they are

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -232,6 +232,20 @@ impl Cli {
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    // Initialise the global tracing subscriber so workspace-wide
+    // `tracing::warn!` / `tracing::debug!` calls land in the user's
+    // terminal when `TMG_LOG` is set. The default filter is `warn` so
+    // production runs only see escalation-grade messages; setting
+    // `TMG_LOG=debug` (or finer-grained `TMG_LOG=tmg_llm=debug,warn`)
+    // surfaces endpoint-resolution and pool-selection diagnostics.
+    //
+    // The TUI captures stderr indirectly via crossterm; in TUI mode the
+    // tracing output stays out of the way until the TUI exits, at
+    // which point it is flushed normally. One-shot mode renders the
+    // logs interleaved with the streamed response (acceptable noise
+    // for a debug session).
+    init_tracing();
+
     // Load and merge configuration: global -> project-local -> env -> CLI.
     let mut config =
         config::load_config(cli.config.as_deref()).context("loading tsumugi configuration")?;
@@ -270,11 +284,69 @@ fn main() -> anyhow::Result<()> {
                     &config.sandbox,
                     &config.workflow,
                     &config.skills,
+                    config.llm.subagent_pool.as_ref(),
                     None,
                 )
             }
         }
     }
+}
+
+/// Build the [`tmg_llm::LlmPool`] (if any) for the subagent resolver.
+///
+/// Returns `None` when no `[llm.subagent_pool]` section was supplied
+/// or when the operator left `endpoints = []` (the relaxed validator
+/// already logged the "pool disabled" notice). Construction errors are
+/// downgraded to a `tracing::warn!` so a malformed pool does not abort
+/// startup — the resolver still has a valid main fallback.
+fn subagent_pool_from_config(
+    pool_cfg: Option<&tmg_llm::PoolConfig>,
+    model: &str,
+) -> Option<Arc<tmg_llm::LlmPool>> {
+    let cfg = pool_cfg?;
+    let report = match cfg.validate_relaxed() {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "subagent pool config invalid; not constructing pool");
+            return None;
+        }
+    };
+    if report.disabled {
+        return None;
+    }
+    let deduped = tmg_llm::PoolConfig {
+        endpoints: report.deduped_endpoints,
+        strategy: cfg.strategy,
+    };
+    match tmg_llm::LlmPool::new(&deduped, model) {
+        Ok(pool) => Some(Arc::new(pool)),
+        Err(e) => {
+            tracing::warn!(error = %e, "subagent pool construction failed; falling back to main endpoint");
+            None
+        }
+    }
+}
+
+/// Initialise the global `tracing` subscriber.
+///
+/// The subscriber is built from the `TMG_LOG` environment variable
+/// (using the standard `EnvFilter` syntax: `TMG_LOG=debug` for global
+/// debug, `TMG_LOG=tmg_llm=debug,warn` for crate-scoped overrides).
+/// When `TMG_LOG` is unset the filter defaults to `warn`, which keeps
+/// the live TUI quiet. Issue #50.
+///
+/// Calling this twice is harmless: the second `try_init` is a no-op
+/// because the global default is already installed, so the function
+/// silently absorbs the error. This matters for tests that may build
+/// a `Cli` and reuse the runtime.
+fn init_tracing() {
+    use tracing_subscriber::EnvFilter;
+    let filter = EnvFilter::try_from_env("TMG_LOG").unwrap_or_else(|_| EnvFilter::new("warn"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .try_init();
 }
 
 /// Resolve the runs-dir against the canonical cwd, mirroring the
@@ -353,6 +425,7 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
                 &config.sandbox,
                 &config.workflow,
                 &config.skills,
+                config.llm.subagent_pool.as_ref(),
                 resolved.as_ref(),
             )
         }
@@ -508,6 +581,7 @@ fn run_tui(
     sandbox_config: &SandboxConfigSection,
     workflow_config: &tmg_workflow::WorkflowConfig,
     skills_config: &tmg_skills::SkillsConfig,
+    subagent_pool: Option<&tmg_llm::PoolConfig>,
     explicit_run_id: Option<&tmg_harness::RunId>,
 ) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
@@ -662,25 +736,32 @@ fn run_tui(
 
         // Create the subagent manager. The escalator's
         // endpoint/model/disable knobs flow through
-        // [`tmg_agents::EscalatorOverrides`] so the resolver in
-        // `SubagentManager` is the single source of truth for
-        // precedence (see `crates/tmg-agents/src/manager.rs` module
-        // docs).
+        // [`tmg_agents::EscalatorOverrides`] into the centralised
+        // [`tmg_agents::EndpointResolver`] (issue #50) so the manager
+        // delegates every spawn-time precedence decision to that
+        // module.
         let escalator_overrides = tmg_agents::EscalatorOverrides::from_strings(
             harness_config.escalator.endpoint.clone(),
             harness_config.escalator.model.clone(),
             harness_config.escalator.disable,
         );
-        let subagent_manager = Arc::new(Mutex::new(
-            tmg_agents::SubagentManager::new(
-                client.clone(),
-                cancel.clone(),
-                endpoint,
-                model,
-                Arc::clone(&sandbox_ctx),
-            )
-            .with_escalator_overrides(escalator_overrides),
-        ));
+        // `[llm.subagent_pool]` is wired into the resolver here so
+        // non-escalator builtin agents fan across the configured pool
+        // endpoints. The validator already deduped URLs and reported
+        // an empty list as "pool disabled" via the relaxed-validation
+        // path; we honour that by only constructing a pool when the
+        // post-validation list has at least one entry.
+        let subagent_pool: Option<Arc<tmg_llm::LlmPool>> =
+            subagent_pool_from_config(subagent_pool, model);
+        let resolver = tmg_agents::EndpointResolver::new(endpoint, model)
+            .with_escalator_overrides(escalator_overrides)
+            .with_pool(subagent_pool);
+        let subagent_manager = Arc::new(Mutex::new(tmg_agents::SubagentManager::new(
+            client.clone(),
+            cancel.clone(),
+            resolver,
+            Arc::clone(&sandbox_ctx),
+        )));
 
         // Wire the active `RunRunner` into the subagent manager so
         // harnessed-run subagents (initializer / tester / qa) get

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -14,6 +14,7 @@ mod config;
 mod error;
 mod harness_init;
 mod init_command;
+mod pool_setup;
 mod run_commands;
 mod workflow_commands;
 
@@ -261,7 +262,9 @@ fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Some(Command::Run { op }) => dispatch_run_command(op, &config),
-        Some(Command::Workflow { op }) => dispatch_workflow_command(op, &config),
+        Some(Command::Workflow { op }) => {
+            dispatch_workflow_command(op, &config, cli.event_log.as_deref())
+        }
         Some(Command::Init(args)) => {
             init_command::cmd_init(&args.workflows, &args.harness, args.all, args.force)
         }
@@ -292,40 +295,8 @@ fn main() -> anyhow::Result<()> {
     }
 }
 
-/// Build the [`tmg_llm::LlmPool`] (if any) for the subagent resolver.
-///
-/// Returns `None` when no `[llm.subagent_pool]` section was supplied
-/// or when the operator left `endpoints = []` (the relaxed validator
-/// already logged the "pool disabled" notice). Construction errors are
-/// downgraded to a `tracing::warn!` so a malformed pool does not abort
-/// startup — the resolver still has a valid main fallback.
-fn subagent_pool_from_config(
-    pool_cfg: Option<&tmg_llm::PoolConfig>,
-    model: &str,
-) -> Option<Arc<tmg_llm::LlmPool>> {
-    let cfg = pool_cfg?;
-    let report = match cfg.validate_relaxed() {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!(error = %e, "subagent pool config invalid; not constructing pool");
-            return None;
-        }
-    };
-    if report.disabled {
-        return None;
-    }
-    let deduped = tmg_llm::PoolConfig {
-        endpoints: report.deduped_endpoints,
-        strategy: cfg.strategy,
-    };
-    match tmg_llm::LlmPool::new(&deduped, model) {
-        Ok(pool) => Some(Arc::new(pool)),
-        Err(e) => {
-            tracing::warn!(error = %e, "subagent pool construction failed; falling back to main endpoint");
-            None
-        }
-    }
-}
+// `subagent_pool_from_config` lives in `crate::pool_setup` so the
+// workflow command path (`tmg workflow run`) can reuse it.
 
 /// Initialise the global `tracing` subscriber.
 ///
@@ -366,12 +337,20 @@ fn resolve_runs_dir(harness_config: &HarnessConfig) -> anyhow::Result<(PathBuf, 
 /// Dispatch one `tmg workflow <op>` invocation. None of these
 /// operations attach to an active TUI; they all read or run workflows
 /// against the configured discovery scope.
-fn dispatch_workflow_command(op: WorkflowCommand, config: &TsumugiConfig) -> anyhow::Result<()> {
+///
+/// `event_log` is threaded only into `Run` because `List` and
+/// `Validate` do not spawn subagents; the resolver / pool / tokenize
+/// hooks are no-ops outside the live engine path.
+fn dispatch_workflow_command(
+    op: WorkflowCommand,
+    config: &TsumugiConfig,
+    event_log: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
     match op {
         WorkflowCommand::List => workflow_commands::cmd_list(config),
         WorkflowCommand::Validate => workflow_commands::cmd_validate(config),
         WorkflowCommand::Run { workflow, inputs } => {
-            workflow_commands::cmd_run(&workflow, &inputs, config)
+            workflow_commands::cmd_run(&workflow, &inputs, config, event_log)
         }
     }
 }
@@ -752,7 +731,12 @@ fn run_tui(
         // path; we honour that by only constructing a pool when the
         // post-validation list has at least one entry.
         let subagent_pool: Option<Arc<tmg_llm::LlmPool>> =
-            subagent_pool_from_config(subagent_pool, model);
+            pool_setup::subagent_pool_from_config(subagent_pool, model);
+        // Capture the strategy BEFORE moving `subagent_pool` into the
+        // resolver so the `--event-log` `pool_selected` records can
+        // stamp the active strategy on every emitted event.
+        let pool_strategy_label: Option<&'static str> =
+            subagent_pool.as_ref().map(|p| p.strategy().as_str());
         let resolver = tmg_agents::EndpointResolver::new(endpoint, model)
             .with_escalator_overrides(escalator_overrides)
             .with_pool(subagent_pool);
@@ -762,6 +746,29 @@ fn run_tui(
             resolver,
             Arc::clone(&sandbox_ctx),
         )));
+
+        // Wire the `--event-log` observers on the subagent manager
+        // and the global tokenize fallback path. Issue #50 review:
+        // the previous wiring claim in the PR description was not
+        // backed by code — the writer methods were defined but never
+        // called. The hooks open the log file in append mode so we
+        // share the same file the TUI itself writes into.
+        if let Some(path) = event_log.as_deref() {
+            match pool_setup::open_event_log(path) {
+                Ok(log_writer) => {
+                    pool_setup::install_event_log_hooks(
+                        Arc::clone(&subagent_manager),
+                        Arc::clone(&log_writer),
+                        pool_strategy_label,
+                    )
+                    .await;
+                    pool_setup::install_tokenize_failure_hook(log_writer);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to open event log for hooks; resolver/tokenize events will not be recorded");
+                }
+            }
+        }
 
         // Wire the active `RunRunner` into the subagent manager so
         // harnessed-run subagents (initializer / tester / qa) get

--- a/tmg-cli/src/pool_setup.rs
+++ b/tmg-cli/src/pool_setup.rs
@@ -1,0 +1,124 @@
+//! Shared CLI helpers for `[llm.subagent_pool]` wiring.
+//!
+//! Moved out of `main.rs` so the workflow command path
+//! (`tmg workflow run`) can reuse the same construction logic instead
+//! of building an [`tmg_agents::EndpointResolver`] without a pool —
+//! that mismatch silently dropped the operator's pool config (issue
+//! #50 review).
+//!
+//! In addition to pool construction, this module also installs the
+//! `--event-log` observers (`endpoint_resolved`, `pool_selected`,
+//! `tokenize_failure`) on the [`tmg_agents::SubagentManager`]
+//! (and via [`tmg_llm::set_tokenize_failure_hook`] on the global
+//! tokenize fallback path). Centralising the wiring keeps both the
+//! TUI and CLI paths in lock-step so a future code change cannot
+//! forget to install one of the hooks on one of the entry points.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use tokio::sync::Mutex as AsyncMutex;
+
+use tmg_agents::{EndpointResolvedEvent, EndpointResolvedHook, SubagentManager};
+use tmg_core::EventLogWriter;
+use tmg_llm::{LlmPool, PoolConfig, TokenizeFailureHook};
+
+/// Build the [`LlmPool`] (if any) for the subagent resolver.
+///
+/// Returns `None` when no `[llm.subagent_pool]` section was supplied
+/// or when the operator left `endpoints = []` (the relaxed validator
+/// already logged the "pool disabled" notice). Construction errors are
+/// downgraded to a `tracing::warn!` so a malformed pool does not abort
+/// startup — the resolver still has a valid main fallback.
+pub(crate) fn subagent_pool_from_config(
+    pool_cfg: Option<&PoolConfig>,
+    model: &str,
+) -> Option<Arc<LlmPool>> {
+    let cfg = pool_cfg?;
+    let report = match cfg.validate_relaxed() {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "subagent pool config invalid; not constructing pool");
+            return None;
+        }
+    };
+    if report.disabled {
+        return None;
+    }
+    let deduped = PoolConfig {
+        endpoints: report.deduped_endpoints,
+        strategy: cfg.strategy,
+    };
+    match LlmPool::new(&deduped, model) {
+        Ok(pool) => Some(Arc::new(pool)),
+        Err(e) => {
+            tracing::warn!(error = %e, "subagent pool construction failed; falling back to main endpoint");
+            None
+        }
+    }
+}
+
+/// Open an [`EventLogWriter`] in append mode.
+///
+/// `append` is preferred over `new` here because both the TUI startup
+/// path and `tmg workflow run` may write into the same `--event-log`
+/// path during a single shell session, and truncating between
+/// invocations would lose the prior run's events.
+///
+/// Returned errors carry context describing the path so the operator
+/// sees what file actually failed to open.
+pub(crate) fn open_event_log(path: &Path) -> anyhow::Result<Arc<std::sync::Mutex<EventLogWriter>>> {
+    let writer = EventLogWriter::open_append(path)
+        .with_context(|| format!("opening event log at {}", path.display()))?;
+    Ok(Arc::new(std::sync::Mutex::new(writer)))
+}
+
+/// Install the `endpoint_resolved` and `pool_selected` hooks on the
+/// supplied [`SubagentManager`].
+///
+/// `pool_selected` events are emitted from inside the
+/// `endpoint_resolved` hook when the resolver reports `source ==
+/// "pool"` — that's the one branch where a multi-endpoint pool
+/// actually picked a URL, so emitting both records lets the
+/// `--event-log` reader correlate the spawn with the pool selection
+/// without a separate observer plumb. The `strategy` string is
+/// stamped from the pool's configured [`tmg_llm::LoadBalanceStrategy`]
+/// at install time, which is stable for the lifetime of the manager.
+pub(crate) async fn install_event_log_hooks(
+    manager: Arc<AsyncMutex<SubagentManager>>,
+    log: Arc<std::sync::Mutex<EventLogWriter>>,
+    pool_strategy: Option<&'static str>,
+) {
+    let log_for_resolved = Arc::clone(&log);
+    let strategy_label: &'static str = pool_strategy.unwrap_or("");
+    let hook: EndpointResolvedHook = Arc::new(move |ev: &EndpointResolvedEvent<'_>| {
+        if let Ok(mut writer) = log_for_resolved.lock() {
+            writer.write_endpoint_resolved(ev.agent_kind, ev.endpoint, ev.model, ev.source);
+            // `pool_selected` is the structurally-richer record for the
+            // pool case; emit it whenever the resolver reports `pool`.
+            if ev.source == "pool" {
+                writer.write_pool_selected(ev.endpoint, strategy_label);
+            }
+        }
+    });
+    manager.lock().await.set_endpoint_resolved_hook(Some(hook));
+}
+
+/// Install the global tokenize-failure observer.
+///
+/// The hook is process-wide (see [`tmg_llm::set_tokenize_failure_hook`])
+/// because the underlying tokenize helper is also process-wide. The
+/// CLI is the only caller and installs the hook once at startup; the
+/// returned guard intentionally does not exist because a tokenize
+/// failure that fires after the CLI exits is harmless.
+pub(crate) fn install_tokenize_failure_hook(log: Arc<std::sync::Mutex<EventLogWriter>>) {
+    let hook: TokenizeFailureHook = Arc::new(
+        move |endpoint: &str, text_len: usize, estimate: usize, error: &str| {
+            if let Ok(mut writer) = log.lock() {
+                writer.write_tokenize_failure(endpoint, text_len, estimate, error);
+            }
+        },
+    );
+    tmg_llm::set_tokenize_failure_hook(Some(hook));
+}

--- a/tmg-cli/src/workflow_commands.rs
+++ b/tmg-cli/src/workflow_commands.rs
@@ -29,6 +29,10 @@ use tmg_workflow::{
 };
 
 use crate::config::{HarnessConfig, TsumugiConfig};
+use crate::pool_setup::{
+    install_event_log_hooks, install_tokenize_failure_hook, open_event_log,
+    subagent_pool_from_config,
+};
 
 /// Parse a single `--input k=v` pair into `(key, value)`.
 ///
@@ -193,6 +197,7 @@ pub(crate) fn cmd_run(
     workflow_id: &str,
     inputs_raw: &[String],
     config: &TsumugiConfig,
+    event_log: Option<&Path>,
 ) -> anyhow::Result<()> {
     // 1. Parse the inputs first so we fail fast on bad CLI input.
     let mut inputs: BTreeMap<String, Value> = BTreeMap::new();
@@ -231,9 +236,11 @@ pub(crate) fn cmd_run(
         let store = Arc::new(RunStore::new(runs_dir));
 
         match workflow.mode {
-            WorkflowMode::Normal => run_normal(&workflow, inputs, &canonical, config).await,
+            WorkflowMode::Normal => {
+                run_normal(&workflow, inputs, &canonical, config, event_log).await
+            }
             WorkflowMode::LongRunning => {
-                run_long_running(&workflow, inputs, &canonical, &store, config).await
+                run_long_running(&workflow, inputs, &canonical, &store, config, event_log).await
             }
             other => anyhow::bail!(
                 "unsupported workflow mode for this CLI: {other:?}. \
@@ -304,11 +311,16 @@ fn render_value(v: &Value) -> String {
     clippy::print_stderr,
     reason = "WorkflowProgress events stream to stderr per SPEC §9.13"
 )]
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear setup (pool -> resolver -> manager -> engine -> stream); splitting obscures the ad-hoc startup sequence"
+)]
 async fn run_normal(
     workflow: &WorkflowDef,
     inputs: BTreeMap<String, Value>,
     canonical: &Path,
     config: &TsumugiConfig,
+    event_log: Option<&Path>,
 ) -> anyhow::Result<()> {
     let llm_pool = Arc::new(
         tmg_llm::LlmPool::new(
@@ -335,12 +347,38 @@ async fn run_normal(
         tmg_sandbox::SandboxConfig::new(canonical)
             .with_mode(tmg_sandbox::SandboxMode::WorkspaceWrite),
     ));
+    // Honour `[llm.subagent_pool]` so subagents spawned by the
+    // workflow engine fan across the configured endpoints. The TUI
+    // path used to be the only consumer of this config — issue #50
+    // review caught the silent drop here.
+    let subagent_pool =
+        subagent_pool_from_config(config.llm.subagent_pool.as_ref(), &config.llm.model);
+    let pool_strategy_label: Option<&'static str> =
+        subagent_pool.as_ref().map(|p| p.strategy().as_str());
+    let resolver = tmg_agents::EndpointResolver::new(&config.llm.endpoint, &config.llm.model)
+        .with_pool(subagent_pool);
     let subagent_manager = Arc::new(Mutex::new(tmg_agents::SubagentManager::new(
         llm_client,
         cancel.clone(),
-        tmg_agents::EndpointResolver::new(&config.llm.endpoint, &config.llm.model),
+        resolver,
         Arc::clone(&sandbox),
     )));
+    if let Some(path) = event_log {
+        match open_event_log(path) {
+            Ok(log_writer) => {
+                install_event_log_hooks(
+                    Arc::clone(&subagent_manager),
+                    Arc::clone(&log_writer),
+                    pool_strategy_label,
+                )
+                .await;
+                install_tokenize_failure_hook(log_writer);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to open event log for workflow run; resolver/tokenize events will not be recorded");
+            }
+        }
+    }
     let registry = Arc::new(tmg_tools::ToolRegistry::new());
     let engine = WorkflowEngine::new(
         llm_pool,
@@ -411,6 +449,7 @@ async fn run_long_running(
     canonical: &Path,
     store: &Arc<RunStore>,
     config: &TsumugiConfig,
+    event_log: Option<&Path>,
 ) -> anyhow::Result<()> {
     let cancel = CancellationToken::new();
     {
@@ -452,12 +491,36 @@ async fn run_long_running(
         tmg_sandbox::SandboxConfig::new(canonical)
             .with_mode(tmg_sandbox::SandboxMode::WorkspaceWrite),
     ));
+    // Honour `[llm.subagent_pool]` for long-running workflow spawns
+    // (issue #50 review).
+    let subagent_pool =
+        subagent_pool_from_config(config.llm.subagent_pool.as_ref(), &config.llm.model);
+    let pool_strategy_label: Option<&'static str> =
+        subagent_pool.as_ref().map(|p| p.strategy().as_str());
+    let resolver = tmg_agents::EndpointResolver::new(&config.llm.endpoint, &config.llm.model)
+        .with_pool(subagent_pool);
     let subagent_manager = Arc::new(Mutex::new(tmg_agents::SubagentManager::new(
         llm_client,
         cancel.clone(),
-        tmg_agents::EndpointResolver::new(&config.llm.endpoint, &config.llm.model),
+        resolver,
         Arc::clone(&sandbox),
     )));
+    if let Some(path) = event_log {
+        match open_event_log(path) {
+            Ok(log_writer) => {
+                install_event_log_hooks(
+                    Arc::clone(&subagent_manager),
+                    Arc::clone(&log_writer),
+                    pool_strategy_label,
+                )
+                .await;
+                install_tokenize_failure_hook(log_writer);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to open event log for long-running workflow; resolver/tokenize events will not be recorded");
+            }
+        }
+    }
     let registry = Arc::new(tmg_tools::ToolRegistry::new());
     let engine = Arc::new(WorkflowEngine::new(
         llm_pool,

--- a/tmg-cli/src/workflow_commands.rs
+++ b/tmg-cli/src/workflow_commands.rs
@@ -338,8 +338,7 @@ async fn run_normal(
     let subagent_manager = Arc::new(Mutex::new(tmg_agents::SubagentManager::new(
         llm_client,
         cancel.clone(),
-        &config.llm.endpoint,
-        &config.llm.model,
+        tmg_agents::EndpointResolver::new(&config.llm.endpoint, &config.llm.model),
         Arc::clone(&sandbox),
     )));
     let registry = Arc::new(tmg_tools::ToolRegistry::new());
@@ -456,8 +455,7 @@ async fn run_long_running(
     let subagent_manager = Arc::new(Mutex::new(tmg_agents::SubagentManager::new(
         llm_client,
         cancel.clone(),
-        &config.llm.endpoint,
-        &config.llm.model,
+        tmg_agents::EndpointResolver::new(&config.llm.endpoint, &config.llm.model),
         Arc::clone(&sandbox),
     )));
     let registry = Arc::new(tmg_tools::ToolRegistry::new());


### PR DESCRIPTION
## Summary

Implements issue #50 — refactor + DX improvement for the LLM subagent
configuration story.

- **`tmg_agents::EndpointResolver`** centralises `(endpoint, model)`
  resolution following SPEC §10.1 / §9.10 / §9.3 precedence:
  `CustomAgentDef` → `EscalatorOverrides` (escalator only — never
  load-balanced) → multi-endpoint `LlmPool` → main fallback.
- **Breaking change**: `SubagentManager::new` now takes an
  `EndpointResolver` instead of the previous `default_endpoint` /
  `default_model` strings. Every CLI / workflow / tui call site and
  test updated.
- **`tmg_llm::count_tokens_or_estimate`** is the shared "exact
  tokenize, fall back to chars/4 on failure" helper. First failure
  emits a `tracing::warn!`; subsequent failures drop to `debug!` so
  the agent loop is not flooded when `llama-server` is genuinely
  down. `tmg_core::TokenCounter::request_update` delegates here.
- **`PoolConfig::validate_relaxed`** treats empty `endpoints` as
  "pool disabled" (not an error), dedupes duplicate URLs with a
  warning, and still rejects malformed URLs / empty strings.
- **`[llm.subagent_pool]`** is now wired through the CLI: deserialised
  from `tsumugi.toml`, validated via `validate_relaxed`, and threaded
  into the resolver.
- **EventLog hooks** for debugging:
  `EventLogWriter::write_endpoint_resolved`, `write_pool_selected`,
  `write_tokenize_failure` plus an `EndpointResolvedHook` on
  `SubagentManager` so the CLI can route resolutions into
  `--event-log`.
- **`tracing` wiring**: `tmg-cli::main` initialises
  `tracing_subscriber` from the `TMG_LOG` env var (default `warn`).

## Crates touched

- `tmg-llm`: new `tokenize` module, `validate_relaxed` + dedupe on
  `PoolConfig`, debug logging on pool acquire, `tracing` dep added.
- `tmg-agents`: new `endpoint_resolver` module, `SubagentManager`
  refactored to delegate to the resolver, `EndpointResolvedHook`,
  `tracing` dep added.
- `tmg-core`: new event-log variants for endpoint resolution / pool
  selection / tokenize failure; `TokenCounter` delegates to the new
  helper.
- `tmg-cli`: `[llm.subagent_pool]` config section, relaxed
  validation, `init_tracing()` + `TMG_LOG` env filter, pool wired
  through to `EndpointResolver`.
- All workflow / tui tests updated for the new constructor signature.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (all green)
- [x] One-shot runtime verification with `--event-log`
- [x] `TMG_LOG=debug` produces structured trace output on stderr

### Runtime Verification

- LLM server: available
- One-shot mode: PASS
  - 168 events, no errors, returned correct answer for `7 + 5`
- TUI mode: SKIP (refactor + breaking-API issue; the new constructor
  signature change is exercised exhaustively by the workspace test
  suite which compiles and runs every TUI / workflow integration test)
- TMG_LOG=debug: PASS — `tracing_subscriber` honours the env filter
  and emits `DEBUG`/`WARN` lines on stderr

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)