### PR TITLE
tmg-memory: project-scoped persistent memory + memory tool (#52)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,6 +2087,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dirs",
+ "regex",
  "serde",
  "serde_json",
  "serde_yml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
  "tmg-core",
  "tmg-harness",
  "tmg-llm",
+ "tmg-memory",
  "tmg-sandbox",
  "tmg-skills",
  "tmg-tools",
@@ -2081,6 +2082,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tmg-memory"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dirs",
+ "serde",
+ "serde_json",
+ "serde_yml",
+ "tempfile",
+ "thiserror",
+ "tmg-sandbox",
+ "tmg-tools",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tmg-sandbox"
 version = "0.1.0"
 dependencies = [
@@ -2143,6 +2161,7 @@ dependencies = [
  "tmg-core",
  "tmg-harness",
  "tmg-llm",
+ "tmg-memory",
  "tmg-sandbox",
  "tmg-skills",
  "tmg-tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "crates/tmg-core",
     "crates/tmg-llm",
+    "crates/tmg-memory",
     "crates/tmg-tools",
     "crates/tmg-skills",
     "crates/tmg-agents",
@@ -92,6 +93,7 @@ libc = "0.2"
 # Workspace crates
 tmg-core = { path = "crates/tmg-core" }
 tmg-llm = { path = "crates/tmg-llm" }
+tmg-memory = { path = "crates/tmg-memory" }
 tmg-tools = { path = "crates/tmg-tools" }
 tmg-skills = { path = "crates/tmg-skills" }
 tmg-agents = { path = "crates/tmg-agents" }

--- a/crates/tmg-agents/src/builtins.rs
+++ b/crates/tmg-agents/src/builtins.rs
@@ -57,6 +57,23 @@ pub trait RunToolProvider: Send + Sync {
     fn register_run_tool(&self, registry: &mut ToolRegistry, name: &str) -> bool;
 }
 
+/// Source of the agent-facing `memory` tool. Lives outside
+/// [`tmg_tools::default_registry`] because constructing the tool
+/// requires an `Arc<MemoryStore>` that the CLI holds, and `tmg-tools`
+/// must not depend on `tmg-memory` (which itself depends on
+/// `tmg-tools`).
+///
+/// When a [`MemoryToolProvider`] is installed on the
+/// [`SubagentManager`](crate::manager::SubagentManager), it registers
+/// the `memory` tool into every spawned subagent's registry — even
+/// when memory is not part of the agent's `allowed_tools` list — so
+/// subagents can read and curate the project memory just like the
+/// top-level agent. Issue #3 of PR #76 review.
+pub trait MemoryToolProvider: Send + Sync {
+    /// Register the `memory` tool into `registry`.
+    fn register_memory_tool(&self, registry: &mut ToolRegistry);
+}
+
 /// Create a [`ToolRegistry`] containing only the stateless tools allowed
 /// for the given agent type.
 ///
@@ -67,7 +84,7 @@ pub trait RunToolProvider: Send + Sync {
 #[must_use]
 pub fn registry_for_agent_type(agent_type: AgentType) -> ToolRegistry {
     let allowed: Vec<&str> = agent_type.allowed_tools().to_vec();
-    build_registry(&allowed, None)
+    build_registry(&allowed, None, None)
 }
 
 /// Create a [`ToolRegistry`] containing only the stateless tools allowed
@@ -79,7 +96,7 @@ pub fn registry_for_agent_type(agent_type: AgentType) -> ToolRegistry {
 #[must_use]
 pub fn registry_for_agent_kind(agent_kind: &AgentKind) -> ToolRegistry {
     let allowed = agent_kind.allowed_tool_names();
-    build_registry(&allowed, None)
+    build_registry(&allowed, None, None)
 }
 
 /// Create a [`ToolRegistry`] for the given agent kind, including
@@ -99,20 +116,41 @@ pub fn registry_for_agent_kind_with_run_provider(
     provider: &dyn RunToolProvider,
 ) -> ToolRegistry {
     let allowed = agent_kind.allowed_tool_names();
-    build_registry(&allowed, Some(provider))
+    build_registry(&allowed, Some(provider), None)
+}
+
+/// Like [`registry_for_agent_kind_with_run_provider`] but also
+/// registers the agent-facing `memory` tool (when `memory_provider` is
+/// `Some`). The memory tool is always installed regardless of the
+/// agent's `allowed_tools` list because the project memory is a
+/// shared, always-available context surface for every subagent (issue
+/// #3 of PR #76 review).
+#[must_use]
+pub fn registry_for_agent_kind_with_providers(
+    agent_kind: &AgentKind,
+    run_provider: Option<&dyn RunToolProvider>,
+    memory_provider: Option<&dyn MemoryToolProvider>,
+) -> ToolRegistry {
+    let allowed = agent_kind.allowed_tool_names();
+    build_registry(&allowed, run_provider, memory_provider)
 }
 
 /// Build a registry containing only the named tools, drawing first from
 /// the stateless default registry and then from the optional
-/// [`RunToolProvider`].
-fn build_registry(allowed: &[&str], provider: Option<&dyn RunToolProvider>) -> ToolRegistry {
+/// [`RunToolProvider`]. The `memory_provider`, when present, registers
+/// the `memory` tool unconditionally.
+fn build_registry(
+    allowed: &[&str],
+    run_provider: Option<&dyn RunToolProvider>,
+    memory_provider: Option<&dyn MemoryToolProvider>,
+) -> ToolRegistry {
     let full_registry = tmg_tools::default_registry();
     let mut filtered = ToolRegistry::new();
 
     for name in allowed {
         if full_registry.get(name).is_some() {
             register_stateless_tool_by_name(&mut filtered, name);
-        } else if let Some(provider) = provider {
+        } else if let Some(provider) = run_provider {
             // Unknown to the stateless default registry; ask the Run
             // provider. A `false` return is the silent-skip path
             // documented above.
@@ -121,6 +159,14 @@ fn build_registry(allowed: &[&str], provider: Option<&dyn RunToolProvider>) -> T
         // No provider AND not in default_registry: silently skip. The
         // subagent will simply not see the tool, which is the intended
         // behaviour for Run-less code paths.
+    }
+
+    // Memory tool is registered unconditionally when a provider is
+    // present so subagents can curate project memory the same way the
+    // top-level agent does. Skipped silently when no provider is
+    // installed (e.g. Run-less code paths or unit tests).
+    if let Some(mp) = memory_provider {
+        mp.register_memory_tool(&mut filtered);
     }
 
     filtered
@@ -349,6 +395,88 @@ allow = ["file_read", "grep_search"]
                 );
             }
         }
+    }
+
+    /// Regression test for issue #3 of PR #76 review: when a
+    /// [`MemoryToolProvider`] is installed, every subagent's registry
+    /// (built-in or custom, regardless of `allowed_tools`) sees the
+    /// `memory` tool. Without this guarantee, subagents that build
+    /// registries from `tmg_tools::default_registry()` would never be
+    /// able to call `memory`.
+    #[test]
+    fn memory_provider_registers_into_every_subagent_registry() {
+        struct TestMemoryProvider;
+        impl MemoryToolProvider for TestMemoryProvider {
+            fn register_memory_tool(&self, registry: &mut ToolRegistry) {
+                registry.register(MemoryStubTool);
+            }
+        }
+        struct MemoryStubTool;
+        impl tmg_tools::Tool for MemoryStubTool {
+            fn name(&self) -> &'static str {
+                "memory"
+            }
+            fn description(&self) -> &'static str {
+                "stub"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            fn execute<'a>(
+                &'a self,
+                _params: serde_json::Value,
+                _ctx: &'a tmg_sandbox::SandboxContext,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = Result<tmg_tools::ToolResult, tmg_tools::ToolError>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                Box::pin(async { Ok(tmg_tools::ToolResult::success("ok")) })
+            }
+        }
+
+        let memory_provider: Arc<dyn MemoryToolProvider> = Arc::new(TestMemoryProvider);
+
+        // Every built-in agent kind must see `memory`.
+        for agent_type in [
+            AgentType::Explore,
+            AgentType::Worker,
+            AgentType::Plan,
+            AgentType::Initializer,
+            AgentType::Tester,
+            AgentType::Qa,
+            AgentType::Escalator,
+        ] {
+            let kind = AgentKind::Builtin(agent_type);
+            let registry =
+                registry_for_agent_kind_with_providers(&kind, None, Some(&*memory_provider));
+            assert!(
+                registry.get("memory").is_some(),
+                "{} subagent registry MUST contain memory when provider is installed",
+                agent_type.name(),
+            );
+        }
+
+        // Custom agents see it too.
+        let toml = r#"
+name = "minimal-custom"
+description = "Minimal"
+instructions = "Do things."
+
+[tools]
+allow = ["file_read"]
+"#;
+        let def = crate::custom::CustomAgentDef::from_toml(toml, "test.toml")
+            .unwrap_or_else(|e| panic!("{e}"));
+        let kind = AgentKind::Custom(std::sync::Arc::new(def));
+        let registry = registry_for_agent_kind_with_providers(&kind, None, Some(&*memory_provider));
+        assert!(registry.get("memory").is_some());
+        // Without the provider, no memory tool.
+        let registry = registry_for_agent_kind_with_providers(&kind, None, None);
+        assert!(registry.get("memory").is_none());
     }
 
     /// The provider's `register_run_tool` is only called for names that

--- a/crates/tmg-agents/src/lib.rs
+++ b/crates/tmg-agents/src/lib.rs
@@ -19,7 +19,8 @@ pub mod status;
 pub mod tools;
 
 pub use builtins::{
-    RunToolProvider, registry_for_agent_kind, registry_for_agent_kind_with_run_provider,
+    MemoryToolProvider, RunToolProvider, registry_for_agent_kind,
+    registry_for_agent_kind_with_providers, registry_for_agent_kind_with_run_provider,
     registry_for_agent_type,
 };
 pub use config::{AgentKind, AgentType, SubagentConfig};

--- a/crates/tmg-agents/src/manager.rs
+++ b/crates/tmg-agents/src/manager.rs
@@ -34,7 +34,8 @@ use tmg_llm::LlmClient;
 use tmg_sandbox::{SandboxContext, SandboxMode};
 
 use crate::builtins::{
-    RunToolProvider, registry_for_agent_kind, registry_for_agent_kind_with_run_provider,
+    MemoryToolProvider, RunToolProvider, registry_for_agent_kind,
+    registry_for_agent_kind_with_providers, registry_for_agent_kind_with_run_provider,
 };
 use crate::config::{AgentKind, AgentType, SubagentConfig};
 use crate::endpoint_resolver::{EndpointResolver, ResolvedEndpoint};
@@ -194,6 +195,13 @@ pub struct SubagentManager {
     /// behaviour for Run-less code paths.
     run_tool_provider: Option<Arc<dyn RunToolProvider>>,
 
+    /// Optional source of the agent-facing `memory` tool. When set,
+    /// every spawned subagent's registry contains `memory` so the
+    /// subagent can read and curate the project memory the same way
+    /// the top-level agent does. When unset, subagents simply do not
+    /// see the `memory` tool. Issue #3 of PR #76 review.
+    memory_tool_provider: Option<Arc<dyn MemoryToolProvider>>,
+
     /// Parent [`SandboxContext`] from which each spawn derives its
     /// per-subagent sandbox.
     ///
@@ -270,6 +278,7 @@ impl SubagentManager {
             instances: Arc::new(Mutex::new(BTreeMap::new())),
             next_id: 1,
             run_tool_provider: None,
+            memory_tool_provider: None,
             parent_sandbox,
             resolved_hook: None,
         }
@@ -358,6 +367,23 @@ impl SubagentManager {
     #[must_use]
     pub fn run_tool_provider(&self) -> Option<&Arc<dyn RunToolProvider>> {
         self.run_tool_provider.as_ref()
+    }
+
+    /// Install (or replace) the [`MemoryToolProvider`] used to register
+    /// the `memory` tool into every spawned subagent's registry.
+    ///
+    /// Pass `None` to clear a previously-installed provider (e.g. when
+    /// the user has disabled `[memory].enabled`). Subsequent spawns
+    /// will not see a `memory` tool just as if no provider had ever
+    /// been set. Issue #3 of PR #76 review.
+    pub fn set_memory_tool_provider(&mut self, provider: Option<Arc<dyn MemoryToolProvider>>) {
+        self.memory_tool_provider = provider;
+    }
+
+    /// Borrow the currently-installed [`MemoryToolProvider`], if any.
+    #[must_use]
+    pub fn memory_tool_provider(&self) -> Option<&Arc<dyn MemoryToolProvider>> {
+        self.memory_tool_provider.as_ref()
     }
 
     /// Test/inspection helper that returns the resolved
@@ -475,6 +501,7 @@ impl SubagentManager {
         let cancel = self.parent_cancel.child_token();
         let instances = Arc::clone(&self.instances);
         let run_tool_provider = self.run_tool_provider.clone();
+        let memory_tool_provider = self.memory_tool_provider.clone();
         // Derive the per-subagent sandbox up-front so the spawn
         // closure does not need to know the precedence rules.
         // Built-in agents pick their mode from `AgentType::sandbox_mode`;
@@ -492,12 +519,17 @@ impl SubagentManager {
             // `RunToolProvider` installed, harnessed agents get
             // Run-aware tools (`progress_append`, `feature_list_*`)
             // registered as well; without one, those names are
-            // silently dropped.
-            let registry = match &run_tool_provider {
-                Some(provider) => {
-                    registry_for_agent_kind_with_run_provider(&agent_kind, &**provider)
-                }
-                None => registry_for_agent_kind(&agent_kind),
+            // silently dropped. With a `MemoryToolProvider`, the
+            // `memory` tool is registered unconditionally so subagents
+            // share access to the project memory store.
+            let registry = match (&run_tool_provider, &memory_tool_provider) {
+                (None, None) => registry_for_agent_kind(&agent_kind),
+                (Some(rp), None) => registry_for_agent_kind_with_run_provider(&agent_kind, &**rp),
+                (rp, mp) => registry_for_agent_kind_with_providers(
+                    &agent_kind,
+                    rp.as_deref(),
+                    mp.as_deref(),
+                ),
             };
             let mut runner =
                 SubagentRunner::new(client, registry, &agent_kind, cancel, subagent_sandbox);

--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -27,7 +27,10 @@ You are tsumugi, a helpful coding assistant running locally. \
 Answer concisely and accurately. You have access to tools for \
 reading, writing, and patching files, running shell commands, \
 listing directories, and searching with grep. Use them when \
-appropriate to answer the user's requests.";
+appropriate to answer the user's requests. Before starting on a \
+task, scan the [memory] index for topics related to the request \
+and call the `memory` tool's `read` action on any that look \
+relevant; record durable lessons via `add` / `update`.";
 
 /// Maximum number of consecutive tool-call rounds before the loop is
 /// forcibly terminated. This prevents infinite loops when the model
@@ -216,6 +219,14 @@ pub struct AgentLoop {
     /// gate (SPEC §9.10). The default is `None`, so non-harness
     /// callers (e.g. one-shot CLI mode) pay nothing.
     turn_observer: Option<TurnObserver>,
+
+    /// Optional memory index injected into the prompt (issue #52).
+    ///
+    /// Stored so that [`Self::clear_history`] can re-inject the same
+    /// payload without forcing the caller to thread it back in. Set
+    /// via [`Self::set_memory_index`]; `None` means the memory layer
+    /// is disabled or the index is empty.
+    memory_index: Option<String>,
 }
 
 impl AgentLoop {
@@ -281,9 +292,14 @@ impl AgentLoop {
 
         let mut history = vec![Message::system(system_prompt)];
 
-        // Load prompt files and inject as initial messages.
+        // Load prompt files (and the memory index, if available)
+        // and inject as initial messages.
         let prompt_messages = prompt::load_prompt_files(project_root, cwd)?;
         history.extend(prompt_messages);
+        // The memory index is wired in lazily via `set_memory_index`;
+        // the initial constructor cannot read it without forcing every
+        // call site to provide a `MemoryStore`. The CLI startup path
+        // calls `set_memory_index` immediately after construction.
 
         let registry = Arc::new(registry);
         let token_counter = TokenCounter::new(client.clone());
@@ -304,7 +320,42 @@ impl AgentLoop {
             tool_calling_mode,
             sandbox,
             turn_observer: None,
+            memory_index: None,
         })
+    }
+
+    /// Install (or replace) the memory index injected into the system
+    /// prompt on every [`Self::clear_history`].
+    ///
+    /// Pass `None` to disable the injection. The caller is responsible
+    /// for refreshing this whenever the index changes (e.g. after a
+    /// `memory` tool write). To make the new value visible to the LLM
+    /// without re-reading prompt files, follow up with
+    /// [`Self::clear_history`] (which re-injects from
+    /// [`prompt::load_prompt_files_with_memory`]).
+    pub fn set_memory_index(&mut self, index: Option<String>) {
+        self.memory_index = index;
+    }
+
+    /// Inject the carried memory index as a user-role message at the
+    /// end of the current history. Idempotent only when called once
+    /// per construction; subsequent calls would duplicate the message,
+    /// so callers should prefer [`Self::clear_history`] for refresh.
+    pub fn inject_memory_index_now(&mut self) {
+        let Some(index) = self.memory_index.as_deref() else {
+            return;
+        };
+        if index.trim().is_empty() {
+            return;
+        }
+        let payload = format!("{}\n\n{index}", prompt::MEMORY_PROMPT_HEADER);
+        self.history.push(Message::user(payload));
+    }
+
+    /// Borrow the active memory index (if any).
+    #[must_use]
+    pub fn memory_index(&self) -> Option<&str> {
+        self.memory_index.as_deref()
     }
 
     /// Replace the active [`SandboxContext`].
@@ -404,7 +455,8 @@ impl AgentLoop {
     pub fn clear_history(&mut self, project_root: &Path, cwd: &Path) -> Result<(), CoreError> {
         let system_prompt = Self::build_system_prompt(self.tool_calling_mode, &self.tool_defs);
         let mut history = vec![Message::system(system_prompt)];
-        let prompt_messages = prompt::load_prompt_files(project_root, cwd)?;
+        let prompt_messages =
+            prompt::load_prompt_files_with_memory(project_root, cwd, self.memory_index.as_deref())?;
         history.extend(prompt_messages);
         self.history = history;
         Ok(())

--- a/crates/tmg-core/src/agent_loop.rs
+++ b/crates/tmg-core/src/agent_loop.rs
@@ -227,6 +227,25 @@ pub struct AgentLoop {
     /// via [`Self::set_memory_index`]; `None` means the memory layer
     /// is disabled or the index is empty.
     memory_index: Option<String>,
+
+    /// Shared pending-swap slot consulted at the top of every
+    /// [`Self::turn`]. When the `memory` tool succeeds it pushes a
+    /// freshly-rendered index here; the next turn picks it up,
+    /// replaces [`Self::memory_index`], and pushes a refreshed
+    /// memory user message into history so the LLM sees the change.
+    /// Issue #4 of PR #76 review.
+    ///
+    /// `None` means no provider has been wired (e.g. one-shot mode
+    /// without a memory tool). Cloned via `Arc` so the producer side
+    /// (the tool callback) and the consumer (`Self::turn`) share the
+    /// same slot.
+    pending_memory_index: Option<Arc<std::sync::Mutex<Option<String>>>>,
+
+    /// Tracks whether [`Self::inject_memory_index_now`] has already
+    /// emitted a user-role message for the current `memory_index`.
+    /// Issue #16 of PR #76 review: previously a second call would
+    /// silently duplicate the memory block.
+    memory_index_injected: bool,
 }
 
 impl AgentLoop {
@@ -321,6 +340,8 @@ impl AgentLoop {
             sandbox,
             turn_observer: None,
             memory_index: None,
+            pending_memory_index: None,
+            memory_index_injected: false,
         })
     }
 
@@ -335,13 +356,72 @@ impl AgentLoop {
     /// [`prompt::load_prompt_files_with_memory`]).
     pub fn set_memory_index(&mut self, index: Option<String>) {
         self.memory_index = index;
+        // Clear the injection flag so the new value can be (re-)pushed
+        // into history at the next opportunity.
+        self.memory_index_injected = false;
+    }
+
+    /// Install (or replace) the shared pending-swap slot consulted at
+    /// the top of every [`Self::turn`]. Producers — typically the
+    /// `memory` tool's refresh callback — push freshly-rendered index
+    /// snapshots here; the agent loop picks them up before sending the
+    /// next request to the LLM, so the model always sees the
+    /// post-mutation state of the project memory. Issue #4 of PR #76
+    /// review.
+    ///
+    /// Pass `None` to detach the slot. The slot is consulted with
+    /// [`std::sync::Mutex::lock`]; poisoning is treated as no-op.
+    pub fn set_pending_memory_index(
+        &mut self,
+        slot: Option<Arc<std::sync::Mutex<Option<String>>>>,
+    ) {
+        self.pending_memory_index = slot;
+    }
+
+    /// Borrow the shared pending-swap slot, if any.
+    #[must_use]
+    pub fn pending_memory_index(&self) -> Option<&Arc<std::sync::Mutex<Option<String>>>> {
+        self.pending_memory_index.as_ref()
+    }
+
+    /// Drain the shared pending-swap slot (if any) and apply the new
+    /// index. When a swap happens we replace [`Self::memory_index`]
+    /// AND push a fresh user-role memory block into history so the
+    /// LLM observes the post-mutation state on its next request.
+    ///
+    /// Returns `Some(new_index_payload)` when a swap occurred,
+    /// `None` otherwise. The returned payload is the same one pushed
+    /// into history, suitable for stream-event emission.
+    fn apply_pending_memory_index(&mut self) -> Option<String> {
+        let slot = self.pending_memory_index.as_ref()?;
+        let mut guard = slot.lock().ok()?;
+        let new_index = guard.take()?;
+        drop(guard);
+
+        let trimmed = new_index.trim();
+        if trimmed.is_empty() {
+            self.memory_index = None;
+            self.memory_index_injected = false;
+            return None;
+        }
+
+        self.memory_index = Some(new_index.clone());
+        let payload = format!("{}\n\n{trimmed}", prompt::MEMORY_PROMPT_HEADER);
+        self.history.push(Message::user(payload.clone()));
+        // Mark as injected so a subsequent `inject_memory_index_now()`
+        // call is a no-op until the next swap.
+        self.memory_index_injected = true;
+        Some(payload)
     }
 
     /// Inject the carried memory index as a user-role message at the
-    /// end of the current history. Idempotent only when called once
-    /// per construction; subsequent calls would duplicate the message,
-    /// so callers should prefer [`Self::clear_history`] for refresh.
+    /// end of the current history. Idempotent: a second call without
+    /// an intervening [`Self::set_memory_index`] / pending-swap apply
+    /// is a no-op. Issue #16 of PR #76 review.
     pub fn inject_memory_index_now(&mut self) {
+        if self.memory_index_injected {
+            return;
+        }
         let Some(index) = self.memory_index.as_deref() else {
             return;
         };
@@ -350,6 +430,7 @@ impl AgentLoop {
         }
         let payload = format!("{}\n\n{index}", prompt::MEMORY_PROMPT_HEADER);
         self.history.push(Message::user(payload));
+        self.memory_index_injected = true;
     }
 
     /// Borrow the active memory index (if any).
@@ -459,6 +540,10 @@ impl AgentLoop {
             prompt::load_prompt_files_with_memory(project_root, cwd, self.memory_index.as_deref())?;
         history.extend(prompt_messages);
         self.history = history;
+        // The fresh history already contains the memory block (via
+        // `load_prompt_files_with_memory`), so mark injected so that a
+        // follow-up `inject_memory_index_now()` is a no-op (issue #16).
+        self.memory_index_injected = self.memory_index.is_some();
         Ok(())
     }
 
@@ -539,6 +624,22 @@ impl AgentLoop {
         user_input: &str,
         sink: &mut impl StreamSink,
     ) -> Result<(), CoreError> {
+        // Drain any pending memory-index swap before the user message.
+        // The `memory` tool's refresh callback may have pushed a fresh
+        // snapshot into the shared slot since the last turn ended; we
+        // pick it up here so the LLM sees the post-mutation index on
+        // its next request. Issue #4 of PR #76 review. The sink hears
+        // about the swap via `on_warning` so the TUI Activity Pane
+        // can render a "memory updated" hint.
+        if let Some(payload) = self.apply_pending_memory_index() {
+            // Best-effort: a sink that errors here would abort the
+            // turn before it begins. Surfacing the message as a
+            // warning is enough to drive the TUI hint without making
+            // memory churn fatal.
+            let preview: String = payload.chars().take(80).collect();
+            let _ = sink.on_warning(&format!("memory updated: {preview}"));
+        }
+
         // Add user message to history.
         self.history.push(Message::user(user_input));
 

--- a/crates/tmg-core/src/event_log.rs
+++ b/crates/tmg-core/src/event_log.rs
@@ -69,6 +69,10 @@ enum EventKind {
         estimate: usize,
         error: String,
     },
+    /// Records a `tmg memory <op>` invocation or a prompt-time memory
+    /// index injection. Issue #12 of PR #76 review.
+    #[serde(rename = "memory")]
+    Memory { op: String, summary: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -171,6 +175,21 @@ impl EventLogWriter {
         let event = EventKind::PoolSelected {
             endpoint: endpoint.to_owned(),
             strategy: strategy.to_owned(),
+        };
+        self.write_event(&event);
+    }
+
+    /// Log a memory CLI / prompt-injection event (issue #52, PR #76 review).
+    ///
+    /// `op` should be a short identifier such as `"memory_list"`,
+    /// `"memory_show"`, `"memory_edit"`, or `"memory_prompt_inject"`.
+    /// `summary` is a free-form one-line description (e.g. entry name,
+    /// scope, or character count) — kept short because event logs are
+    /// JSONL streams.
+    pub fn write_memory(&mut self, op: &str, summary: &str) {
+        let event = EventKind::Memory {
+            op: op.to_owned(),
+            summary: summary.to_owned(),
         };
         self.write_event(&event);
     }

--- a/crates/tmg-core/src/prompt.rs
+++ b/crates/tmg-core/src/prompt.rs
@@ -1,9 +1,15 @@
-//! System prompt assembly from TSUMUGI.md and AGENTS.md files.
+//! System prompt assembly from TSUMUGI.md, AGENTS.md, and the memory
+//! index (`MEMORY.md`).
 //!
 //! Loads prompt files from:
 //! - `~/.config/tsumugi/TSUMUGI.md` (global)
 //! - Each directory from project root down to the current working directory
 //! - Same paths for `AGENTS.md` (compatibility alias)
+//!
+//! The memory index ([`MEMORY_INDEX_FILE_NAMES`]) is loaded alongside
+//! the prompt files when [`load_prompt_files_with_memory`] is used:
+//! global memory first, then project memory, both wrapped in a header
+//! that explains their role and the `memory` tool surface.
 //!
 //! Missing files are silently skipped. I/O errors on existing files are
 //! propagated with context.
@@ -11,6 +17,20 @@
 use std::path::{Path, PathBuf};
 
 use crate::message::Message;
+
+/// Header prefixed to the memory index when injected into the prompt.
+///
+/// Public so call sites that want to render the index identically (e.g.
+/// the `/memory` slash command) can reuse the same framing.
+pub const MEMORY_PROMPT_HEADER: &str = "\
+[memory] Project & global persistent memory index. Each row is \
+`- [topic](file.md) — one-line hook`. Use the `memory` tool's `read` \
+action with `name = topic` to load a body before starting work; \
+use `add` / `update` / `remove` to curate.";
+
+/// Memory index file name. Matches [`tmg_memory::INDEX_FILE_NAME`] but
+/// is duplicated here so `tmg-core` does not depend on `tmg-memory`.
+const MEMORY_INDEX_FILE_NAME: &str = "MEMORY.md";
 
 /// File names to search for prompt content.
 const PROMPT_FILE_NAMES: &[&str] = &["TSUMUGI.md", "AGENTS.md"];
@@ -28,6 +48,29 @@ const PROMPT_FILE_NAMES: &[&str] = &["TSUMUGI.md", "AGENTS.md"];
 ///
 /// Returns an I/O error if a file exists but cannot be read.
 pub fn load_prompt_files(project_root: &Path, cwd: &Path) -> Result<Vec<Message>, std::io::Error> {
+    load_prompt_files_with_memory(project_root, cwd, None)
+}
+
+/// Like [`load_prompt_files`], but also injects the merged
+/// [`tmg_memory`] index ahead of any further user content when the
+/// caller passes one.
+///
+/// `memory_index` is the rendered output of
+/// [`tmg_memory::MemoryStore::read_merged_index`]. When `None` or
+/// blank, the memory block is skipped entirely.
+///
+/// Order: prompt files (global → project) → memory index. The index
+/// is added last so chat templates that scan from the top see the
+/// invariant project context first.
+///
+/// # Errors
+///
+/// Returns an I/O error if a prompt file exists but cannot be read.
+pub fn load_prompt_files_with_memory(
+    project_root: &Path,
+    cwd: &Path,
+    memory_index: Option<&str>,
+) -> Result<Vec<Message>, std::io::Error> {
     let mut messages = Vec::new();
 
     // 1. Global config directory
@@ -42,7 +85,35 @@ pub fn load_prompt_files(project_root: &Path, cwd: &Path) -> Result<Vec<Message>
         load_from_directory(dir, &mut messages)?;
     }
 
+    // 3. Memory index (project + optional global, already merged by
+    //    the caller). The header makes the role of the index clear to
+    //    the LLM so it knows to consult the `memory` tool.
+    if let Some(index) = memory_index
+        && !index.trim().is_empty()
+    {
+        let payload = format!("{MEMORY_PROMPT_HEADER}\n\n{index}");
+        messages.push(Message::user(payload));
+    }
+
     Ok(messages)
+}
+
+/// Convenience: read `MEMORY.md` from a memory directory if it exists.
+///
+/// Used by integration code that wants to thread the project-only
+/// index into the prompt without depending on `tmg-memory`. Returns
+/// `Ok(None)` when the file is missing.
+///
+/// # Errors
+///
+/// Surfaces I/O errors other than `NotFound`.
+pub fn read_memory_index(memory_dir: &Path) -> Result<Option<String>, std::io::Error> {
+    let path = memory_dir.join(MEMORY_INDEX_FILE_NAME);
+    match std::fs::read_to_string(&path) {
+        Ok(s) => Ok(Some(s)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
 }
 
 /// Attempt to load prompt files from a single directory.

--- a/crates/tmg-memory/Cargo.toml
+++ b/crates/tmg-memory/Cargo.toml
@@ -14,12 +14,18 @@ serde_yml = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
-tokio = { workspace = true, features = ["fs", "io-util"] }
+regex = { workspace = true }
+# `tracing` is wired into store / tool mutation paths so debugging
+# memory regressions is possible without `--event-log`. Issue #10 of
+# PR #76 review suggested either dropping `tracing` (it had been
+# unused) or wiring it; we wire it.
 tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "io-util"] }
+# Tests use `#[tokio::test]` for the async tool surface; keep tokio in
+# `dev-dependencies` only since the production code is synchronous.
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [lints]
 workspace = true

--- a/crates/tmg-memory/Cargo.toml
+++ b/crates/tmg-memory/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tmg-memory"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tmg-sandbox = { workspace = true }
+tmg-tools = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yml = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+dirs = { workspace = true }
+tokio = { workspace = true, features = ["fs", "io-util"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "io-util"] }
+
+[lints]
+workspace = true

--- a/crates/tmg-memory/src/budget.rs
+++ b/crates/tmg-memory/src/budget.rs
@@ -55,10 +55,17 @@ pub struct BudgetReport {
 
 impl BudgetReport {
     /// Compute a [`BudgetReport`] for the given measurements.
+    ///
+    /// "Near capacity" fires at 80% of either limit (rounded down):
+    /// the agent is nudged to curate before any limit is met, so the
+    /// store has room to accept the next legitimate entry. Issue #9
+    /// of PR #76 raised that the previous `>= limit` threshold fired
+    /// only after the store was already full.
     #[must_use]
     pub fn from_measurements(index_lines: usize, file_count: usize, budget: &MemoryBudget) -> Self {
-        let near_capacity =
-            index_lines >= budget.index_max_lines || file_count >= budget.total_files_limit;
+        let lines_threshold = (budget.index_max_lines * 4) / 5;
+        let files_threshold = (budget.total_files_limit * 4) / 5;
+        let near_capacity = index_lines >= lines_threshold || file_count >= files_threshold;
         Self {
             index_lines,
             file_count,
@@ -105,6 +112,7 @@ mod tests {
     #[test]
     fn report_near_capacity_lines() {
         let b = MemoryBudget::default();
+        // 200 lines: well past the 80% threshold of 160 lines.
         let r = BudgetReport::from_measurements(200, 10, &b);
         assert!(r.near_capacity());
     }
@@ -112,13 +120,33 @@ mod tests {
     #[test]
     fn report_near_capacity_files() {
         let b = MemoryBudget::default();
+        // 50 files: at the limit, well past the 80% threshold of 40.
         let r = BudgetReport::from_measurements(10, 50, &b);
         assert!(r.near_capacity());
+    }
+
+    /// Issue #9 regression: nudge fires at 80% of limit, not just at
+    /// 100%, so the agent has time to curate before being blocked.
+    #[test]
+    fn nudge_fires_at_80_percent_lines() {
+        let b = MemoryBudget::default();
+        // 80% of 200 = 160 — exactly at the threshold.
+        let r = BudgetReport::from_measurements(160, 5, &b);
+        assert!(r.near_capacity(), "nudge must fire at 80% of index lines");
+    }
+
+    #[test]
+    fn nudge_fires_at_80_percent_files() {
+        let b = MemoryBudget::default();
+        // 80% of 50 = 40 — exactly at the threshold.
+        let r = BudgetReport::from_measurements(10, 40, &b);
+        assert!(r.near_capacity(), "nudge must fire at 80% of file count");
     }
 
     #[test]
     fn report_under_budget() {
         let b = MemoryBudget::default();
+        // Well under 80% on both axes.
         let r = BudgetReport::from_measurements(10, 5, &b);
         assert!(!r.near_capacity());
         assert!(capacity_nudge(&r, &b).is_none());

--- a/crates/tmg-memory/src/budget.rs
+++ b/crates/tmg-memory/src/budget.rs
@@ -1,0 +1,134 @@
+//! Capacity limits for the memory store.
+//!
+//! The store is intentionally small: the index is part of every system
+//! prompt and individual entries are read into context on demand. The
+//! limits here express what "near capacity" means; exceeding them
+//! emits a warning rather than a hard error so the agent can still
+//! curate its way back under the threshold.
+
+use serde::{Deserialize, Serialize};
+
+/// Capacity caps for the memory store.
+///
+/// Values here mirror the issue spec defaults:
+/// - `index_max_lines = 200`
+/// - `entry_max_chars = 600`
+/// - `total_files_limit = 50`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryBudget {
+    /// Maximum number of lines in the `MEMORY.md` index.
+    pub index_max_lines: usize,
+    /// Maximum body character count for any one entry.
+    pub entry_max_chars: usize,
+    /// Maximum number of memory files (excluding `MEMORY.md`).
+    pub total_files_limit: usize,
+}
+
+impl MemoryBudget {
+    /// Default budget matching the issue spec.
+    #[must_use]
+    pub const fn default_const() -> Self {
+        Self {
+            index_max_lines: 200,
+            entry_max_chars: 600,
+            total_files_limit: 50,
+        }
+    }
+}
+
+impl Default for MemoryBudget {
+    fn default() -> Self {
+        Self::default_const()
+    }
+}
+
+/// Snapshot of the store's current size relative to the budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BudgetReport {
+    /// Current line count of `MEMORY.md`.
+    pub index_lines: usize,
+    /// Current number of entry files.
+    pub file_count: usize,
+    /// `true` when at least one limit is met or exceeded.
+    pub near_capacity: bool,
+}
+
+impl BudgetReport {
+    /// Compute a [`BudgetReport`] for the given measurements.
+    #[must_use]
+    pub fn from_measurements(index_lines: usize, file_count: usize, budget: &MemoryBudget) -> Self {
+        let near_capacity =
+            index_lines >= budget.index_max_lines || file_count >= budget.total_files_limit;
+        Self {
+            index_lines,
+            file_count,
+            near_capacity,
+        }
+    }
+
+    /// Return `true` when the agent should be nudged to curate.
+    #[must_use]
+    pub const fn near_capacity(&self) -> bool {
+        self.near_capacity
+    }
+}
+
+/// Build the system-prompt snippet that nudges the agent to curate
+/// when [`BudgetReport::near_capacity`] is `true`. Returns `None` when
+/// the store is comfortably under budget.
+#[must_use]
+pub fn capacity_nudge(report: &BudgetReport, budget: &MemoryBudget) -> Option<String> {
+    if !report.near_capacity {
+        return None;
+    }
+    Some(format!(
+        "\n\n[memory] near capacity (index {} / {} lines, {} / {} files). \
+         Consider integrating overlapping entries or removing stale ones \
+         via the `memory` tool's `update` / `remove` actions.",
+        report.index_lines, budget.index_max_lines, report.file_count, budget.total_files_limit,
+    ))
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_defaults_match_spec() {
+        let b = MemoryBudget::default();
+        assert_eq!(b.index_max_lines, 200);
+        assert_eq!(b.entry_max_chars, 600);
+        assert_eq!(b.total_files_limit, 50);
+    }
+
+    #[test]
+    fn report_near_capacity_lines() {
+        let b = MemoryBudget::default();
+        let r = BudgetReport::from_measurements(200, 10, &b);
+        assert!(r.near_capacity());
+    }
+
+    #[test]
+    fn report_near_capacity_files() {
+        let b = MemoryBudget::default();
+        let r = BudgetReport::from_measurements(10, 50, &b);
+        assert!(r.near_capacity());
+    }
+
+    #[test]
+    fn report_under_budget() {
+        let b = MemoryBudget::default();
+        let r = BudgetReport::from_measurements(10, 5, &b);
+        assert!(!r.near_capacity());
+        assert!(capacity_nudge(&r, &b).is_none());
+    }
+
+    #[test]
+    fn nudge_emitted_when_full() {
+        let b = MemoryBudget::default();
+        let r = BudgetReport::from_measurements(200, 50, &b);
+        let msg = capacity_nudge(&r, &b).expect("nudge present");
+        assert!(msg.contains("near capacity"));
+    }
+}

--- a/crates/tmg-memory/src/entry.rs
+++ b/crates/tmg-memory/src/entry.rs
@@ -1,0 +1,278 @@
+//! Memory entry types: [`MemoryEntry`], [`MemoryType`], [`Frontmatter`].
+
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::MemoryError;
+
+/// The frontmatter delimiter used in memory entry files.
+pub(crate) const FRONTMATTER_DELIMITER: &str = "---";
+
+/// Vocabulary for the `type` frontmatter field.
+///
+/// The four variants are taken from the Hermes / Claude Code curation
+/// philosophy and tagged at the entry level so future retrieval logic
+/// can filter by category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryType {
+    /// Owner / collaborator preferences and roles.
+    User,
+    /// Feedback received from the human (with `why` and `when`).
+    Feedback,
+    /// Project structure, in-flight tasks, organisational knowledge.
+    Project,
+    /// Pointers to external resources (Linear, Grafana, Notion, etc.).
+    Reference,
+}
+
+impl MemoryType {
+    /// Return the canonical lowercase string representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Feedback => "feedback",
+            Self::Project => "project",
+            Self::Reference => "reference",
+        }
+    }
+}
+
+impl std::fmt::Display for MemoryType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for MemoryType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "user" => Ok(Self::User),
+            "feedback" => Ok(Self::Feedback),
+            "project" => Ok(Self::Project),
+            "reference" => Ok(Self::Reference),
+            other => Err(other.to_owned()),
+        }
+    }
+}
+
+/// YAML frontmatter on a memory entry file.
+///
+/// `name`, `description`, and `type` are required. Timestamps are
+/// optional in the on-disk format but are populated on every write so
+/// that a file written by tsumugi always carries them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Frontmatter {
+    /// Topic name (matches the file stem `<name>.md`).
+    pub name: String,
+    /// One-line description that surfaces in the `MEMORY.md` index.
+    pub description: String,
+    /// Categorical type tag.
+    #[serde(rename = "type")]
+    pub kind: MemoryType,
+    /// Creation timestamp (RFC 3339).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
+    /// Last update timestamp (RFC 3339).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// A loaded memory entry: frontmatter plus body text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryEntry {
+    /// Parsed frontmatter.
+    pub frontmatter: Frontmatter,
+    /// The free-form body text following the closing `---` delimiter.
+    pub body: String,
+}
+
+impl MemoryEntry {
+    /// Render the entry to its on-disk markdown form.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Yaml`] if the frontmatter cannot be
+    /// serialised (effectively impossible for the typed schema, but
+    /// surfaced so callers do not need to `unwrap`).
+    pub fn to_markdown(&self) -> Result<String, MemoryError> {
+        let yaml = serde_yml::to_string(&self.frontmatter).map_err(|e| MemoryError::Yaml {
+            path: format!("<{}>", self.frontmatter.name),
+            source: e,
+        })?;
+        // serde_yml emits a trailing newline; ensure a single newline
+        // between the YAML block and the closing delimiter so the
+        // round-trip is deterministic.
+        let yaml_block = yaml.trim_end_matches('\n');
+        let body = self.body.trim_start_matches(['\n', '\r']);
+        Ok(format!(
+            "{FRONTMATTER_DELIMITER}\n{yaml_block}\n{FRONTMATTER_DELIMITER}\n\n{body}"
+        ))
+    }
+}
+
+/// Parse a memory entry markdown string into [`MemoryEntry`].
+///
+/// `path_hint` is used purely for error messages.
+///
+/// # Errors
+///
+/// Returns [`MemoryError::InvalidFrontmatter`] for missing / malformed
+/// delimiters, [`MemoryError::Yaml`] for bad YAML, and
+/// [`MemoryError::InvalidType`] when `type` is outside the vocabulary
+/// (caught via deserialisation).
+pub fn parse_entry(content: &str, path_hint: &str) -> Result<MemoryEntry, MemoryError> {
+    let trimmed = content.trim_start();
+    let Some(rest) = trimmed.strip_prefix(FRONTMATTER_DELIMITER) else {
+        return Err(MemoryError::invalid_frontmatter(
+            path_hint,
+            "file does not start with '---'",
+        ));
+    };
+
+    let Some(end_idx) = find_closing_delimiter(rest) else {
+        return Err(MemoryError::invalid_frontmatter(
+            path_hint,
+            "closing '---' delimiter not found",
+        ));
+    };
+
+    let yaml_content = &rest[..end_idx];
+    let body_start = end_idx + FRONTMATTER_DELIMITER.len();
+    let body = rest
+        .get(body_start..)
+        .unwrap_or("")
+        .trim_start_matches(['\n', '\r'])
+        .to_owned();
+
+    let frontmatter: Frontmatter =
+        serde_yml::from_str(yaml_content).map_err(|e| MemoryError::Yaml {
+            path: path_hint.to_owned(),
+            source: e,
+        })?;
+
+    if frontmatter.name.is_empty() {
+        return Err(MemoryError::invalid_frontmatter(
+            path_hint,
+            "frontmatter `name` is empty",
+        ));
+    }
+    if frontmatter.description.is_empty() {
+        return Err(MemoryError::invalid_frontmatter(
+            path_hint,
+            "frontmatter `description` is empty",
+        ));
+    }
+
+    Ok(MemoryEntry { frontmatter, body })
+}
+
+/// Find the byte offset of the closing `---` delimiter within the text
+/// after the opening delimiter has been stripped.
+///
+/// The closing delimiter must appear at the start of a line. Mirrors
+/// the helper used in `tmg-skills::parse`.
+fn find_closing_delimiter(text: &str) -> Option<usize> {
+    let mut offset = 0;
+    for (idx, line) in text.split('\n').enumerate() {
+        if idx == 0 {
+            offset += line.len() + 1;
+            continue;
+        }
+        if line.trim() == FRONTMATTER_DELIMITER {
+            return Some(offset);
+        }
+        offset += line.len() + 1;
+    }
+    None
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_type_roundtrip() {
+        for variant in [
+            MemoryType::User,
+            MemoryType::Feedback,
+            MemoryType::Project,
+            MemoryType::Reference,
+        ] {
+            let s = variant.as_str();
+            let back: MemoryType = s.parse().expect("parses");
+            assert_eq!(back, variant);
+        }
+    }
+
+    #[test]
+    fn parse_valid_entry() {
+        let content = "\
+---
+name: project_layout
+description: Layout description
+type: project
+---
+
+Body text here.
+";
+        let entry = parse_entry(content, "test").expect("parses");
+        assert_eq!(entry.frontmatter.name, "project_layout");
+        assert_eq!(entry.frontmatter.kind, MemoryType::Project);
+        assert!(entry.body.starts_with("Body text"));
+    }
+
+    #[test]
+    fn rejects_missing_opening_delimiter() {
+        let content = "name: foo\n---\nbody\n";
+        let err = parse_entry(content, "test").expect_err("must reject");
+        assert!(matches!(err, MemoryError::InvalidFrontmatter { .. }));
+    }
+
+    #[test]
+    fn rejects_missing_closing_delimiter() {
+        let content = "---\nname: foo\ndescription: bar\ntype: user\n";
+        let err = parse_entry(content, "test").expect_err("must reject");
+        assert!(matches!(err, MemoryError::InvalidFrontmatter { .. }));
+    }
+
+    #[test]
+    fn rejects_invalid_type_value() {
+        let content = "---\nname: foo\ndescription: bar\ntype: invalid_kind\n---\nbody\n";
+        let err = parse_entry(content, "test").expect_err("must reject");
+        // Bad enum value comes back as a YAML error.
+        assert!(matches!(err, MemoryError::Yaml { .. }));
+    }
+
+    #[test]
+    fn rejects_empty_required_field() {
+        let content = "---\nname: \"\"\ndescription: bar\ntype: user\n---\nbody\n";
+        let err = parse_entry(content, "test").expect_err("must reject");
+        assert!(matches!(err, MemoryError::InvalidFrontmatter { .. }));
+    }
+
+    #[test]
+    fn render_then_parse_roundtrips() {
+        let entry = MemoryEntry {
+            frontmatter: Frontmatter {
+                name: "x".to_owned(),
+                description: "y".to_owned(),
+                kind: MemoryType::Feedback,
+                created_at: None,
+                updated_at: None,
+            },
+            body: "hello\n".to_owned(),
+        };
+        let text = entry.to_markdown().expect("renders");
+        let back = parse_entry(&text, "test").expect("parses");
+        assert_eq!(back.frontmatter.name, "x");
+        assert_eq!(back.frontmatter.kind, MemoryType::Feedback);
+        assert!(back.body.starts_with("hello"));
+    }
+}

--- a/crates/tmg-memory/src/entry.rs
+++ b/crates/tmg-memory/src/entry.rs
@@ -156,16 +156,16 @@ pub fn parse_entry(content: &str, path_hint: &str) -> Result<MemoryEntry, Memory
             source: e,
         })?;
 
-    if frontmatter.name.is_empty() {
+    if frontmatter.name.trim().is_empty() {
         return Err(MemoryError::invalid_frontmatter(
             path_hint,
-            "frontmatter `name` is empty",
+            "frontmatter `name` is empty or whitespace-only",
         ));
     }
-    if frontmatter.description.is_empty() {
+    if frontmatter.description.trim().is_empty() {
         return Err(MemoryError::invalid_frontmatter(
             path_hint,
-            "frontmatter `description` is empty",
+            "frontmatter `description` is empty or whitespace-only",
         ));
     }
 
@@ -253,6 +253,23 @@ Body text here.
     #[test]
     fn rejects_empty_required_field() {
         let content = "---\nname: \"\"\ndescription: bar\ntype: user\n---\nbody\n";
+        let err = parse_entry(content, "test").expect_err("must reject");
+        assert!(matches!(err, MemoryError::InvalidFrontmatter { .. }));
+    }
+
+    /// Regression test for issue #15: a whitespace-only name passes
+    /// YAML deserialisation but cannot be looked up later. Reject at
+    /// parse time so the entry never enters the store.
+    #[test]
+    fn rejects_whitespace_only_name() {
+        let content = "---\nname: \"   \"\ndescription: bar\ntype: user\n---\nbody\n";
+        let err = parse_entry(content, "test").expect_err("must reject");
+        assert!(matches!(err, MemoryError::InvalidFrontmatter { .. }));
+    }
+
+    #[test]
+    fn rejects_whitespace_only_description() {
+        let content = "---\nname: foo\ndescription: \"   \"\ntype: user\n---\nbody\n";
         let err = parse_entry(content, "test").expect_err("must reject");
         assert!(matches!(err, MemoryError::InvalidFrontmatter { .. }));
     }

--- a/crates/tmg-memory/src/error.rs
+++ b/crates/tmg-memory/src/error.rs
@@ -12,6 +12,13 @@ pub enum MemoryError {
         reason: String,
     },
 
+    /// Memory entry description failed validation (empty, contains newline, etc.).
+    #[error("invalid memory description: {reason}")]
+    InvalidDescription {
+        /// Why it was rejected.
+        reason: String,
+    },
+
     /// A memory entry with the requested name already exists.
     #[error("memory entry already exists: {name}")]
     AlreadyExists {
@@ -80,6 +87,13 @@ impl MemoryError {
     pub fn invalid_name(name: impl Into<String>, reason: impl Into<String>) -> Self {
         Self::InvalidName {
             name: name.into(),
+            reason: reason.into(),
+        }
+    }
+
+    /// Convenience: construct an [`Self::InvalidDescription`].
+    pub fn invalid_description(reason: impl Into<String>) -> Self {
+        Self::InvalidDescription {
             reason: reason.into(),
         }
     }

--- a/crates/tmg-memory/src/error.rs
+++ b/crates/tmg-memory/src/error.rs
@@ -1,0 +1,94 @@
+//! Error types for the memory crate.
+
+/// Errors that can occur when working with the memory store.
+#[derive(Debug, thiserror::Error)]
+pub enum MemoryError {
+    /// Memory entry name failed validation (empty, contains slashes, etc.).
+    #[error("invalid memory name {name:?}: {reason}")]
+    InvalidName {
+        /// The offending name.
+        name: String,
+        /// Why it was rejected.
+        reason: String,
+    },
+
+    /// A memory entry with the requested name already exists.
+    #[error("memory entry already exists: {name}")]
+    AlreadyExists {
+        /// The name of the conflicting entry.
+        name: String,
+    },
+
+    /// No memory entry with the requested name was found.
+    #[error("memory entry not found: {name}")]
+    NotFound {
+        /// The name that was looked up.
+        name: String,
+    },
+
+    /// The frontmatter on a memory file was missing or malformed.
+    #[error("invalid frontmatter at {path}: {reason}")]
+    InvalidFrontmatter {
+        /// File path that failed to parse.
+        path: String,
+        /// What was wrong.
+        reason: String,
+    },
+
+    /// The `type` value on a memory entry was outside the allowed vocabulary.
+    #[error(
+        "invalid memory type {value:?} at {path}: must be one of user, feedback, project, reference"
+    )]
+    InvalidType {
+        /// File path with the bad type.
+        path: String,
+        /// The offending value.
+        value: String,
+    },
+
+    /// An I/O error occurred during memory store operations.
+    #[error("{context}: {source}")]
+    Io {
+        /// What was being attempted.
+        context: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A YAML serialization or deserialization error.
+    #[error("yaml error at {path}: {source}")]
+    Yaml {
+        /// File path involved.
+        path: String,
+        /// Underlying YAML error.
+        #[source]
+        source: serde_yml::Error,
+    },
+}
+
+impl MemoryError {
+    /// Convenience: construct an [`Self::Io`] with context.
+    pub fn io(context: impl Into<String>, source: std::io::Error) -> Self {
+        Self::Io {
+            context: context.into(),
+            source,
+        }
+    }
+
+    /// Convenience: construct an [`Self::InvalidName`].
+    pub fn invalid_name(name: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::InvalidName {
+            name: name.into(),
+            reason: reason.into(),
+        }
+    }
+
+    /// Convenience: construct an [`Self::InvalidFrontmatter`].
+    pub fn invalid_frontmatter(path: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::InvalidFrontmatter {
+            path: path.into(),
+            reason: reason.into(),
+        }
+    }
+}

--- a/crates/tmg-memory/src/lib.rs
+++ b/crates/tmg-memory/src/lib.rs
@@ -1,0 +1,44 @@
+//! tmg-memory: project-scoped persistent memory for the tsumugi agent.
+//!
+//! The memory layer is a flat directory of markdown files plus a single
+//! `MEMORY.md` index. Both layers (project and global) use the same
+//! schema; the index is loaded into every system prompt and individual
+//! entry bodies are read on demand via the `memory` tool.
+//!
+//! # Layout
+//!
+//! ```text
+//! <project_root>/.tsumugi/memory/
+//!   MEMORY.md                       # 1 row per entry, capped at 200 lines
+//!   project_layout.md               # YAML frontmatter + body
+//!   feedback_review_style.md
+//!   ...
+//!
+//! ~/.config/tsumugi/memory/         # optional low-priority layer
+//!   MEMORY.md
+//!   ...
+//! ```
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use tmg_memory::{MemoryStore, MemoryTool, MemoryType};
+//!
+//! let store = Arc::new(MemoryStore::open("."));
+//! // Register the tool with the standard registry:
+//! let mut registry = tmg_tools::default_registry();
+//! registry.register(MemoryTool::new(Arc::clone(&store)));
+//! ```
+
+pub mod budget;
+pub mod entry;
+pub mod error;
+pub mod store;
+pub mod tool;
+
+pub use budget::{BudgetReport, MemoryBudget, capacity_nudge};
+pub use entry::{Frontmatter, MemoryEntry, MemoryType, parse_entry};
+pub use error::MemoryError;
+pub use store::{INDEX_FILE_NAME, MemoryScope, MemoryStore};
+pub use tool::{MEMORY_TOOL_NAME, MemoryTool};

--- a/crates/tmg-memory/src/store.rs
+++ b/crates/tmg-memory/src/store.rs
@@ -6,8 +6,11 @@
 //! on name collision); writes always target the project layer.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use chrono::Utc;
+use regex::Regex;
+use tracing::debug;
 
 use crate::budget::{BudgetReport, MemoryBudget};
 use crate::entry::{Frontmatter, MemoryEntry, MemoryType, parse_entry};
@@ -41,11 +44,29 @@ impl MemoryScope {
 /// Construction is cheap (no I/O); the directory is created on first
 /// write. The store is `Send + Sync` and intended to be wrapped in
 /// `Arc` for shared access from the agent loop and CLI tools.
+///
+/// Concurrent writes within the same process are serialised via an
+/// internal [`AsyncMutex`] held only for the duration of each
+/// mutation (so the index file cannot be corrupted by interleaved
+/// read-modify-write sequences when the agent loop dispatches multiple
+/// `memory` tool calls in parallel via `JoinSet`). Cross-process
+/// safety is **not** provided: multiple `tmg` processes editing the
+/// same store concurrently can still race; this is acceptable because
+/// the memory store is project-scoped and there is no production use
+/// case for multiple `tmg` agents writing the same `.tsumugi/memory/`
+/// at once.
 #[derive(Debug, Clone)]
 pub struct MemoryStore {
     project_dir: PathBuf,
     global_dir: Option<PathBuf>,
     budget: MemoryBudget,
+    /// In-process mutation lock. Cloned via `Arc` so every clone of the
+    /// store sees the same lock state (the `Clone` derive on `Arc` is a
+    /// pointer bump, not a deep copy). Held only for the brief duration
+    /// of each synchronous read-modify-write of `MEMORY.md`; tools
+    /// dispatched via `JoinSet` therefore see consistent index state
+    /// even when their `memory add` calls overlap.
+    write_lock: Arc<Mutex<()>>,
 }
 
 impl MemoryStore {
@@ -54,31 +75,50 @@ impl MemoryStore {
     /// The project directory is `<project_root>/.tsumugi/memory/`.
     /// The global directory defaults to `~/.config/tsumugi/memory/`
     /// (via the [`dirs`] crate) when available.
+    ///
+    /// The returned store has run [`Self::reconcile`] best-effort: any
+    /// drift between the on-disk markdown files and the index rows is
+    /// repaired so `MEMORY.md` always reflects reality. Reconciliation
+    /// failure is logged via `tracing::debug!` and otherwise ignored
+    /// (the store still functions, just without the self-heal).
     #[must_use]
     pub fn open(project_root: impl AsRef<Path>) -> Self {
         let project_dir = project_root.as_ref().join(".tsumugi").join("memory");
         let global_dir = dirs::config_dir().map(|d| d.join("tsumugi").join("memory"));
-        Self {
+        let store = Self {
             project_dir,
             global_dir,
             budget: MemoryBudget::default(),
+            write_lock: Arc::new(Mutex::new(())),
+        };
+        if let Err(e) = store.reconcile() {
+            debug!(error = %e, "memory store reconcile on open failed (ignoring)");
         }
+        store
     }
 
     /// Construct a store with explicit project / global directories
     /// and a custom budget. Used by the CLI when honouring the
     /// `[memory]` section of `tsumugi.toml`.
+    ///
+    /// Like [`Self::open`], runs [`Self::reconcile`] best-effort so
+    /// callers do not need to remember to invoke it themselves.
     #[must_use]
     pub fn with_dirs(
         project_dir: impl Into<PathBuf>,
         global_dir: Option<PathBuf>,
         budget: MemoryBudget,
     ) -> Self {
-        Self {
+        let store = Self {
             project_dir: project_dir.into(),
             global_dir,
             budget,
+            write_lock: Arc::new(Mutex::new(())),
+        };
+        if let Err(e) = store.reconcile() {
+            debug!(error = %e, "memory store reconcile on open failed (ignoring)");
         }
+        store
     }
 
     /// Override the budget after construction.
@@ -153,14 +193,16 @@ impl MemoryStore {
         if let Some(g) = global.as_deref() {
             // Drop global lines whose `(file.md)` token collides with a
             // project entry. Lines that do not match the index format
-            // are passed through.
+            // are passed through unchanged (e.g. user-added headers
+            // like `# My Memory` should not be relabelled `[global] # My Memory`).
             for line in g.lines() {
                 if let Some(file) = extract_link_target(line)
                     && project_names.iter().any(|p| p == &file)
                 {
                     continue;
                 }
-                if !line.trim().is_empty() {
+                let is_link_row = extract_link_target(line).is_some();
+                if is_link_row && !line.trim().is_empty() {
                     out.push_str("[global] ");
                 }
                 out.push_str(line);
@@ -257,6 +299,18 @@ impl MemoryStore {
         validate_name(name)?;
         validate_description(description)?;
 
+        // Hold the in-process write lock for the duration of the
+        // read-modify-write so concurrent `memory add` calls
+        // (dispatched through the agent loop's JoinSet) cannot drop
+        // index rows. `lock()` returns a poisoned guard if a previous
+        // holder panicked; we ignore the poison and proceed because the
+        // protected data lives entirely on disk and is reconciled from
+        // there.
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         let path = self.entry_path_in_project(name);
         if path.exists() {
             return Err(MemoryError::AlreadyExists {
@@ -282,7 +336,13 @@ impl MemoryStore {
             .map_err(|e| MemoryError::io(format!("writing {}", path.display()), e))?;
 
         let new_line = format_index_line(name, description);
-        append_index_line(&self.project_index_path(), &new_line)?;
+        // Use `replace_index_line` rather than `append_index_line` so a
+        // stale row left behind by a manual file deletion + re-add is
+        // updated in place rather than duplicated. `replace_index_line`
+        // appends when no existing row matches, so the first-add path
+        // still works.
+        replace_index_line(&self.project_index_path(), name, Some(&new_line))?;
+        debug!(name = %name, "memory add: wrote entry and updated index");
 
         self.budget_report()
     }
@@ -308,6 +368,11 @@ impl MemoryStore {
         if let Some(d) = description {
             validate_description(d)?;
         }
+
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let path = self.entry_path_in_project(name);
         if !path.exists() {
@@ -342,6 +407,7 @@ impl MemoryStore {
         // Refresh index row (description may have changed).
         let new_line = format_index_line(name, &entry.frontmatter.description);
         replace_index_line(&self.project_index_path(), name, Some(&new_line))?;
+        debug!(name = %name, "memory update: rewrote entry and refreshed index");
 
         self.budget_report()
     }
@@ -353,6 +419,12 @@ impl MemoryStore {
     /// - [`MemoryError::NotFound`] when the entry is absent.
     pub fn remove(&self, name: &str) -> Result<BudgetReport, MemoryError> {
         validate_name(name)?;
+
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         let path = self.entry_path_in_project(name);
         if !path.exists() {
             return Err(MemoryError::NotFound {
@@ -362,6 +434,7 @@ impl MemoryStore {
         std::fs::remove_file(&path)
             .map_err(|e| MemoryError::io(format!("removing {}", path.display()), e))?;
         replace_index_line(&self.project_index_path(), name, None)?;
+        debug!(name = %name, "memory remove: deleted entry and dropped index row");
         self.budget_report()
     }
 
@@ -403,6 +476,143 @@ impl MemoryStore {
 
     fn entry_path_in_project(&self, name: &str) -> PathBuf {
         self.project_dir.join(entry_file_name(name))
+    }
+
+    /// Best-effort self-heal between the on-disk markdown files and
+    /// the `MEMORY.md` index. Called automatically by [`Self::open`]
+    /// and [`Self::with_dirs`] so callers do not need to invoke it
+    /// themselves; exposed as `pub` so tests and recovery tooling can
+    /// trigger it on demand.
+    ///
+    /// Concretely:
+    ///
+    /// - Index rows that point at a missing `<name>.md` are dropped.
+    /// - Entry files without a matching index row get an appended row
+    ///   constructed from their frontmatter `description`.
+    ///
+    /// The reconciliation does **not** mutate entry-file contents — it
+    /// only edits the index. Files with malformed frontmatter are
+    /// silently skipped (logged at `tracing::debug!`); a future repair
+    /// command can be added if more aggressive recovery is needed.
+    ///
+    /// Holds the in-process write lock so concurrent CRUD calls cannot
+    /// observe a partial reconciliation state.
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from reading the project directory or
+    /// writing `MEMORY.md`. Errors that would require interactive
+    /// recovery (malformed frontmatter on a single file) are skipped
+    /// silently; the caller can run `tmg memory show <name>` to
+    /// surface them.
+    pub fn reconcile(&self) -> Result<(), MemoryError> {
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Project dir absent? Nothing to reconcile.
+        if !self.project_dir.exists() {
+            return Ok(());
+        }
+
+        // 1. Enumerate on-disk entry files and read their descriptions.
+        let mut on_disk: Vec<(String, String)> = Vec::new();
+        let read_dir = match std::fs::read_dir(&self.project_dir) {
+            Ok(d) => d,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => {
+                return Err(MemoryError::io(
+                    format!("reading {}", self.project_dir.display()),
+                    e,
+                ));
+            }
+        };
+        for ent in read_dir {
+            let Ok(ent) = ent else { continue };
+            let name_os = ent.file_name();
+            let Some(name_str) = name_os.to_str() else {
+                continue;
+            };
+            if name_str == INDEX_FILE_NAME {
+                continue;
+            }
+            let Some(stem) = name_str.strip_suffix(".md") else {
+                continue;
+            };
+            let path = ent.path();
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                debug!(path = %path.display(), "reconcile: failed to read entry file");
+                continue;
+            };
+            match parse_entry(&text, &path.display().to_string()) {
+                Ok(entry) => {
+                    on_disk.push((stem.to_owned(), entry.frontmatter.description));
+                }
+                Err(e) => {
+                    debug!(path = %path.display(), error = %e, "reconcile: skipping malformed entry");
+                }
+            }
+        }
+
+        // 2. Read the existing index (may not exist).
+        let index_path = self.project_index_path();
+        let existing = match std::fs::read_to_string(&index_path) {
+            Ok(t) => t,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => {
+                return Err(MemoryError::io(
+                    format!("reading {}", index_path.display()),
+                    e,
+                ));
+            }
+        };
+
+        let on_disk_names: Vec<String> = on_disk.iter().map(|(n, _)| n.clone()).collect();
+
+        // 3. Rebuild the index: keep non-link rows verbatim, drop link
+        //    rows whose target is missing, and append rows for files
+        //    that lack one.
+        let mut out = String::with_capacity(existing.len());
+        let mut covered: Vec<String> = Vec::new();
+        for line in existing.lines() {
+            if let Some(file) = extract_link_target(line) {
+                let stem_owned = file
+                    .strip_suffix(".md")
+                    .map_or_else(|| file.clone(), str::to_owned);
+                if on_disk_names.iter().any(|n| n == &stem_owned) {
+                    out.push_str(line);
+                    out.push('\n');
+                    covered.push(stem_owned);
+                }
+                // Else: drop the orphan row.
+            } else {
+                // Pass-through (header, blank line, comment, etc.).
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        for (name, desc) in &on_disk {
+            if !covered.iter().any(|c| c == name) {
+                if !out.is_empty() && !out.ends_with('\n') {
+                    out.push('\n');
+                }
+                out.push_str(&format_index_line(name, desc));
+                out.push('\n');
+            }
+        }
+
+        // 4. Only write if something changed and we have entries (or
+        //    a previously-existing index file). Avoid creating an empty
+        //    `MEMORY.md` on a fresh, empty project directory.
+        if out != existing && (!out.is_empty() || index_path.exists()) {
+            ensure_dir(&self.project_dir)?;
+            std::fs::write(&index_path, &out)
+                .map_err(|e| MemoryError::io(format!("writing {}", index_path.display()), e))?;
+            debug!(path = %index_path.display(), "memory reconcile: rewrote index");
+        }
+
+        Ok(())
     }
 }
 
@@ -458,25 +668,11 @@ fn format_index_line(name: &str, description: &str) -> String {
     format!("- [{name}]({file}) — {description}")
 }
 
-fn append_index_line(index_path: &Path, line: &str) -> Result<(), MemoryError> {
-    let mut current = match std::fs::read_to_string(index_path) {
-        Ok(t) => t,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(e) => {
-            return Err(MemoryError::io(
-                format!("reading {}", index_path.display()),
-                e,
-            ));
-        }
-    };
-    if !current.is_empty() && !current.ends_with('\n') {
-        current.push('\n');
-    }
-    current.push_str(line);
-    current.push('\n');
-    std::fs::write(index_path, current)
-        .map_err(|e| MemoryError::io(format!("writing {}", index_path.display()), e))
-}
+// `append_index_line` was used by the previous `add` path but issue
+// #13 of PR #76 review moved `add` to `replace_index_line` (which
+// dedupes stale rows on the way through), so this helper is unused.
+// Kept only as a comment marker; the function has been removed to
+// silence dead-code warnings.
 
 fn replace_index_line(
     index_path: &Path,
@@ -485,7 +681,17 @@ fn replace_index_line(
 ) -> Result<(), MemoryError> {
     let current = match std::fs::read_to_string(index_path) {
         Ok(t) => t,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Index file doesn't exist yet. If we have a replacement
+            // line, we need to create the file so the row is
+            // persisted. Without a replacement (i.e. we're removing a
+            // row that was never indexed) the missing file is
+            // already the correct state.
+            if replacement.is_none() {
+                return Ok(());
+            }
+            String::new()
+        }
         Err(e) => {
             return Err(MemoryError::io(
                 format!("reading {}", index_path.display()),
@@ -526,16 +732,34 @@ fn replace_index_line(
         .map_err(|e| MemoryError::io(format!("writing {}", index_path.display()), e))
 }
 
+/// Cached compiled regex for index link rows. Pattern matches a
+/// strict markdown link-list item where the `(...)` target ends in
+/// `.md`. This deliberately rejects user-added comments like
+/// `<!-- index of memory (auto-generated) -->` so they round-trip
+/// through `read_merged_index` unchanged.
+fn link_row_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        // `^\s*-\s*\[name\]\(target.md\)` with the `target.md`
+        // captured. Trailing description / em-dash text is allowed.
+        // The pattern is anchored so non-link lines (headers, blank
+        // lines, freeform comments) do not match.
+        #[expect(
+            clippy::expect_used,
+            reason = "static regex literal cannot fail at runtime"
+        )]
+        Regex::new(r"^\s*-\s*\[[^\]]+\]\(([^)]+\.md)\)").expect("static regex compiles")
+    })
+}
+
 /// Extract the file name inside the `(...)` of an index line.
 ///
 /// Returns `None` for lines that do not look like a markdown link list
-/// item; this includes blank and comment lines, which the merge logic
-/// passes through unchanged.
+/// item with a `.md` target; user-added headers, comments, and blank
+/// lines are passed through unchanged by the merge logic.
 fn extract_link_target(line: &str) -> Option<String> {
-    let open = line.find('(')?;
-    let close = line[open + 1..].find(')')?;
-    let inner = &line[open + 1..open + 1 + close];
-    Some(inner.to_owned())
+    let captures = link_row_regex().captures(line)?;
+    Some(captures.get(1)?.as_str().to_owned())
 }
 
 fn extract_index_names(index: &str) -> Vec<String> {
@@ -564,6 +788,19 @@ fn validate_name(name: &str) -> Result<(), MemoryError> {
             "name must not start with '.'",
         ));
     }
+    // The literal stem of the index file must not be reused as an entry
+    // name; otherwise `entry_file_name(name)` would collide with
+    // `INDEX_FILE_NAME` (`MEMORY.md`) and the entry write would either
+    // overwrite the index or be overwritten by the next index append.
+    // The check is case-insensitive because macOS / Windows have
+    // case-insensitive filesystems by default.
+    let index_stem = INDEX_FILE_NAME.trim_end_matches(".md");
+    if name.eq_ignore_ascii_case(index_stem) {
+        return Err(MemoryError::invalid_name(
+            name,
+            "name must not collide with the reserved index file stem (MEMORY)",
+        ));
+    }
     let valid = name
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
@@ -578,14 +815,12 @@ fn validate_name(name: &str) -> Result<(), MemoryError> {
 
 fn validate_description(description: &str) -> Result<(), MemoryError> {
     if description.trim().is_empty() {
-        return Err(MemoryError::invalid_name(
-            "<description>",
+        return Err(MemoryError::invalid_description(
             "description must not be empty",
         ));
     }
     if description.contains('\n') {
-        return Err(MemoryError::invalid_name(
-            "<description>",
+        return Err(MemoryError::invalid_description(
             "description must be a single line",
         ));
     }
@@ -613,6 +848,57 @@ mod tests {
         assert!(validate_name(".hidden").is_err());
         assert!(validate_name("ok_name").is_ok());
         assert!(validate_name("ok-name-1").is_ok());
+    }
+
+    /// Regression test for issue #1 in PR #76 review: an entry named
+    /// `MEMORY` (or any case variant) collides with the index file
+    /// stem. Without this guard, `add("MEMORY", ...)` would write the
+    /// entry as `MEMORY.md` and the subsequent index append would
+    /// overwrite the brand-new entry.
+    #[test]
+    fn validate_name_rejects_reserved_index_stem() {
+        assert!(validate_name("MEMORY").is_err());
+        assert!(validate_name("memory").is_err());
+        assert!(validate_name("Memory").is_err());
+        assert!(validate_name("MeMoRy").is_err());
+        // Substrings that contain the stem are still allowed.
+        assert!(validate_name("MEMORY_2").is_ok());
+        assert!(validate_name("project_memory").is_ok());
+    }
+
+    /// End-to-end regression test: even if the validator gate was
+    /// bypassed, calling `add("MEMORY", ...)` must not corrupt the
+    /// index. `add` returns `MemoryError::InvalidName` and
+    /// `MEMORY.md` is left untouched (still empty / absent).
+    #[test]
+    fn add_with_reserved_name_does_not_corrupt_index() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = store_at(dir.path());
+        // Seed a real entry so the index has known content to detect
+        // corruption against.
+        store
+            .add("real_topic", MemoryType::Project, "real desc", "body")
+            .expect("seed");
+        let before = std::fs::read_to_string(store.project_index_path()).expect("read index");
+
+        // Both the upper-case and lower-case forms must reject.
+        let err = store
+            .add("MEMORY", MemoryType::Project, "d", "c")
+            .expect_err("MEMORY");
+        assert!(
+            matches!(err, MemoryError::InvalidName { .. }),
+            "expected InvalidName, got {err:?}",
+        );
+        let err = store
+            .add("memory", MemoryType::Project, "d", "c")
+            .expect_err("memory");
+        assert!(matches!(err, MemoryError::InvalidName { .. }));
+
+        let after = std::fs::read_to_string(store.project_index_path()).expect("read index 2");
+        assert_eq!(
+            before, after,
+            "index file changed after a rejected add call",
+        );
     }
 
     #[test]
@@ -739,20 +1025,114 @@ mod tests {
         assert_eq!(names, vec!["a".to_owned(), "b".to_owned()]);
     }
 
+    /// Regression test for issue #7: when an entry file is deleted out
+    /// of band but the index still references it, `reconcile` repairs
+    /// the index. Symmetrically, when a file exists with no row,
+    /// `reconcile` appends the row.
+    #[test]
+    fn reconcile_drops_orphan_rows_and_appends_missing_rows() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = store_at(dir.path());
+        store
+            .add("alpha", MemoryType::Project, "alpha desc", "alpha body")
+            .expect("alpha");
+        store
+            .add("beta", MemoryType::Project, "beta desc", "beta body")
+            .expect("beta");
+
+        // 1. Delete `beta.md` out-of-band: the index still references it.
+        let beta_path = store.project_dir().join("beta.md");
+        std::fs::remove_file(&beta_path).expect("remove beta");
+
+        // 2. Hand-write a `gamma.md` file with no matching row.
+        let gamma_path = store.project_dir().join("gamma.md");
+        let gamma_entry = MemoryEntry {
+            frontmatter: Frontmatter {
+                name: "gamma".to_owned(),
+                description: "gamma desc".to_owned(),
+                kind: MemoryType::User,
+                created_at: None,
+                updated_at: None,
+            },
+            body: "gamma body".to_owned(),
+        };
+        std::fs::write(&gamma_path, gamma_entry.to_markdown().expect("md")).expect("write gamma");
+
+        store.reconcile().expect("reconcile");
+
+        let index = std::fs::read_to_string(store.project_index_path()).expect("read index");
+        assert!(index.contains("alpha.md"), "alpha row preserved");
+        assert!(!index.contains("beta.md"), "beta row dropped");
+        assert!(index.contains("gamma.md"), "gamma row appended");
+    }
+
+    /// Regression test for issue #11: a stray `(...)` in user content
+    /// must not be misclassified as a link target. The merge logic
+    /// should pass header/comment lines through unchanged.
+    #[test]
+    fn read_merged_index_preserves_non_link_lines() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_dir = dir.path().join("proj").join(".tsumugi").join("memory");
+        let global_dir = dir.path().join("global");
+        std::fs::create_dir_all(&global_dir).expect("global dir");
+        // Global index with a comment + a link row.
+        let global_index = "# My global memory (the good one)\n\
+            <!-- index of memory (auto-generated) -->\n\
+            - [thing](thing.md) — global desc\n";
+        std::fs::write(global_dir.join(INDEX_FILE_NAME), global_index).expect("idx");
+        // Need a matching entry file so the row is sound; reconcile
+        // will not delete it because the file is on disk.
+        let thing = MemoryEntry {
+            frontmatter: Frontmatter {
+                name: "thing".to_owned(),
+                description: "global desc".to_owned(),
+                kind: MemoryType::Reference,
+                created_at: None,
+                updated_at: None,
+            },
+            body: "body".to_owned(),
+        };
+        std::fs::write(
+            global_dir.join("thing.md"),
+            thing.to_markdown().expect("md"),
+        )
+        .expect("write thing");
+
+        let store = MemoryStore::with_dirs(
+            project_dir.clone(),
+            Some(global_dir.clone()),
+            MemoryBudget::default(),
+        );
+        let merged = store.read_merged_index().expect("merged");
+        // The header and comment must NOT get the `[global] ` prefix.
+        assert!(merged.contains("# My global memory (the good one)"));
+        assert!(merged.contains("<!-- index of memory (auto-generated) -->"));
+        assert!(!merged.contains("[global] # My"));
+        assert!(!merged.contains("[global] <!--"));
+        // Link row gets the prefix.
+        assert!(merged.contains("[global] - [thing]"));
+    }
+
     #[test]
     fn budget_report_tracks_files() {
         let dir = tempfile::tempdir().expect("tempdir");
+        // total_files_limit = 5 so the 80% threshold (= 4) leaves
+        // headroom for the under-budget assertion. With the previous
+        // limit of 2 the 80% threshold rounded down to 1, which fired
+        // immediately on the first add and made the assertion flaky.
         let small = MemoryBudget {
             index_max_lines: 200,
             entry_max_chars: 600,
-            total_files_limit: 2,
+            total_files_limit: 5,
         };
         let store = MemoryStore::with_dirs(dir.path().join(".tsumugi").join("memory"), None, small);
         store.add("a", MemoryType::User, "d", "b").expect("a");
         let r1 = store.budget_report().expect("r1");
-        assert!(!r1.near_capacity());
-        store.add("b", MemoryType::User, "d", "b").expect("b");
+        assert!(!r1.near_capacity(), "1/5 files: under 80% threshold");
+        for n in ["b", "c", "d"] {
+            store.add(n, MemoryType::User, "d", "b").expect("seed");
+        }
         let r2 = store.budget_report().expect("r2");
-        assert!(r2.near_capacity());
+        assert!(r2.near_capacity(), "4/5 files: at 80% threshold");
     }
 }

--- a/crates/tmg-memory/src/store.rs
+++ b/crates/tmg-memory/src/store.rs
@@ -1,0 +1,758 @@
+//! [`MemoryStore`]: filesystem-backed CRUD for project / global memory.
+//!
+//! The store owns a project memory directory (e.g. `.tsumugi/memory/`)
+//! and optionally a low-priority global directory (e.g.
+//! `~/.config/tsumugi/memory/`). Reads merge both layers (project wins
+//! on name collision); writes always target the project layer.
+
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+
+use crate::budget::{BudgetReport, MemoryBudget};
+use crate::entry::{Frontmatter, MemoryEntry, MemoryType, parse_entry};
+use crate::error::MemoryError;
+
+/// File name of the index inside each memory directory.
+pub const INDEX_FILE_NAME: &str = "MEMORY.md";
+
+/// Origin layer of a [`MemoryEntry`] discovered by the store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryScope {
+    /// Project-local memory at `<project_root>/.tsumugi/memory/`.
+    Project,
+    /// Global memory at `~/.config/tsumugi/memory/`.
+    Global,
+}
+
+impl MemoryScope {
+    /// Lowercase string used in event log payloads / display.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::Global => "global",
+        }
+    }
+}
+
+/// Filesystem-backed memory store.
+///
+/// Construction is cheap (no I/O); the directory is created on first
+/// write. The store is `Send + Sync` and intended to be wrapped in
+/// `Arc` for shared access from the agent loop and CLI tools.
+#[derive(Debug, Clone)]
+pub struct MemoryStore {
+    project_dir: PathBuf,
+    global_dir: Option<PathBuf>,
+    budget: MemoryBudget,
+}
+
+impl MemoryStore {
+    /// Open a store rooted at `project_root`.
+    ///
+    /// The project directory is `<project_root>/.tsumugi/memory/`.
+    /// The global directory defaults to `~/.config/tsumugi/memory/`
+    /// (via the [`dirs`] crate) when available.
+    #[must_use]
+    pub fn open(project_root: impl AsRef<Path>) -> Self {
+        let project_dir = project_root.as_ref().join(".tsumugi").join("memory");
+        let global_dir = dirs::config_dir().map(|d| d.join("tsumugi").join("memory"));
+        Self {
+            project_dir,
+            global_dir,
+            budget: MemoryBudget::default(),
+        }
+    }
+
+    /// Construct a store with explicit project / global directories
+    /// and a custom budget. Used by the CLI when honouring the
+    /// `[memory]` section of `tsumugi.toml`.
+    #[must_use]
+    pub fn with_dirs(
+        project_dir: impl Into<PathBuf>,
+        global_dir: Option<PathBuf>,
+        budget: MemoryBudget,
+    ) -> Self {
+        Self {
+            project_dir: project_dir.into(),
+            global_dir,
+            budget,
+        }
+    }
+
+    /// Override the budget after construction.
+    #[must_use]
+    pub fn with_budget(mut self, budget: MemoryBudget) -> Self {
+        self.budget = budget;
+        self
+    }
+
+    /// Path to the project memory directory.
+    #[must_use]
+    pub fn project_dir(&self) -> &Path {
+        &self.project_dir
+    }
+
+    /// Path to the global memory directory (if any).
+    #[must_use]
+    pub fn global_dir(&self) -> Option<&Path> {
+        self.global_dir.as_deref()
+    }
+
+    /// Path to the project `MEMORY.md` file.
+    #[must_use]
+    pub fn project_index_path(&self) -> PathBuf {
+        self.project_dir.join(INDEX_FILE_NAME)
+    }
+
+    /// Active capacity budget.
+    #[must_use]
+    pub fn budget(&self) -> &MemoryBudget {
+        &self.budget
+    }
+
+    /// Read the merged `MEMORY.md` index (global followed by project,
+    /// with project entries overriding any global rows whose link
+    /// target collides on file name).
+    ///
+    /// Returns an empty string when neither index exists.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces I/O errors other than `NotFound`.
+    pub fn read_merged_index(&self) -> Result<String, MemoryError> {
+        let project = match read_index_at(&self.project_dir) {
+            Ok(text) => Some(text),
+            Err(MemoryError::Io { source, .. })
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                None
+            }
+            Err(e) => return Err(e),
+        };
+        let global = match self.global_dir.as_deref() {
+            Some(dir) => match read_index_at(dir) {
+                Ok(text) => Some(text),
+                Err(MemoryError::Io { source, .. })
+                    if source.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    None
+                }
+                Err(e) => return Err(e),
+            },
+            None => None,
+        };
+
+        let project_names = project
+            .as_deref()
+            .map(extract_index_names)
+            .unwrap_or_default();
+
+        let mut out = String::new();
+        if let Some(g) = global.as_deref() {
+            // Drop global lines whose `(file.md)` token collides with a
+            // project entry. Lines that do not match the index format
+            // are passed through.
+            for line in g.lines() {
+                if let Some(file) = extract_link_target(line)
+                    && project_names.iter().any(|p| p == &file)
+                {
+                    continue;
+                }
+                if !line.trim().is_empty() {
+                    out.push_str("[global] ");
+                }
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        if let Some(p) = project.as_deref() {
+            if !out.is_empty() && !out.ends_with('\n') {
+                out.push('\n');
+            }
+            for line in p.lines() {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        Ok(out)
+    }
+
+    /// Take a [`BudgetReport`] snapshot of the project store. Index
+    /// line count and file count are measured against [`Self::budget`].
+    ///
+    /// # Errors
+    ///
+    /// Surfaces I/O errors other than `NotFound`.
+    pub fn budget_report(&self) -> Result<BudgetReport, MemoryError> {
+        let index_lines = match read_index_at(&self.project_dir) {
+            Ok(s) => s.lines().filter(|l| !l.trim().is_empty()).count(),
+            Err(MemoryError::Io { source, .. })
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                0
+            }
+            Err(e) => return Err(e),
+        };
+        let file_count = count_entry_files(&self.project_dir)?;
+        Ok(BudgetReport::from_measurements(
+            index_lines,
+            file_count,
+            &self.budget,
+        ))
+    }
+
+    /// Read one memory entry by name.
+    ///
+    /// Project layer wins on name collision; if the entry is missing
+    /// from project, the global layer is consulted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::NotFound`] when no entry matches in
+    /// either layer; other I/O / parse failures surface as their
+    /// respective variants.
+    pub fn read(&self, name: &str) -> Result<(MemoryEntry, MemoryScope), MemoryError> {
+        validate_name(name)?;
+        let file = entry_file_name(name);
+        let project_path = self.project_dir.join(&file);
+        match read_entry_file(&project_path) {
+            Ok(entry) => return Ok((entry, MemoryScope::Project)),
+            Err(MemoryError::Io { source, .. })
+                if source.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+        if let Some(dir) = self.global_dir.as_deref() {
+            let global_path = dir.join(&file);
+            match read_entry_file(&global_path) {
+                Ok(entry) => return Ok((entry, MemoryScope::Global)),
+                Err(MemoryError::Io { source, .. })
+                    if source.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Err(MemoryError::NotFound {
+            name: name.to_owned(),
+        })
+    }
+
+    /// Add a new memory entry. Returns an error if an entry with the
+    /// same `name` already exists in the project layer.
+    ///
+    /// Writes the entry file and appends a row to `MEMORY.md`.
+    ///
+    /// # Errors
+    ///
+    /// - [`MemoryError::AlreadyExists`] on name collision.
+    /// - [`MemoryError::InvalidName`] on bad input.
+    /// - [`MemoryError::Io`] / [`MemoryError::Yaml`] on persist failure.
+    pub fn add(
+        &self,
+        name: &str,
+        kind: MemoryType,
+        description: &str,
+        content: &str,
+    ) -> Result<BudgetReport, MemoryError> {
+        validate_name(name)?;
+        validate_description(description)?;
+
+        let path = self.entry_path_in_project(name);
+        if path.exists() {
+            return Err(MemoryError::AlreadyExists {
+                name: name.to_owned(),
+            });
+        }
+
+        ensure_dir(&self.project_dir)?;
+
+        let now = Utc::now();
+        let entry = MemoryEntry {
+            frontmatter: Frontmatter {
+                name: name.to_owned(),
+                description: description.to_owned(),
+                kind,
+                created_at: Some(now),
+                updated_at: Some(now),
+            },
+            body: content.to_owned(),
+        };
+        let markdown = entry.to_markdown()?;
+        std::fs::write(&path, markdown)
+            .map_err(|e| MemoryError::io(format!("writing {}", path.display()), e))?;
+
+        let new_line = format_index_line(name, description);
+        append_index_line(&self.project_index_path(), &new_line)?;
+
+        self.budget_report()
+    }
+
+    /// Update an existing memory entry. `description` and `content`
+    /// are partial updates: pass `None` to leave that field unchanged.
+    /// `kind` is updated when `Some`.
+    ///
+    /// `updated_at` is bumped on every successful update.
+    ///
+    /// # Errors
+    ///
+    /// - [`MemoryError::NotFound`] when the entry is absent from the
+    ///   project layer (global entries are read-only).
+    pub fn update(
+        &self,
+        name: &str,
+        kind: Option<MemoryType>,
+        description: Option<&str>,
+        content: Option<&str>,
+    ) -> Result<BudgetReport, MemoryError> {
+        validate_name(name)?;
+        if let Some(d) = description {
+            validate_description(d)?;
+        }
+
+        let path = self.entry_path_in_project(name);
+        if !path.exists() {
+            return Err(MemoryError::NotFound {
+                name: name.to_owned(),
+            });
+        }
+
+        let existing_text = std::fs::read_to_string(&path)
+            .map_err(|e| MemoryError::io(format!("reading {}", path.display()), e))?;
+        let mut entry = parse_entry(&existing_text, &path.display().to_string())?;
+
+        if let Some(k) = kind {
+            entry.frontmatter.kind = k;
+        }
+        if let Some(d) = description {
+            d.clone_into(&mut entry.frontmatter.description);
+        }
+        if let Some(c) = content {
+            c.clone_into(&mut entry.body);
+        }
+        let now = Utc::now();
+        if entry.frontmatter.created_at.is_none() {
+            entry.frontmatter.created_at = Some(now);
+        }
+        entry.frontmatter.updated_at = Some(now);
+
+        let markdown = entry.to_markdown()?;
+        std::fs::write(&path, markdown)
+            .map_err(|e| MemoryError::io(format!("writing {}", path.display()), e))?;
+
+        // Refresh index row (description may have changed).
+        let new_line = format_index_line(name, &entry.frontmatter.description);
+        replace_index_line(&self.project_index_path(), name, Some(&new_line))?;
+
+        self.budget_report()
+    }
+
+    /// Remove a memory entry. Idempotent: missing entries are an error.
+    ///
+    /// # Errors
+    ///
+    /// - [`MemoryError::NotFound`] when the entry is absent.
+    pub fn remove(&self, name: &str) -> Result<BudgetReport, MemoryError> {
+        validate_name(name)?;
+        let path = self.entry_path_in_project(name);
+        if !path.exists() {
+            return Err(MemoryError::NotFound {
+                name: name.to_owned(),
+            });
+        }
+        std::fs::remove_file(&path)
+            .map_err(|e| MemoryError::io(format!("removing {}", path.display()), e))?;
+        replace_index_line(&self.project_index_path(), name, None)?;
+        self.budget_report()
+    }
+
+    /// List the names of every entry in the project layer (no global merge).
+    ///
+    /// # Errors
+    ///
+    /// Surfaces I/O errors other than `NotFound`.
+    pub fn list_project(&self) -> Result<Vec<String>, MemoryError> {
+        let read_dir = match std::fs::read_dir(&self.project_dir) {
+            Ok(d) => d,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => {
+                return Err(MemoryError::io(
+                    format!("reading {}", self.project_dir.display()),
+                    e,
+                ));
+            }
+        };
+        let mut names = Vec::new();
+        for ent in read_dir {
+            let ent = ent.map_err(|e| {
+                MemoryError::io(format!("iterating {}", self.project_dir.display()), e)
+            })?;
+            let name_os = ent.file_name();
+            let Some(name_str) = name_os.to_str() else {
+                continue;
+            };
+            if name_str == INDEX_FILE_NAME {
+                continue;
+            }
+            if let Some(stem) = name_str.strip_suffix(".md") {
+                names.push(stem.to_owned());
+            }
+        }
+        names.sort();
+        Ok(names)
+    }
+
+    fn entry_path_in_project(&self, name: &str) -> PathBuf {
+        self.project_dir.join(entry_file_name(name))
+    }
+}
+
+fn entry_file_name(name: &str) -> String {
+    format!("{name}.md")
+}
+
+fn read_index_at(dir: &Path) -> Result<String, MemoryError> {
+    let path = dir.join(INDEX_FILE_NAME);
+    std::fs::read_to_string(&path)
+        .map_err(|e| MemoryError::io(format!("reading {}", path.display()), e))
+}
+
+fn read_entry_file(path: &Path) -> Result<MemoryEntry, MemoryError> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| MemoryError::io(format!("reading {}", path.display()), e))?;
+    parse_entry(&text, &path.display().to_string())
+}
+
+fn count_entry_files(dir: &Path) -> Result<usize, MemoryError> {
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(MemoryError::io(format!("reading {}", dir.display()), e)),
+    };
+    let mut count = 0;
+    for ent in read_dir {
+        let ent = ent.map_err(|e| MemoryError::io(format!("iterating {}", dir.display()), e))?;
+        let name = ent.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if name_str == INDEX_FILE_NAME {
+            continue;
+        }
+        if std::path::Path::new(name_str)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+        {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+fn ensure_dir(dir: &Path) -> Result<(), MemoryError> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| MemoryError::io(format!("creating {}", dir.display()), e))
+}
+
+fn format_index_line(name: &str, description: &str) -> String {
+    let file = entry_file_name(name);
+    format!("- [{name}]({file}) — {description}")
+}
+
+fn append_index_line(index_path: &Path, line: &str) -> Result<(), MemoryError> {
+    let mut current = match std::fs::read_to_string(index_path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(MemoryError::io(
+                format!("reading {}", index_path.display()),
+                e,
+            ));
+        }
+    };
+    if !current.is_empty() && !current.ends_with('\n') {
+        current.push('\n');
+    }
+    current.push_str(line);
+    current.push('\n');
+    std::fs::write(index_path, current)
+        .map_err(|e| MemoryError::io(format!("writing {}", index_path.display()), e))
+}
+
+fn replace_index_line(
+    index_path: &Path,
+    name: &str,
+    replacement: Option<&str>,
+) -> Result<(), MemoryError> {
+    let current = match std::fs::read_to_string(index_path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(MemoryError::io(
+                format!("reading {}", index_path.display()),
+                e,
+            ));
+        }
+    };
+    let target_file = entry_file_name(name);
+    let mut out = String::with_capacity(current.len());
+    let mut replaced = false;
+    for line in current.lines() {
+        if extract_link_target(line).as_deref() == Some(target_file.as_str()) {
+            if let Some(new_line) = replacement
+                && !replaced
+            {
+                out.push_str(new_line);
+                out.push('\n');
+                replaced = true;
+            }
+            // remove==None: drop the line; replace==Some & already replaced: dedupe.
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    if let Some(new_line) = replacement
+        && !replaced
+    {
+        // Entry was missing from the index; append so callers always
+        // see the row reflect reality.
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str(new_line);
+        out.push('\n');
+    }
+    std::fs::write(index_path, out)
+        .map_err(|e| MemoryError::io(format!("writing {}", index_path.display()), e))
+}
+
+/// Extract the file name inside the `(...)` of an index line.
+///
+/// Returns `None` for lines that do not look like a markdown link list
+/// item; this includes blank and comment lines, which the merge logic
+/// passes through unchanged.
+fn extract_link_target(line: &str) -> Option<String> {
+    let open = line.find('(')?;
+    let close = line[open + 1..].find(')')?;
+    let inner = &line[open + 1..open + 1 + close];
+    Some(inner.to_owned())
+}
+
+fn extract_index_names(index: &str) -> Vec<String> {
+    index.lines().filter_map(extract_link_target).collect()
+}
+
+fn validate_name(name: &str) -> Result<(), MemoryError> {
+    if name.is_empty() {
+        return Err(MemoryError::invalid_name(name, "name must not be empty"));
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err(MemoryError::invalid_name(
+            name,
+            "name must not contain path separators",
+        ));
+    }
+    if name.contains("..") {
+        return Err(MemoryError::invalid_name(
+            name,
+            "name must not contain '..'",
+        ));
+    }
+    if name.starts_with('.') {
+        return Err(MemoryError::invalid_name(
+            name,
+            "name must not start with '.'",
+        ));
+    }
+    let valid = name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if !valid {
+        return Err(MemoryError::invalid_name(
+            name,
+            "name must be ASCII alphanumeric with underscores or hyphens",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_description(description: &str) -> Result<(), MemoryError> {
+    if description.trim().is_empty() {
+        return Err(MemoryError::invalid_name(
+            "<description>",
+            "description must not be empty",
+        ));
+    }
+    if description.contains('\n') {
+        return Err(MemoryError::invalid_name(
+            "<description>",
+            "description must be a single line",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    fn store_at(root: &Path) -> MemoryStore {
+        MemoryStore::with_dirs(
+            root.join(".tsumugi").join("memory"),
+            None,
+            MemoryBudget::default(),
+        )
+    }
+
+    #[test]
+    fn validate_name_rejects_path_traversal() {
+        assert!(validate_name("../escape").is_err());
+        assert!(validate_name("foo/bar").is_err());
+        assert!(validate_name("").is_err());
+        assert!(validate_name(".hidden").is_err());
+        assert!(validate_name("ok_name").is_ok());
+        assert!(validate_name("ok-name-1").is_ok());
+    }
+
+    #[test]
+    fn add_then_read_roundtrip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = store_at(dir.path());
+        store
+            .add("topic", MemoryType::Project, "desc", "body content")
+            .expect("add");
+        let (entry, scope) = store.read("topic").expect("read");
+        assert_eq!(scope, MemoryScope::Project);
+        assert_eq!(entry.frontmatter.name, "topic");
+        assert!(entry.body.starts_with("body content"));
+
+        let index = store.read_merged_index().expect("index");
+        assert!(index.contains("- [topic](topic.md) — desc"));
+    }
+
+    #[test]
+    fn add_duplicate_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = store_at(dir.path());
+        store.add("t", MemoryType::User, "d", "body").expect("add");
+        let err = store
+            .add("t", MemoryType::User, "d", "body")
+            .expect_err("dup");
+        assert!(matches!(err, MemoryError::AlreadyExists { .. }));
+    }
+
+    #[test]
+    fn update_modifies_description_and_body() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = store_at(dir.path());
+        store
+            .add("t", MemoryType::User, "old", "old body")
+            .expect("add");
+        store
+            .update("t", None, Some("new desc"), Some("new body"))
+            .expect("update");
+        let (entry, _) = store.read("t").expect("read");
+        assert_eq!(entry.frontmatter.description, "new desc");
+        assert!(entry.body.contains("new body"));
+
+        let index = store.read_merged_index().expect("index");
+        assert!(index.contains("new desc"));
+        assert!(!index.contains("— old"));
+    }
+
+    #[test]
+    fn remove_drops_file_and_index_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = store_at(dir.path());
+        store
+            .add("t", MemoryType::Project, "desc", "body")
+            .expect("add");
+        store.remove("t").expect("remove");
+        let err = store.read("t").expect_err("missing");
+        assert!(matches!(err, MemoryError::NotFound { .. }));
+        let index = store.read_merged_index().expect("index");
+        assert!(!index.contains("topic.md"));
+    }
+
+    #[test]
+    fn global_layer_is_merged_and_overridden_by_project() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project_dir = dir.path().join("proj").join(".tsumugi").join("memory");
+        let global_dir = dir.path().join("global");
+        std::fs::create_dir_all(&global_dir).expect("global dir");
+        // Build a global entry by hand.
+        let entry_path = global_dir.join("shared.md");
+        let entry = MemoryEntry {
+            frontmatter: Frontmatter {
+                name: "shared".to_owned(),
+                description: "global desc".to_owned(),
+                kind: MemoryType::Reference,
+                created_at: None,
+                updated_at: None,
+            },
+            body: "global body".to_owned(),
+        };
+        std::fs::write(&entry_path, entry.to_markdown().expect("md")).expect("write");
+        let global_index = format_index_line("shared", "global desc");
+        std::fs::write(global_dir.join(INDEX_FILE_NAME), global_index + "\n").expect("idx");
+
+        let store = MemoryStore::with_dirs(
+            project_dir.clone(),
+            Some(global_dir.clone()),
+            MemoryBudget::default(),
+        );
+
+        // Read falls back to global.
+        let (got, scope) = store.read("shared").expect("read");
+        assert_eq!(scope, MemoryScope::Global);
+        assert_eq!(got.frontmatter.description, "global desc");
+
+        // Project add wins on collision.
+        store
+            .add(
+                "shared",
+                MemoryType::Project,
+                "project desc",
+                "project body",
+            )
+            .expect("add");
+        let (got, scope) = store.read("shared").expect("read");
+        assert_eq!(scope, MemoryScope::Project);
+        assert_eq!(got.frontmatter.description, "project desc");
+
+        let merged = store.read_merged_index().expect("merge");
+        assert!(merged.contains("project desc"));
+        // Global row is suppressed because the file name collides.
+        let global_count = merged.matches("global desc").count();
+        assert_eq!(global_count, 0);
+    }
+
+    #[test]
+    fn list_project_excludes_index_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = store_at(dir.path());
+        store.add("a", MemoryType::User, "d", "b").expect("a");
+        store.add("b", MemoryType::User, "d", "b").expect("b");
+        let mut names = store.list_project().expect("list");
+        names.sort();
+        assert_eq!(names, vec!["a".to_owned(), "b".to_owned()]);
+    }
+
+    #[test]
+    fn budget_report_tracks_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let small = MemoryBudget {
+            index_max_lines: 200,
+            entry_max_chars: 600,
+            total_files_limit: 2,
+        };
+        let store = MemoryStore::with_dirs(dir.path().join(".tsumugi").join("memory"), None, small);
+        store.add("a", MemoryType::User, "d", "b").expect("a");
+        let r1 = store.budget_report().expect("r1");
+        assert!(!r1.near_capacity());
+        store.add("b", MemoryType::User, "d", "b").expect("b");
+        let r2 = store.budget_report().expect("r2");
+        assert!(r2.near_capacity());
+    }
+}

--- a/crates/tmg-memory/src/tool.rs
+++ b/crates/tmg-memory/src/tool.rs
@@ -1,0 +1,533 @@
+//! [`MemoryTool`]: the agent-facing CRUD tool over a [`MemoryStore`].
+
+use std::pin::Pin;
+use std::str::FromStr as _;
+use std::sync::Arc;
+
+use serde_json::Value as JsonValue;
+use tmg_sandbox::SandboxContext;
+use tmg_tools::error::ToolError;
+use tmg_tools::types::{Tool, ToolResult};
+
+use crate::budget::{BudgetReport, capacity_nudge};
+use crate::entry::MemoryType;
+use crate::error::MemoryError;
+use crate::store::MemoryStore;
+
+/// Name of the tool registered in the [`tmg_tools::ToolRegistry`].
+pub const MEMORY_TOOL_NAME: &str = "memory";
+
+/// Agent-facing CRUD tool over a [`MemoryStore`].
+///
+/// All write operations target the project layer; the global layer is
+/// read-only from the LLM's perspective. The tool generates file paths
+/// internally so the LLM cannot inject arbitrary write targets.
+pub struct MemoryTool {
+    store: Arc<MemoryStore>,
+}
+
+impl MemoryTool {
+    /// Construct a tool around an existing store.
+    #[must_use]
+    pub fn new(store: Arc<MemoryStore>) -> Self {
+        Self { store }
+    }
+}
+
+impl Tool for MemoryTool {
+    fn name(&self) -> &'static str {
+        MEMORY_TOOL_NAME
+    }
+
+    fn description(&self) -> &'static str {
+        "Project-scoped persistent memory. Use `read` to inspect a topic before starting work, \
+         and `add` / `update` / `remove` to curate. Index lives at `.tsumugi/memory/MEMORY.md` \
+         and is included in the system prompt."
+    }
+
+    fn parameters_schema(&self) -> JsonValue {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["add", "update", "remove", "read"],
+                    "description": "Which CRUD operation to perform."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Topic name (ASCII alphanumerics + `_` / `-`). Becomes <name>.md."
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["user", "feedback", "project", "reference"],
+                    "description": "Categorical tag; required for `add`, optional for `update`."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "One-line summary written into MEMORY.md. Required for `add`."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Full body text. Required for `add`; optional for `update`."
+                }
+            },
+            "required": ["action", "name"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute<'a>(
+        &'a self,
+        params: JsonValue,
+        ctx: &'a SandboxContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult, ToolError>> + Send + 'a>> {
+        // The store I/O is synchronous (small files; the agent loop
+        // already runs us inside a tokio task). Wrap the result in a
+        // ready-future so the Tool trait stays uniform across async
+        // and sync implementations.
+        let result = self.execute_inner(&params, ctx);
+        Box::pin(std::future::ready(result))
+    }
+}
+
+impl MemoryTool {
+    fn execute_inner(
+        &self,
+        params: &JsonValue,
+        ctx: &SandboxContext,
+    ) -> Result<ToolResult, ToolError> {
+        let Some(action) = params.get("action").and_then(JsonValue::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: action",
+            ));
+        };
+        let Some(name) = params.get("name").and_then(JsonValue::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: name",
+            ));
+        };
+
+        match action {
+            "read" => self.handle_read(name),
+            "add" => {
+                let kind_str = params
+                    .get("type")
+                    .and_then(JsonValue::as_str)
+                    .ok_or_else(|| ToolError::invalid_params("missing required parameter: type"))?;
+                let kind = MemoryType::from_str(kind_str)
+                    .map_err(|v| ToolError::invalid_params(format!("invalid type: {v}")))?;
+                let description = params
+                    .get("description")
+                    .and_then(JsonValue::as_str)
+                    .ok_or_else(|| {
+                        ToolError::invalid_params("missing required parameter: description")
+                    })?;
+                let content = params
+                    .get("content")
+                    .and_then(JsonValue::as_str)
+                    .ok_or_else(|| {
+                        ToolError::invalid_params("missing required parameter: content")
+                    })?;
+                self.handle_add(name, kind, description, content, ctx)
+            }
+            "update" => {
+                let kind = match params.get("type").and_then(JsonValue::as_str) {
+                    Some(s) => Some(
+                        MemoryType::from_str(s)
+                            .map_err(|v| ToolError::invalid_params(format!("invalid type: {v}")))?,
+                    ),
+                    None => None,
+                };
+                let description = params.get("description").and_then(JsonValue::as_str);
+                let content = params.get("content").and_then(JsonValue::as_str);
+                if description.is_none() && content.is_none() && kind.is_none() {
+                    return Err(ToolError::invalid_params(
+                        "update requires at least one of: type, description, content",
+                    ));
+                }
+                self.handle_update(name, kind, description, content, ctx)
+            }
+            "remove" => self.handle_remove(name, ctx),
+            other => Err(ToolError::invalid_params(format!(
+                "unknown action {other:?}; expected add | update | remove | read"
+            ))),
+        }
+    }
+
+    fn handle_read(&self, name: &str) -> Result<ToolResult, ToolError> {
+        match self.store.read(name) {
+            Ok((entry, scope)) => {
+                let body = entry.body;
+                let header = format!(
+                    "[memory:{}] {} ({}) — {}\n\n",
+                    scope.as_str(),
+                    entry.frontmatter.name,
+                    entry.frontmatter.kind,
+                    entry.frontmatter.description,
+                );
+                Ok(ToolResult::success(header + &body))
+            }
+            Err(MemoryError::NotFound { .. }) => {
+                Ok(ToolResult::error(format!("no memory entry named {name:?}")))
+            }
+            Err(MemoryError::InvalidName { reason, .. }) => Err(ToolError::invalid_params(reason)),
+            Err(other) => Err(map_memory_error(other)),
+        }
+    }
+
+    fn handle_add(
+        &self,
+        name: &str,
+        kind: MemoryType,
+        description: &str,
+        content: &str,
+        ctx: &SandboxContext,
+    ) -> Result<ToolResult, ToolError> {
+        // Sandbox check — the project memory directory must be writable
+        // under the active sandbox policy. The path is generated by the
+        // store, so the LLM cannot influence the destination.
+        let target_dir = self.store.project_dir();
+        ctx.check_write_access(target_dir)?;
+
+        match self.store.add(name, kind, description, content) {
+            Ok(report) => Ok(success_with_budget(
+                format!("added memory entry {name:?} ({kind}). Index updated."),
+                &report,
+                self.store.budget(),
+                content.chars().count(),
+            )),
+            Err(MemoryError::AlreadyExists { .. }) => Ok(ToolResult::error(format!(
+                "memory entry {name:?} already exists; use action=update to modify it"
+            ))),
+            Err(MemoryError::InvalidName { reason, .. }) => Err(ToolError::invalid_params(reason)),
+            Err(other) => Err(map_memory_error(other)),
+        }
+    }
+
+    fn handle_update(
+        &self,
+        name: &str,
+        kind: Option<MemoryType>,
+        description: Option<&str>,
+        content: Option<&str>,
+        ctx: &SandboxContext,
+    ) -> Result<ToolResult, ToolError> {
+        ctx.check_write_access(self.store.project_dir())?;
+        match self.store.update(name, kind, description, content) {
+            Ok(report) => {
+                let chars = content.map_or(0, |c| c.chars().count());
+                Ok(success_with_budget(
+                    format!("updated memory entry {name:?}."),
+                    &report,
+                    self.store.budget(),
+                    chars,
+                ))
+            }
+            Err(MemoryError::NotFound { .. }) => Ok(ToolResult::error(format!(
+                "no project-layer memory entry named {name:?}"
+            ))),
+            Err(MemoryError::InvalidName { reason, .. }) => Err(ToolError::invalid_params(reason)),
+            Err(other) => Err(map_memory_error(other)),
+        }
+    }
+
+    fn handle_remove(&self, name: &str, ctx: &SandboxContext) -> Result<ToolResult, ToolError> {
+        ctx.check_write_access(self.store.project_dir())?;
+        match self.store.remove(name) {
+            Ok(report) => Ok(success_with_budget(
+                format!("removed memory entry {name:?}."),
+                &report,
+                self.store.budget(),
+                0,
+            )),
+            Err(MemoryError::NotFound { .. }) => Ok(ToolResult::error(format!(
+                "no project-layer memory entry named {name:?}"
+            ))),
+            Err(MemoryError::InvalidName { reason, .. }) => Err(ToolError::invalid_params(reason)),
+            Err(other) => Err(map_memory_error(other)),
+        }
+    }
+}
+
+fn success_with_budget(
+    base_message: String,
+    report: &BudgetReport,
+    budget: &crate::budget::MemoryBudget,
+    body_chars: usize,
+) -> ToolResult {
+    use std::fmt::Write as _;
+    let mut msg = base_message;
+    if body_chars > budget.entry_max_chars {
+        // Best-effort: writing into a `String` cannot fail.
+        let _ = write!(
+            msg,
+            " warning: body is {} chars (limit {}). Consider summarising.",
+            body_chars, budget.entry_max_chars,
+        );
+    }
+    if let Some(nudge) = capacity_nudge(report, budget) {
+        msg.push_str(&nudge);
+    }
+    ToolResult::success(msg)
+}
+
+fn map_memory_error(err: MemoryError) -> ToolError {
+    match err {
+        MemoryError::Io { context, source } => ToolError::Io { context, source },
+        MemoryError::Yaml { path, source } => ToolError::Io {
+            context: format!("yaml at {path}"),
+            source: std::io::Error::other(source.to_string()),
+        },
+        other => ToolError::Io {
+            context: "memory store".to_owned(),
+            source: std::io::Error::other(other.to_string()),
+        },
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::budget::MemoryBudget;
+
+    fn make_store(root: &std::path::Path) -> Arc<MemoryStore> {
+        Arc::new(MemoryStore::with_dirs(
+            root.join(".tsumugi").join("memory"),
+            None,
+            MemoryBudget::default(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn add_then_read_roundtrip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = make_store(dir.path());
+        let tool = MemoryTool::new(store);
+        let ctx = SandboxContext::test_default();
+
+        let res = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "topic_one",
+                    "type": "project",
+                    "description": "first topic",
+                    "content": "topic body content",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("add ok");
+        assert!(!res.is_error, "add error: {}", res.output);
+
+        let res = tool
+            .execute(
+                serde_json::json!({
+                    "action": "read",
+                    "name": "topic_one",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("read ok");
+        assert!(!res.is_error, "read error: {}", res.output);
+        assert!(res.output.contains("topic body content"));
+        assert!(res.output.contains("[memory:project]"));
+    }
+
+    #[tokio::test]
+    async fn add_duplicate_returns_error_result() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = make_store(dir.path());
+        let tool = MemoryTool::new(store);
+        let ctx = SandboxContext::test_default();
+
+        let _ = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "dup",
+                    "type": "user",
+                    "description": "d",
+                    "content": "c",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("first add");
+        let res = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "dup",
+                    "type": "user",
+                    "description": "d",
+                    "content": "c",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("second add (returns error result)");
+        assert!(res.is_error);
+        assert!(res.output.contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn update_partial_description_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = make_store(dir.path());
+        let tool = MemoryTool::new(store);
+        let ctx = SandboxContext::test_default();
+
+        let _ = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "t",
+                    "type": "feedback",
+                    "description": "old",
+                    "content": "old body",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("add");
+        let _ = tool
+            .execute(
+                serde_json::json!({
+                    "action": "update",
+                    "name": "t",
+                    "description": "new",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("update");
+        let res = tool
+            .execute(
+                serde_json::json!({
+                    "action": "read",
+                    "name": "t",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("read");
+        assert!(res.output.contains("new"));
+        assert!(res.output.contains("old body"));
+    }
+
+    #[tokio::test]
+    async fn remove_drops_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = make_store(dir.path());
+        let tool = MemoryTool::new(store);
+        let ctx = SandboxContext::test_default();
+        let _ = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "t",
+                    "type": "feedback",
+                    "description": "d",
+                    "content": "c",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("add");
+        let res = tool
+            .execute(
+                serde_json::json!({
+                    "action": "remove",
+                    "name": "t",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("remove");
+        assert!(!res.is_error);
+        let res = tool
+            .execute(
+                serde_json::json!({
+                    "action": "read",
+                    "name": "t",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("read missing");
+        assert!(res.is_error);
+    }
+
+    #[tokio::test]
+    async fn capacity_warning_surfaces_in_result() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let small = MemoryBudget {
+            index_max_lines: 200,
+            entry_max_chars: 600,
+            total_files_limit: 1,
+        };
+        let store = Arc::new(MemoryStore::with_dirs(
+            dir.path().join(".tsumugi").join("memory"),
+            None,
+            small,
+        ));
+        let tool = MemoryTool::new(store);
+        let ctx = SandboxContext::test_default();
+        // First add fills the budget; second add exceeds it.
+        let _ = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "a",
+                    "type": "user",
+                    "description": "d",
+                    "content": "c",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("first");
+        let res = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "b",
+                    "type": "user",
+                    "description": "d",
+                    "content": "c",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("second");
+        assert!(!res.is_error, "expected success with warning, got error");
+        assert!(
+            res.output.contains("near capacity"),
+            "expected capacity nudge, got: {}",
+            res.output
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_action_is_invalid_params() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = make_store(dir.path());
+        let tool = MemoryTool::new(store);
+        let ctx = SandboxContext::test_default();
+        let err = tool
+            .execute(
+                serde_json::json!({
+                    "action": "wat",
+                    "name": "t",
+                }),
+                &ctx,
+            )
+            .await
+            .expect_err("invalid action");
+        assert!(matches!(err, ToolError::InvalidParams { .. }));
+    }
+}

--- a/crates/tmg-memory/src/tool.rs
+++ b/crates/tmg-memory/src/tool.rs
@@ -17,6 +17,16 @@ use crate::store::MemoryStore;
 /// Name of the tool registered in the [`tmg_tools::ToolRegistry`].
 pub const MEMORY_TOOL_NAME: &str = "memory";
 
+/// Callback fired after every successful write (`add` / `update` /
+/// `remove`) with the freshly-rendered merged index. The agent loop
+/// installs one of these so the in-memory copy of the index stays in
+/// sync with disk and a "memory updated" hint can be surfaced in the
+/// TUI Activity Pane.
+///
+/// The closure must be `Send + Sync` so it can be moved into the
+/// async tool dispatch path.
+pub type MemoryRefreshCallback = Arc<dyn Fn(&str) + Send + Sync>;
+
 /// Agent-facing CRUD tool over a [`MemoryStore`].
 ///
 /// All write operations target the project layer; the global layer is
@@ -24,13 +34,53 @@ pub const MEMORY_TOOL_NAME: &str = "memory";
 /// internally so the LLM cannot inject arbitrary write targets.
 pub struct MemoryTool {
     store: Arc<MemoryStore>,
+    /// Optional refresh callback fired after every successful write.
+    /// `None` means the tool runs without notifying anyone, which is
+    /// the right default for code paths that don't have an
+    /// `AgentLoop` to update (e.g. unit tests).
+    refresh: Option<MemoryRefreshCallback>,
 }
 
 impl MemoryTool {
-    /// Construct a tool around an existing store.
+    /// Construct a tool around an existing store, with no refresh
+    /// hook installed.
     #[must_use]
     pub fn new(store: Arc<MemoryStore>) -> Self {
-        Self { store }
+        Self {
+            store,
+            refresh: None,
+        }
+    }
+
+    /// Construct a tool with a refresh callback that fires after every
+    /// successful write. The callback receives the freshly-rendered
+    /// merged index payload (matching what the system prompt saw at
+    /// startup).
+    ///
+    /// Used by the CLI startup wiring to keep [`tmg_core::AgentLoop`]'s
+    /// in-memory index up to date and to emit a "memory updated"
+    /// stream event into the TUI Activity Pane (issue #4 of PR #76).
+    #[must_use]
+    pub fn with_refresh(store: Arc<MemoryStore>, refresh: MemoryRefreshCallback) -> Self {
+        Self {
+            store,
+            refresh: Some(refresh),
+        }
+    }
+
+    /// Fire the refresh callback (if any) with the latest merged
+    /// index. Best-effort: a stale read is silently ignored so a
+    /// transient I/O error never aborts a successful write.
+    fn fire_refresh(&self) {
+        let Some(cb) = self.refresh.as_ref() else {
+            return;
+        };
+        match self.store.read_merged_index() {
+            Ok(index) => cb(&index),
+            Err(e) => {
+                tracing::debug!(error = %e, "memory refresh: read_merged_index failed; skipping callback");
+            }
+        }
     }
 }
 
@@ -190,17 +240,36 @@ impl MemoryTool {
         let target_dir = self.store.project_dir();
         ctx.check_write_access(target_dir)?;
 
+        // Validate body length BEFORE the store write so an oversized
+        // entry never persists. Issue #9 of PR #76: previously the
+        // length check fired after `store.add(...)` and the entry was
+        // already on disk by the time the warning surfaced.
+        let body_chars = content.chars().count();
+        let budget = self.store.budget();
+        if body_chars > budget.entry_max_chars {
+            return Ok(ToolResult::error(format!(
+                "body is {body_chars} chars (limit {}). Trim or split the entry before adding.",
+                budget.entry_max_chars,
+            )));
+        }
+
         match self.store.add(name, kind, description, content) {
-            Ok(report) => Ok(success_with_budget(
-                format!("added memory entry {name:?} ({kind}). Index updated."),
-                &report,
-                self.store.budget(),
-                content.chars().count(),
-            )),
+            Ok(report) => {
+                self.fire_refresh();
+                Ok(success_with_budget(
+                    format!("added memory entry {name:?} ({kind}). Index updated."),
+                    &report,
+                    self.store.budget(),
+                    body_chars,
+                ))
+            }
             Err(MemoryError::AlreadyExists { .. }) => Ok(ToolResult::error(format!(
                 "memory entry {name:?} already exists; use action=update to modify it"
             ))),
             Err(MemoryError::InvalidName { reason, .. }) => Err(ToolError::invalid_params(reason)),
+            Err(MemoryError::InvalidDescription { reason }) => {
+                Err(ToolError::invalid_params(reason))
+            }
             Err(other) => Err(map_memory_error(other)),
         }
     }
@@ -214,20 +283,34 @@ impl MemoryTool {
         ctx: &SandboxContext,
     ) -> Result<ToolResult, ToolError> {
         ctx.check_write_access(self.store.project_dir())?;
+        // Same budget gate as `add`: reject before mutating disk.
+        let body_chars = content.map_or(0, |c| c.chars().count());
+        let budget = self.store.budget();
+        if let Some(_c) = content
+            && body_chars > budget.entry_max_chars
+        {
+            return Ok(ToolResult::error(format!(
+                "body is {body_chars} chars (limit {}). Trim or split the entry before updating.",
+                budget.entry_max_chars,
+            )));
+        }
         match self.store.update(name, kind, description, content) {
             Ok(report) => {
-                let chars = content.map_or(0, |c| c.chars().count());
+                self.fire_refresh();
                 Ok(success_with_budget(
                     format!("updated memory entry {name:?}."),
                     &report,
                     self.store.budget(),
-                    chars,
+                    body_chars,
                 ))
             }
             Err(MemoryError::NotFound { .. }) => Ok(ToolResult::error(format!(
                 "no project-layer memory entry named {name:?}"
             ))),
             Err(MemoryError::InvalidName { reason, .. }) => Err(ToolError::invalid_params(reason)),
+            Err(MemoryError::InvalidDescription { reason }) => {
+                Err(ToolError::invalid_params(reason))
+            }
             Err(other) => Err(map_memory_error(other)),
         }
     }
@@ -235,12 +318,15 @@ impl MemoryTool {
     fn handle_remove(&self, name: &str, ctx: &SandboxContext) -> Result<ToolResult, ToolError> {
         ctx.check_write_access(self.store.project_dir())?;
         match self.store.remove(name) {
-            Ok(report) => Ok(success_with_budget(
-                format!("removed memory entry {name:?}."),
-                &report,
-                self.store.budget(),
-                0,
-            )),
+            Ok(report) => {
+                self.fire_refresh();
+                Ok(success_with_budget(
+                    format!("removed memory entry {name:?}."),
+                    &report,
+                    self.store.budget(),
+                    0,
+                ))
+            }
             Err(MemoryError::NotFound { .. }) => Ok(ToolResult::error(format!(
                 "no project-layer memory entry named {name:?}"
             ))),
@@ -254,35 +340,47 @@ fn success_with_budget(
     base_message: String,
     report: &BudgetReport,
     budget: &crate::budget::MemoryBudget,
-    body_chars: usize,
+    _body_chars: usize,
 ) -> ToolResult {
-    use std::fmt::Write as _;
     let mut msg = base_message;
-    if body_chars > budget.entry_max_chars {
-        // Best-effort: writing into a `String` cannot fail.
-        let _ = write!(
-            msg,
-            " warning: body is {} chars (limit {}). Consider summarising.",
-            body_chars, budget.entry_max_chars,
-        );
-    }
+    // Body-length check now lives in `handle_add` / `handle_update`
+    // (before the write). Here we only surface the index/file-count
+    // capacity nudge.
     if let Some(nudge) = capacity_nudge(report, budget) {
         msg.push_str(&nudge);
     }
     ToolResult::success(msg)
 }
 
+/// Map a [`MemoryError`] to the right [`ToolError`] / [`ToolResult`]
+/// variant. Issue #8 of PR #76: lossy mapping (everything → `ToolError::Io`)
+/// produced misleading error messages and lost variant info.
+///
+/// Callers handle [`MemoryError::AlreadyExists`] and
+/// [`MemoryError::NotFound`] inline because those map to a soft
+/// `ToolResult::error` so the LLM can adapt; everything else flows
+/// through this function.
 fn map_memory_error(err: MemoryError) -> ToolError {
     match err {
         MemoryError::Io { context, source } => ToolError::Io { context, source },
-        MemoryError::Yaml { path, source } => ToolError::Io {
-            context: format!("yaml at {path}"),
-            source: std::io::Error::other(source.to_string()),
-        },
-        other => ToolError::Io {
-            context: "memory store".to_owned(),
-            source: std::io::Error::other(other.to_string()),
-        },
+        // Frontmatter / YAML / Type / Description failures are user-
+        // input errors from the LLM's perspective, not I/O failures.
+        MemoryError::InvalidFrontmatter { path, reason } => {
+            ToolError::invalid_params(format!("invalid frontmatter at {path}: {reason}"))
+        }
+        MemoryError::InvalidType { path, value } => ToolError::invalid_params(format!(
+            "invalid memory type {value:?} at {path}: must be one of user, feedback, project, reference",
+        )),
+        MemoryError::InvalidDescription { reason } => ToolError::invalid_params(reason),
+        MemoryError::Yaml { path, source } => {
+            ToolError::invalid_params(format!("yaml error at {path}: {source}"))
+        }
+        // The handlers route AlreadyExists / NotFound / InvalidName
+        // before calling here; if any reach this fallthrough it is a
+        // bug, but surface a useful message anyway.
+        other @ (MemoryError::AlreadyExists { .. }
+        | MemoryError::NotFound { .. }
+        | MemoryError::InvalidName { .. }) => ToolError::invalid_params(other.to_string()),
     }
 }
 
@@ -509,6 +607,146 @@ mod tests {
             res.output.contains("near capacity"),
             "expected capacity nudge, got: {}",
             res.output
+        );
+    }
+
+    /// Regression test for issue #4 of PR #76: after a successful
+    /// `add` / `update` / `remove`, the registered refresh callback
+    /// fires with the freshly-rendered merged index so the agent loop
+    /// can re-inject it into the system prompt.
+    #[tokio::test]
+    async fn refresh_callback_fires_after_successful_writes() {
+        use std::sync::Mutex;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = make_store(dir.path());
+        let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let received_clone = Arc::clone(&received);
+        let cb: super::MemoryRefreshCallback = Arc::new(move |index: &str| {
+            received_clone.lock().expect("lock").push(index.to_owned());
+        });
+        let tool = MemoryTool::with_refresh(Arc::clone(&store), cb);
+        let ctx = SandboxContext::test_default();
+
+        // add
+        let _ = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "topic_one",
+                    "type": "project",
+                    "description": "first",
+                    "content": "body",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("add");
+        // update
+        let _ = tool
+            .execute(
+                serde_json::json!({
+                    "action": "update",
+                    "name": "topic_one",
+                    "description": "renamed",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("update");
+        // remove
+        let _ = tool
+            .execute(
+                serde_json::json!({
+                    "action": "remove",
+                    "name": "topic_one",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("remove");
+
+        let received = received.lock().expect("lock");
+        assert_eq!(
+            received.len(),
+            3,
+            "expected 3 callback invocations (one per write), got {}: {received:?}",
+            received.len(),
+        );
+        // First snapshot: contains topic_one with "first" desc.
+        assert!(received[0].contains("topic_one"));
+        assert!(received[0].contains("first"));
+        // Second snapshot: still contains topic_one but renamed.
+        assert!(received[1].contains("topic_one"));
+        assert!(received[1].contains("renamed"));
+        // Third snapshot: topic_one removed.
+        assert!(!received[2].contains("topic_one"));
+    }
+
+    /// Regression test for issue #1 of PR #76: `add(name="MEMORY")`
+    /// must be rejected at validation time so the index file cannot
+    /// be overwritten by an entry that shares its stem.
+    #[tokio::test]
+    async fn add_with_reserved_name_is_invalid_params() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = make_store(dir.path());
+        let tool = MemoryTool::new(store);
+        let ctx = SandboxContext::test_default();
+        let err = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "MEMORY",
+                    "type": "project",
+                    "description": "should fail",
+                    "content": "body",
+                }),
+                &ctx,
+            )
+            .await
+            .expect_err("MEMORY must be rejected");
+        assert!(
+            matches!(err, ToolError::InvalidParams { .. }),
+            "expected InvalidParams, got {err:?}",
+        );
+    }
+
+    /// Regression test for issue #9 of PR #76: oversized bodies must
+    /// be rejected BEFORE the store write so the entry file never
+    /// lands on disk in an over-budget state.
+    #[tokio::test]
+    async fn oversized_body_is_rejected_before_write() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let small = MemoryBudget {
+            index_max_lines: 200,
+            entry_max_chars: 10,
+            total_files_limit: 50,
+        };
+        let store = Arc::new(MemoryStore::with_dirs(
+            dir.path().join(".tsumugi").join("memory"),
+            None,
+            small,
+        ));
+        let tool = MemoryTool::new(Arc::clone(&store));
+        let ctx = SandboxContext::test_default();
+        let res = tool
+            .execute(
+                serde_json::json!({
+                    "action": "add",
+                    "name": "big",
+                    "type": "project",
+                    "description": "d",
+                    "content": "this body is way over the ten-character limit",
+                }),
+                &ctx,
+            )
+            .await
+            .expect("call");
+        assert!(res.is_error, "oversized body must be a soft error result");
+        // The entry file must NOT exist on disk.
+        let entry_path = dir.path().join(".tsumugi").join("memory").join("big.md");
+        assert!(
+            !entry_path.exists(),
+            "oversized entry file should not have been written",
         );
     }
 

--- a/crates/tmg-skills/src/slash.rs
+++ b/crates/tmg-skills/src/slash.rs
@@ -124,6 +124,7 @@ pub fn parse_slash_command(input: &str) -> SlashParseResult {
         "agents" => return Ok(Some(SlashCommand::ListAgents)),
         "workflows" => return Ok(Some(SlashCommand::ListWorkflows)),
         "run" => return parse_run_subcommand(args.as_deref()).map(Some),
+        "memory" => return Ok(Some(parse_memory_subcommand(args.as_deref()))),
         _ => {}
     }
 
@@ -189,6 +190,30 @@ fn parse_run_subcommand(args: Option<&str>) -> Result<SlashCommand, SlashParseEr
         "abort" => Ok(SlashCommand::RunAbort),
         other => Err(SlashParseError::UnknownRunSubcommand(other.to_owned())),
     }
+}
+
+/// Parse the body of a `/memory ...` invocation.
+///
+/// `/memory` (no body) → [`SlashCommand::MemoryIndex`].
+/// `/memory show <name>` → [`SlashCommand::MemoryShow`].
+/// Anything else falls back to `MemoryIndex` so the user always gets
+/// a useful response (the malformed shape is documented in the body
+/// the TUI prints).
+fn parse_memory_subcommand(args: Option<&str>) -> SlashCommand {
+    let body = args.unwrap_or("").trim();
+    if body.is_empty() {
+        return SlashCommand::MemoryIndex;
+    }
+    let (sub, rest) = match body.split_once(char::is_whitespace) {
+        Some((s, r)) => (s, r.trim()),
+        None => (body, ""),
+    };
+    if sub == "show" && !rest.is_empty() {
+        return SlashCommand::MemoryShow {
+            name: rest.to_owned(),
+        };
+    }
+    SlashCommand::MemoryIndex
 }
 
 /// Format a list of skills for display (e.g. in TUI).
@@ -400,6 +425,24 @@ mod tests {
             SlashParseError::UnknownRunSubcommand(rest) => assert_eq!(rest, "bogus"),
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_memory_bare() {
+        assert_eq!(
+            parse_slash_command("/memory").expect("ok"),
+            Some(SlashCommand::MemoryIndex)
+        );
+    }
+
+    #[test]
+    fn parse_memory_show() {
+        assert_eq!(
+            parse_slash_command("/memory show topic_one").expect("ok"),
+            Some(SlashCommand::MemoryShow {
+                name: "topic_one".to_owned(),
+            })
+        );
     }
 
     #[test]

--- a/crates/tmg-skills/src/types.rs
+++ b/crates/tmg-skills/src/types.rs
@@ -258,4 +258,13 @@ pub enum SlashCommand {
     /// `/run abort` — flip the active run to `Failed { reason: "user
     /// aborted" }`.
     RunAbort,
+
+    // ---- /memory subcommands (issue #52) --------------------------------
+    /// `/memory` — show the merged memory index.
+    MemoryIndex,
+    /// `/memory show <name>` — show one entry's body.
+    MemoryShow {
+        /// Topic name.
+        name: String,
+    },
 }

--- a/crates/tmg-tui/Cargo.toml
+++ b/crates/tmg-tui/Cargo.toml
@@ -10,6 +10,7 @@ tmg-core = { workspace = true }
 tmg-llm = { workspace = true }
 tmg-agents = { workspace = true }
 tmg-harness = { workspace = true }
+tmg-memory = { workspace = true }
 tmg-skills = { workspace = true }
 tmg-workflow = { workspace = true }
 ratatui = { workspace = true }

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -8,6 +8,7 @@ use tmg_agents::{AgentType, CustomAgentDef, SubagentManager, truncate_str};
 use tmg_core::{AgentLoop, CoreError, StreamSink, format_context_usage};
 use tmg_harness::{HarnessStreamSink, RunProgressEvent, RunRunner, RunSummary};
 use tmg_llm::Role;
+use tmg_memory::MemoryStore;
 use tmg_skills::{SkillMeta, SlashCommand};
 use tmg_workflow::{WorkflowMeta, WorkflowProgress};
 use tokio::sync::Mutex;
@@ -272,6 +273,12 @@ pub struct App {
     /// [`Self::dispatch_slash`] (`SlashDispatch::Async`) and
     /// drained by the event loop on the next tick.
     pending_slash: Option<SlashCommand>,
+
+    /// Optional memory store for `/memory` slash commands. Constructed
+    /// once in `tmg-cli::run_tui` and shared with the `MemoryTool` on
+    /// the registry so the TUI display path and the LLM's tool calls
+    /// see exactly the same on-disk state.
+    memory_store: Option<Arc<MemoryStore>>,
 }
 
 impl App {
@@ -316,7 +323,15 @@ impl App {
             workflows: Vec::new(),
             skills: Vec::new(),
             pending_slash: None,
+            memory_store: None,
         }
+    }
+
+    /// Install the shared memory store so the `/memory` slash commands
+    /// can render index / entries without round-tripping through the
+    /// LLM. When unset (or `None`), `/memory` reports memory disabled.
+    pub fn set_memory_store(&mut self, store: Arc<MemoryStore>) {
+        self.memory_store = Some(store);
     }
 
     /// Dequeue any pending async slash command so the event loop can
@@ -819,6 +834,12 @@ impl App {
             SlashCommand::ListWorkflows => {
                 self.show_workflows_list();
             }
+            SlashCommand::MemoryIndex => {
+                self.show_memory_index();
+            }
+            SlashCommand::MemoryShow { name } => {
+                self.show_memory_entry(&name);
+            }
             // The /run family and /<skill> need async work (harness
             // mutex, workflow tools). Defer to the event loop.
             other @ (SlashCommand::RunStart { .. }
@@ -920,6 +941,64 @@ impl App {
             role: Role::System,
             text,
         });
+    }
+
+    /// Render the merged memory index in the chat pane.
+    fn show_memory_index(&mut self) {
+        let Some(store) = self.memory_store.as_ref() else {
+            self.error_message =
+                Some("memory is disabled; enable [memory] in tsumugi.toml".to_owned());
+            return;
+        };
+        match store.read_merged_index() {
+            Ok(index) if !index.trim().is_empty() => {
+                let mut text = String::from("Memory index:\n\n");
+                text.push_str(&index);
+                self.chat_entries.push(ChatEntry {
+                    role: Role::System,
+                    text,
+                });
+            }
+            Ok(_) => {
+                self.chat_entries.push(ChatEntry {
+                    role: Role::System,
+                    text: "(memory is empty — use the `memory` tool's `add` action or \
+                          `tmg memory edit <name>`)"
+                        .to_owned(),
+                });
+            }
+            Err(e) => {
+                self.error_message = Some(format!("failed to read memory index: {e}"));
+            }
+        }
+    }
+
+    /// Render one memory entry in the chat pane.
+    fn show_memory_entry(&mut self, name: &str) {
+        let Some(store) = self.memory_store.as_ref() else {
+            self.error_message =
+                Some("memory is disabled; enable [memory] in tsumugi.toml".to_owned());
+            return;
+        };
+        match store.read(name) {
+            Ok((entry, scope)) => {
+                let mut text = format!(
+                    "[{}] {} ({}) — {}\n\n",
+                    scope.as_str(),
+                    entry.frontmatter.name,
+                    entry.frontmatter.kind,
+                    entry.frontmatter.description,
+                );
+                text.push_str(&entry.body);
+                self.chat_entries.push(ChatEntry {
+                    role: Role::System,
+                    text,
+                });
+            }
+            Err(e) => {
+                self.error_message = Some(format!("memory: {e}"));
+            }
+        }
     }
 
     /// Append a system message describing slash-command output (e.g. a

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -32,6 +32,7 @@ use crossterm::execute;
 use tmg_agents::{CustomAgentDef, SubagentManager};
 use tmg_core::AgentLoop;
 use tmg_harness::{RunProgressReceiver, RunRunner, RunSummary};
+use tmg_memory::MemoryStore;
 use tmg_skills::SkillMeta;
 use tmg_workflow::{WorkflowMeta, WorkflowProgress};
 use tokio::sync::{Mutex, mpsc};
@@ -93,6 +94,7 @@ pub async fn run(
     workflow_progress_rx: Option<mpsc::Receiver<WorkflowProgress>>,
     workflows: Vec<WorkflowMeta>,
     skills: Vec<SkillMeta>,
+    memory_store: Option<Arc<MemoryStore>>,
 ) -> Result<(), TuiError> {
     // Pre-warm the syntect bundle off the rendering thread. Loading
     // `SyntaxSet::load_defaults_newlines` + `ThemeSet::load_defaults`
@@ -167,6 +169,10 @@ pub async fn run(
 
     if !skills.is_empty() {
         app.set_skills(skills);
+    }
+
+    if let Some(store) = memory_store {
+        app.set_memory_store(store);
     }
 
     let result = event::run_event_loop(&mut terminal, &mut app, cancel).await;

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -29,6 +29,7 @@ tmg-agents = { workspace = true }
 tmg-core = { workspace = true }
 tmg-harness = { workspace = true }
 tmg-llm = { workspace = true }
+tmg-memory = { workspace = true }
 tmg-sandbox = { workspace = true }
 tmg-skills = { workspace = true }
 tmg-tools = { workspace = true }

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -552,6 +552,54 @@ fn parse_humantime_duration(field: &str, value: &str) -> Result<std::time::Durat
 
 /// Partial top-level config used for deserialization and merging.
 ///
+/// Partial memory config used for deserialization / merging. Each
+/// field is `Option` so a partial layer can override one knob without
+/// resetting the others to their defaults.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PartialMemoryConfig {
+    pub enabled: Option<bool>,
+    pub project_dir: Option<PathBuf>,
+    pub global_dir: Option<PathBuf>,
+    pub index_max_lines: Option<usize>,
+    pub entry_max_chars: Option<usize>,
+    pub total_files_limit: Option<usize>,
+}
+
+impl PartialMemoryConfig {
+    fn merge_from(&mut self, other: &Self) {
+        if other.enabled.is_some() {
+            self.enabled = other.enabled;
+        }
+        if other.project_dir.is_some() {
+            self.project_dir.clone_from(&other.project_dir);
+        }
+        if other.global_dir.is_some() {
+            self.global_dir.clone_from(&other.global_dir);
+        }
+        if other.index_max_lines.is_some() {
+            self.index_max_lines = other.index_max_lines;
+        }
+        if other.entry_max_chars.is_some() {
+            self.entry_max_chars = other.entry_max_chars;
+        }
+        if other.total_files_limit.is_some() {
+            self.total_files_limit = other.total_files_limit;
+        }
+    }
+
+    fn into_final(self) -> MemoryConfig {
+        let defaults = MemoryConfig::default();
+        MemoryConfig {
+            enabled: self.enabled.unwrap_or(defaults.enabled),
+            project_dir: self.project_dir.unwrap_or(defaults.project_dir),
+            global_dir: self.global_dir.unwrap_or(defaults.global_dir),
+            index_max_lines: self.index_max_lines.unwrap_or(defaults.index_max_lines),
+            entry_max_chars: self.entry_max_chars.unwrap_or(defaults.entry_max_chars),
+            total_files_limit: self.total_files_limit.unwrap_or(defaults.total_files_limit),
+        }
+    }
+}
+
 /// Deserialized from TOML, merged across sources, then converted to
 /// the final [`TsumugiConfig`] via [`into_final`](Self::into_final).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -568,6 +616,8 @@ struct PartialTsumugiConfig {
     pub harness: PartialHarnessConfig,
     #[serde(default)]
     pub workflow: PartialWorkflowConfig,
+    #[serde(default)]
+    pub memory: PartialMemoryConfig,
 }
 
 impl PartialTsumugiConfig {
@@ -580,6 +630,7 @@ impl PartialTsumugiConfig {
         self.skills.merge_from(&other.skills);
         self.harness.merge_from(&other.harness);
         self.workflow.merge_from(&other.workflow);
+        self.memory.merge_from(&other.memory);
     }
 
     /// Apply environment variable overrides (`TMG_*` prefix).
@@ -863,6 +914,7 @@ impl PartialTsumugiConfig {
             skills: self.skills.into_final(),
             harness: self.harness.into_final()?,
             workflow: self.workflow.into_final()?,
+            memory: self.memory.into_final(),
         })
     }
 }
@@ -1198,6 +1250,109 @@ pub struct TsumugiConfig {
     /// Workflow runtime settings (SPEC §8 / issue #39).
     #[serde(default)]
     pub workflow: tmg_workflow::WorkflowConfig,
+
+    /// Memory layer settings (issue #52).
+    #[serde(default)]
+    pub memory: MemoryConfig,
+}
+
+/// `[memory]` section: project-scoped persistent memory configuration.
+///
+/// Mirrors [`tmg_memory::MemoryBudget`] for the capacity caps and adds
+/// the directory overrides that let operators relocate the project /
+/// global stores. An empty `global_dir` falls back to
+/// `~/.config/tsumugi/memory/` via [`dirs::config_dir`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryConfig {
+    /// Master switch — `false` keeps the tool unregistered and skips
+    /// the prompt injection.
+    #[serde(default = "default_memory_enabled")]
+    pub enabled: bool,
+    /// Project memory directory, relative to the project root or
+    /// absolute. Defaults to `.tsumugi/memory`.
+    #[serde(default = "default_memory_project_dir")]
+    pub project_dir: PathBuf,
+    /// Global memory directory. Empty (or `""`) means "use
+    /// `~/.config/tsumugi/memory`".
+    #[serde(default)]
+    pub global_dir: PathBuf,
+    /// Maximum number of lines in `MEMORY.md`.
+    #[serde(default = "default_memory_index_max_lines")]
+    pub index_max_lines: usize,
+    /// Maximum body character count per entry.
+    #[serde(default = "default_memory_entry_max_chars")]
+    pub entry_max_chars: usize,
+    /// Maximum number of memory files (excluding the index).
+    #[serde(default = "default_memory_total_files_limit")]
+    pub total_files_limit: usize,
+}
+
+const fn default_memory_enabled() -> bool {
+    true
+}
+
+fn default_memory_project_dir() -> PathBuf {
+    PathBuf::from(".tsumugi/memory")
+}
+
+const fn default_memory_index_max_lines() -> usize {
+    200
+}
+
+const fn default_memory_entry_max_chars() -> usize {
+    600
+}
+
+const fn default_memory_total_files_limit() -> usize {
+    50
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_memory_enabled(),
+            project_dir: default_memory_project_dir(),
+            global_dir: PathBuf::new(),
+            index_max_lines: default_memory_index_max_lines(),
+            entry_max_chars: default_memory_entry_max_chars(),
+            total_files_limit: default_memory_total_files_limit(),
+        }
+    }
+}
+
+impl MemoryConfig {
+    /// Resolve `project_dir` against `project_root` (relative paths
+    /// only) and return the absolute path.
+    #[must_use]
+    pub fn resolve_project_dir(&self, project_root: &Path) -> PathBuf {
+        if self.project_dir.is_absolute() {
+            self.project_dir.clone()
+        } else {
+            project_root.join(&self.project_dir)
+        }
+    }
+
+    /// Resolve `global_dir` to a concrete path. An empty path falls
+    /// back to `~/.config/tsumugi/memory`. Returns `None` when neither
+    /// the override nor the platform config dir is available.
+    #[must_use]
+    pub fn resolve_global_dir(&self) -> Option<PathBuf> {
+        if self.global_dir.as_os_str().is_empty() {
+            dirs::config_dir().map(|d| d.join("tsumugi").join("memory"))
+        } else {
+            Some(self.global_dir.clone())
+        }
+    }
+
+    /// Build the [`tmg_memory::MemoryBudget`] from the configured caps.
+    #[must_use]
+    pub fn to_budget(&self) -> tmg_memory::MemoryBudget {
+        tmg_memory::MemoryBudget {
+            index_max_lines: self.index_max_lines,
+            entry_max_chars: self.entry_max_chars,
+            total_files_limit: self.total_files_limit,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -14,6 +14,7 @@ mod config;
 mod error;
 mod harness_init;
 mod init_command;
+mod memory_commands;
 mod pool_setup;
 mod run_commands;
 mod workflow_commands;
@@ -104,6 +105,29 @@ enum Command {
     },
     /// Scaffold a `.tsumugi/` directory from the built-in templates.
     Init(InitArgs),
+    /// Inspect or edit the project memory store (issue #52).
+    Memory {
+        /// Sub-operation on the memory store.
+        #[command(subcommand)]
+        op: MemoryCommand,
+    },
+}
+
+/// Operations under `tmg memory`. Issue #52.
+#[derive(Subcommand, Debug)]
+enum MemoryCommand {
+    /// List entry names in the project memory store.
+    List,
+    /// Print the body of a single memory entry.
+    Show {
+        /// Topic name (file stem, without `.md`).
+        name: String,
+    },
+    /// Open the named entry in `$EDITOR` for manual editing.
+    Edit {
+        /// Topic name (file stem). Created on first save.
+        name: String,
+    },
 }
 
 /// Operations under `tmg workflow`. SPEC §8.13.
@@ -268,6 +292,7 @@ fn main() -> anyhow::Result<()> {
         Some(Command::Init(args)) => {
             init_command::cmd_init(&args.workflows, &args.harness, args.all, args.force)
         }
+        Some(Command::Memory { op }) => dispatch_memory_command(op, &config),
         None => {
             if let Some(prompt) = cli.prompt {
                 run_prompt(
@@ -275,6 +300,7 @@ fn main() -> anyhow::Result<()> {
                     &config.llm.model,
                     &prompt,
                     cli.event_log.as_deref(),
+                    &config.memory,
                 )
             } else {
                 run_tui(
@@ -287,6 +313,7 @@ fn main() -> anyhow::Result<()> {
                     &config.sandbox,
                     &config.workflow,
                     &config.skills,
+                    &config.memory,
                     config.llm.subagent_pool.as_ref(),
                     None,
                 )
@@ -332,6 +359,39 @@ fn resolve_runs_dir(harness_config: &HarnessConfig) -> anyhow::Result<(PathBuf, 
         canonical_cwd.join(&harness_config.runs_dir)
     };
     Ok((runs_dir, canonical_cwd))
+}
+
+/// Dispatch one `tmg memory <op>` invocation.
+fn dispatch_memory_command(op: MemoryCommand, config: &TsumugiConfig) -> anyhow::Result<()> {
+    memory_commands::dispatch(op, config)
+}
+
+/// Read the merged `MEMORY.md` index from the configured memory dirs
+/// and render it with the prompt header [`tmg_core::prompt::MEMORY_PROMPT_HEADER`].
+///
+/// Returns an empty string when the index does not exist or both
+/// directories are absent — callers can fall through to a no-op
+/// injection without inspecting the result further.
+fn load_memory_index_for_prompt(memory_config: &config::MemoryConfig) -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    let canonical = cwd.canonicalize().unwrap_or(cwd);
+    let project_dir = memory_config.resolve_project_dir(&canonical);
+    let global_dir = memory_config.resolve_global_dir();
+    let store =
+        tmg_memory::MemoryStore::with_dirs(project_dir, global_dir, memory_config.to_budget());
+    let index = store.read_merged_index().ok()?;
+    let trimmed = index.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let report = store.budget_report().ok();
+    let mut out = format!("{}\n\n{}", tmg_core::prompt::MEMORY_PROMPT_HEADER, trimmed);
+    if let Some(r) = report
+        && let Some(nudge) = tmg_memory::capacity_nudge(&r, store.budget())
+    {
+        out.push_str(&nudge);
+    }
+    Some(out)
 }
 
 /// Dispatch one `tmg workflow <op>` invocation. None of these
@@ -404,6 +464,7 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
                 &config.sandbox,
                 &config.workflow,
                 &config.skills,
+                &config.memory,
                 config.llm.subagent_pool.as_ref(),
                 resolved.as_ref(),
             )
@@ -462,6 +523,7 @@ fn run_prompt(
     model: &str,
     prompt: &str,
     event_log: Option<&std::path::Path>,
+    memory_config: &config::MemoryConfig,
 ) -> anyhow::Result<()> {
     use std::io::Write as _;
     use tokio_stream::StreamExt as _;
@@ -471,17 +533,37 @@ fn run_prompt(
         .transpose()
         .context("opening event log file")?;
 
+    // One-shot mode reads memory normally so the LLM has the same
+    // context block the TUI sees. Writes via the `memory` tool are
+    // not available here (no agent loop / tool dispatch in this
+    // streaming-only path), but reads through the index header still
+    // surface to the model.
+    let memory_block = if memory_config.enabled {
+        load_memory_index_for_prompt(memory_config).unwrap_or_default()
+    } else {
+        String::new()
+    };
+
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let config = tmg_llm::LlmClientConfig::new(endpoint, model);
         let client = tmg_llm::LlmClient::new(config)?;
 
-        let messages = vec![tmg_llm::ChatMessage {
+        let mut messages = Vec::with_capacity(2);
+        if !memory_block.is_empty() {
+            messages.push(tmg_llm::ChatMessage {
+                role: tmg_llm::Role::System,
+                content: Some(memory_block),
+                tool_calls: None,
+                tool_call_id: None,
+            });
+        }
+        messages.push(tmg_llm::ChatMessage {
             role: tmg_llm::Role::User,
             content: Some(prompt.to_owned()),
             tool_calls: None,
             tool_call_id: None,
-        }];
+        });
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let mut stream = client.chat_streaming(messages, vec![], cancel).await?;
@@ -560,6 +642,7 @@ fn run_tui(
     sandbox_config: &SandboxConfigSection,
     workflow_config: &tmg_workflow::WorkflowConfig,
     skills_config: &tmg_skills::SkillsConfig,
+    memory_config: &config::MemoryConfig,
     subagent_pool: Option<&tmg_llm::PoolConfig>,
     explicit_run_id: Option<&tmg_harness::RunId>,
 ) -> anyhow::Result<()> {
@@ -783,12 +866,27 @@ fn run_tui(
             .await
             .set_run_tool_provider(Some(Arc::clone(&run_tool_provider)));
 
-        // Create the tool registry: built-ins, then spawn_agent, then
-        // the Run-scoped harness tools. `register_run_tools` is the
-        // single authoritative place where the harnessed-vs-ad-hoc
-        // tool set is decided; the CLI does not branch on `scope()`
-        // itself so the gating logic lives in one place.
+        // Build the project memory store from `[memory]` config so the
+        // `memory` tool and the prompt injection share one source of
+        // truth. Construction is cheap (no I/O) and is always done so
+        // the index can be re-read mid-session by the slash-command
+        // path without re-parsing config.
+        let memory_store = Arc::new(tmg_memory::MemoryStore::with_dirs(
+            memory_config.resolve_project_dir(&canonical_cwd),
+            memory_config.resolve_global_dir(),
+            memory_config.to_budget(),
+        ));
+
+        // Create the tool registry: built-ins, then `memory`, then
+        // spawn_agent, then the Run-scoped harness tools.
+        // `register_run_tools` is the single authoritative place where
+        // the harnessed-vs-ad-hoc tool set is decided; the CLI does
+        // not branch on `scope()` itself so the gating logic lives in
+        // one place.
         let mut registry = tmg_tools::default_registry();
+        if memory_config.enabled {
+            registry.register(tmg_memory::MemoryTool::new(Arc::clone(&memory_store)));
+        }
         registry.register(tmg_agents::SpawnAgentTool::with_custom_agents(
             Arc::clone(&subagent_manager),
             custom_agent_defs.clone(),
@@ -920,6 +1018,35 @@ fn run_tui(
             Arc::clone(&sandbox_ctx),
         )?;
 
+        // Inject the memory index into the system prompt for this
+        // session. Reading the merged index is best-effort: an I/O
+        // error here downgrades to "no memory in prompt" so the agent
+        // still starts. The capacity nudge is appended when the store
+        // is at or above the configured caps so the agent knows to
+        // curate before adding new entries.
+        if memory_config.enabled {
+            match memory_store.read_merged_index() {
+                Ok(index) if !index.trim().is_empty() => {
+                    let report = memory_store.budget_report().ok();
+                    let mut payload = index.trim().to_owned();
+                    if let Some(r) = report
+                        && let Some(nudge) =
+                            tmg_memory::capacity_nudge(&r, memory_store.budget())
+                    {
+                        payload.push_str(&nudge);
+                    }
+                    agent.set_memory_index(Some(payload));
+                    agent.inject_memory_index_now();
+                }
+                Ok(_) => {
+                    // Index empty / absent: nothing to inject.
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to read memory index for prompt");
+                }
+            }
+        }
+
         // Wire the auto-promotion gate (issue #37): after every turn,
         // the harness observer records the turn metrics into
         // `RunRunner::session_state` so the
@@ -969,6 +1096,11 @@ fn run_tui(
             };
 
         let tui_cancel = cancel.clone();
+        let memory_store_for_tui = if memory_config.enabled {
+            Some(Arc::clone(&memory_store))
+        } else {
+            None
+        };
         let tui_result = tmg_tui::run(
             agent,
             model,
@@ -984,6 +1116,7 @@ fn run_tui(
             workflow_progress_rx,
             workflow_metas.clone(),
             skill_metas,
+            memory_store_for_tui,
         )
         .await;
 

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -292,7 +292,9 @@ fn main() -> anyhow::Result<()> {
         Some(Command::Init(args)) => {
             init_command::cmd_init(&args.workflows, &args.harness, args.all, args.force)
         }
-        Some(Command::Memory { op }) => dispatch_memory_command(op, &config),
+        Some(Command::Memory { op }) => {
+            dispatch_memory_command(op, &config, cli.event_log.as_deref())
+        }
         None => {
             if let Some(prompt) = cli.prompt {
                 run_prompt(
@@ -301,6 +303,9 @@ fn main() -> anyhow::Result<()> {
                     &prompt,
                     cli.event_log.as_deref(),
                     &config.memory,
+                    &config.sandbox,
+                    context_config,
+                    config.llm.tool_calling,
                 )
             } else {
                 run_tui(
@@ -362,37 +367,19 @@ fn resolve_runs_dir(harness_config: &HarnessConfig) -> anyhow::Result<(PathBuf, 
 }
 
 /// Dispatch one `tmg memory <op>` invocation.
-fn dispatch_memory_command(op: MemoryCommand, config: &TsumugiConfig) -> anyhow::Result<()> {
-    memory_commands::dispatch(op, config)
+fn dispatch_memory_command(
+    op: MemoryCommand,
+    config: &TsumugiConfig,
+    event_log: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    memory_commands::dispatch(op, config, event_log)
 }
 
-/// Read the merged `MEMORY.md` index from the configured memory dirs
-/// and render it with the prompt header [`tmg_core::prompt::MEMORY_PROMPT_HEADER`].
-///
-/// Returns an empty string when the index does not exist or both
-/// directories are absent — callers can fall through to a no-op
-/// injection without inspecting the result further.
-fn load_memory_index_for_prompt(memory_config: &config::MemoryConfig) -> Option<String> {
-    let cwd = std::env::current_dir().ok()?;
-    let canonical = cwd.canonicalize().unwrap_or(cwd);
-    let project_dir = memory_config.resolve_project_dir(&canonical);
-    let global_dir = memory_config.resolve_global_dir();
-    let store =
-        tmg_memory::MemoryStore::with_dirs(project_dir, global_dir, memory_config.to_budget());
-    let index = store.read_merged_index().ok()?;
-    let trimmed = index.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    let report = store.budget_report().ok();
-    let mut out = format!("{}\n\n{}", tmg_core::prompt::MEMORY_PROMPT_HEADER, trimmed);
-    if let Some(r) = report
-        && let Some(nudge) = tmg_memory::capacity_nudge(&r, store.budget())
-    {
-        out.push_str(&nudge);
-    }
-    Some(out)
-}
+// `load_memory_index_for_prompt` was the bespoke helper used by the
+// pre-AgentLoop one-shot path. Issue #2 of PR #76 review moved
+// one-shot mode through the full agent loop, which already injects
+// the index via `AgentLoop::inject_memory_index_now`, so the helper
+// is no longer needed.
 
 /// Dispatch one `tmg workflow <op>` invocation. None of these
 /// operations attach to an active TUI; they all read or run workflows
@@ -512,11 +499,13 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
 
 /// Run a one-shot streaming prompt against the LLM server.
 ///
-/// This function is the integration check for issue #2: it sends a prompt
-/// to the llama-server and streams the response token-by-token to stdout.
+/// One-shot mode runs through the full [`tmg_core::AgentLoop`] (issue
+/// #2 of PR #76 review) so memory `add` / `read` and the standard
+/// file/grep tool surface are available the same way they are in the
+/// TUI. Output is streamed to stdout via a custom [`StdoutSink`].
 #[expect(
-    clippy::print_stdout,
-    reason = "integration check: intentional stdout streaming output"
+    clippy::too_many_arguments,
+    reason = "linear setup helper takes the merged config sections as discrete refs"
 )]
 fn run_prompt(
     endpoint: &str,
@@ -524,88 +513,258 @@ fn run_prompt(
     prompt: &str,
     event_log: Option<&std::path::Path>,
     memory_config: &config::MemoryConfig,
+    sandbox_config: &SandboxConfigSection,
+    context_config: tmg_core::ContextConfig,
+    tool_calling_mode: tmg_llm::ToolCallingMode,
 ) -> anyhow::Result<()> {
-    use std::io::Write as _;
-    use tokio_stream::StreamExt as _;
-
-    let mut log_writer = event_log
-        .map(tmg_core::EventLogWriter::new)
-        .transpose()
-        .context("opening event log file")?;
-
-    // One-shot mode reads memory normally so the LLM has the same
-    // context block the TUI sees. Writes via the `memory` tool are
-    // not available here (no agent loop / tool dispatch in this
-    // streaming-only path), but reads through the index header still
-    // surface to the model.
-    let memory_block = if memory_config.enabled {
-        load_memory_index_for_prompt(memory_config).unwrap_or_default()
-    } else {
-        String::new()
-    };
-
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let config = tmg_llm::LlmClientConfig::new(endpoint, model);
         let client = tmg_llm::LlmClient::new(config)?;
 
-        let mut messages = Vec::with_capacity(2);
-        if !memory_block.is_empty() {
-            messages.push(tmg_llm::ChatMessage {
-                role: tmg_llm::Role::System,
-                content: Some(memory_block),
-                tool_calls: None,
-                tool_call_id: None,
-            });
-        }
-        messages.push(tmg_llm::ChatMessage {
-            role: tmg_llm::Role::User,
-            content: Some(prompt.to_owned()),
-            tool_calls: None,
-            tool_call_id: None,
-        });
-
         let cancel = tokio_util::sync::CancellationToken::new();
-        let mut stream = client.chat_streaming(messages, vec![], cancel).await?;
+        let cwd = std::env::current_dir()?;
+        let canonical_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+        let project_root = canonical_cwd.clone();
 
-        while let Some(event) = stream.next().await {
-            match event? {
-                tmg_llm::StreamEvent::ThinkingDelta(token) => {
-                    if let Some(ref mut log) = log_writer {
-                        log.write_thinking(&token);
+        // Build the project memory store from the same `[memory]`
+        // config the TUI consumes, so one-shot mode and TUI agree on
+        // the index payload and the directory layout.
+        let memory_store = Arc::new(tmg_memory::MemoryStore::with_dirs(
+            memory_config.resolve_project_dir(&canonical_cwd),
+            memory_config.resolve_global_dir(),
+            memory_config.to_budget(),
+        ));
+
+        // Build the sandbox context from the operator's `[sandbox]`
+        // config. We don't `activate()` it because one-shot mode is
+        // expected to be the user's interactive integration smoke
+        // test; activating would require platform-specific privileges
+        // (Landlock, netns) that the user might not have.
+        let sandbox_ctx = Arc::new(tmg_sandbox::SandboxContext::new(
+            sandbox_config.to_sandbox_config(&canonical_cwd),
+        ));
+
+        // Build the tool registry: built-ins + (optionally) the memory
+        // tool. No subagent registration in one-shot mode because
+        // there's no Run/Workflow/Subagent context here; the goal is
+        // a self-contained tool surface that lets the model curate
+        // memory and read/write files.
+        let mut registry = tmg_tools::default_registry();
+        if memory_config.enabled {
+            registry.register(tmg_memory::MemoryTool::new(Arc::clone(&memory_store)));
+        }
+
+        let mut agent = tmg_core::AgentLoop::with_context_config(
+            client,
+            registry,
+            cancel.clone(),
+            &project_root,
+            &canonical_cwd,
+            context_config,
+            tool_calling_mode,
+            Arc::clone(&sandbox_ctx),
+        )?;
+
+        // Inject the memory index into the system prompt the same way
+        // the TUI does so the model sees the curated `MEMORY.md` rows
+        // before its first reply.
+        if memory_config.enabled {
+            match memory_store.read_merged_index() {
+                Ok(index) if !index.trim().is_empty() => {
+                    let report = memory_store.budget_report().ok();
+                    let mut payload = index.trim().to_owned();
+                    if let Some(r) = report
+                        && let Some(nudge) = tmg_memory::capacity_nudge(&r, memory_store.budget())
+                    {
+                        payload.push_str(&nudge);
                     }
-                    // Thinking tokens are not displayed in one-shot mode.
-                }
-                tmg_llm::StreamEvent::ContentDelta(text) => {
-                    if let Some(ref mut log) = log_writer {
-                        log.write_token(&text);
-                    }
-                    print!("{text}");
-                    std::io::stdout().flush()?;
-                }
-                tmg_llm::StreamEvent::ToolCallComplete(tc) => {
-                    if let Some(ref mut log) = log_writer {
-                        log.write_tool_call(&tc.function.name, &tc.function.arguments);
-                    }
-                    println!(
-                        "\n[tool_call] {}({})",
-                        tc.function.name, tc.function.arguments
+                    let summary = format!(
+                        "merged index: {} chars / {} lines",
+                        payload.len(),
+                        payload.lines().count(),
                     );
+                    agent.set_memory_index(Some(payload));
+                    agent.inject_memory_index_now();
+                    if let Some(path) = event_log
+                        && let Ok(mut writer) = tmg_core::EventLogWriter::open_append(path)
+                    {
+                        writer.write_memory("memory_prompt_inject", &summary);
+                    }
                 }
-                tmg_llm::StreamEvent::Done(reason) => {
-                    if let Some(ref mut log) = log_writer {
-                        log.write_done();
-                    }
-                    println!();
-                    if let Some(r) = reason {
-                        println!("[done: {r}]");
-                    }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to read memory index for one-shot prompt");
                 }
             }
         }
 
+        // The agent's `turn` method takes `&mut impl StreamSink` which
+        // is `Sized`, so we cannot use `Box<dyn StreamSink>` here.
+        // Branch on the event-log presence and call `turn` separately
+        // in each arm so the sink type is statically known.
+        if let Some(path) = event_log {
+            let log = tmg_core::EventLogWriter::new(path).context("opening event log file")?;
+            let mut sink = tmg_core::TeeStreamSink::new(StdoutSink::default(), log);
+            agent
+                .turn(prompt, &mut sink)
+                .await
+                .context("running one-shot agent turn")?;
+        } else {
+            let mut sink = StdoutSink::default();
+            agent
+                .turn(prompt, &mut sink)
+                .await
+                .context("running one-shot agent turn")?;
+        }
+
         Ok::<(), anyhow::Error>(())
     })
+}
+
+/// One-shot stdout sink that mirrors [`StreamEvent`] output to the
+/// terminal. Tool calls and warnings are surfaced as bracketed lines
+/// so the user can see what the agent is doing without the TUI.
+#[derive(Default)]
+struct StdoutSink {
+    /// True while the model is still emitting content tokens. Used to
+    /// add a newline before printing tool-call markers / warnings so
+    /// they don't fuse onto the same line as the streamed text.
+    streaming_text: bool,
+}
+
+impl tmg_core::agent_loop::StreamSink for StdoutSink {
+    #[expect(
+        clippy::print_stdout,
+        reason = "stdout is the contract for one-shot mode"
+    )]
+    fn on_token(&mut self, token: &str) -> Result<(), tmg_core::CoreError> {
+        use std::io::Write as _;
+        self.streaming_text = true;
+        print!("{token}");
+        let _ = std::io::stdout().flush();
+        Ok(())
+    }
+
+    #[expect(
+        clippy::print_stdout,
+        reason = "stdout is the contract for one-shot mode"
+    )]
+    fn on_done(&mut self) -> Result<(), tmg_core::CoreError> {
+        if self.streaming_text {
+            println!();
+            self.streaming_text = false;
+        }
+        Ok(())
+    }
+
+    #[expect(
+        clippy::print_stdout,
+        reason = "stdout is the contract for one-shot mode"
+    )]
+    fn on_tool_call(
+        &mut self,
+        _call_id: &str,
+        name: &str,
+        arguments: &str,
+    ) -> Result<(), tmg_core::CoreError> {
+        if self.streaming_text {
+            println!();
+            self.streaming_text = false;
+        }
+        println!("[tool_call] {name}({arguments})");
+        Ok(())
+    }
+
+    #[expect(
+        clippy::print_stdout,
+        reason = "stdout is the contract for one-shot mode"
+    )]
+    fn on_tool_result(
+        &mut self,
+        _call_id: &str,
+        name: &str,
+        output: &str,
+        is_error: bool,
+    ) -> Result<(), tmg_core::CoreError> {
+        let tag = if is_error {
+            "tool_error"
+        } else {
+            "tool_result"
+        };
+        // Truncate noisy tool output to one line so the terminal stays
+        // readable; the full payload is in the event log when one is
+        // configured.
+        let preview: String = output.chars().take(160).collect();
+        let suffix = if output.len() > preview.len() {
+            "…"
+        } else {
+            ""
+        };
+        println!("[{tag}] {name}: {preview}{suffix}");
+        Ok(())
+    }
+
+    #[expect(
+        clippy::print_stdout,
+        reason = "stdout is the contract for one-shot mode"
+    )]
+    fn on_warning(&mut self, message: &str) -> Result<(), tmg_core::CoreError> {
+        if self.streaming_text {
+            println!();
+            self.streaming_text = false;
+        }
+        println!("[warning] {message}");
+        Ok(())
+    }
+}
+
+/// Concrete [`tmg_agents::MemoryToolProvider`] used by the CLI to
+/// register a memory tool into every spawned subagent's registry.
+/// Issue #3 of PR #76 review: previously the memory tool was wired
+/// only into the top-level agent's registry, so subagents could not
+/// curate the project memory.
+///
+/// Each invocation constructs a fresh [`tmg_memory::MemoryTool`] that
+/// shares the parent's [`MemoryStore`] via `Arc` and the same
+/// pending-swap slot. When a subagent successfully writes through
+/// `memory`, the parent agent loop's next `turn` picks up the new
+/// snapshot just as if the parent had performed the write itself.
+struct CliMemoryToolProvider {
+    store: Arc<tmg_memory::MemoryStore>,
+    pending: Option<Arc<std::sync::Mutex<Option<String>>>>,
+}
+
+impl tmg_agents::MemoryToolProvider for CliMemoryToolProvider {
+    fn register_memory_tool(&self, registry: &mut tmg_tools::ToolRegistry) {
+        if let Some(slot) = self.pending.clone() {
+            let store_for_cb = Arc::clone(&self.store);
+            let cb: tmg_memory::tool::MemoryRefreshCallback = Arc::new(move |_index: &str| {
+                let snapshot = match store_for_cb.read_merged_index() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::debug!(
+                            error = %e,
+                            "subagent memory refresh: read_merged_index failed",
+                        );
+                        return;
+                    }
+                };
+                if let Ok(mut guard) = slot.lock() {
+                    *guard = Some(snapshot);
+                }
+            });
+            registry.register(tmg_memory::MemoryTool::with_refresh(
+                Arc::clone(&self.store),
+                cb,
+            ));
+        } else {
+            // No shared slot configured (memory was disabled for the
+            // top-level loop); register without a refresh hook so
+            // the subagent still has read access.
+            registry.register(tmg_memory::MemoryTool::new(Arc::clone(&self.store)));
+        }
+    }
 }
 
 /// Run the TUI-based interactive session.
@@ -877,6 +1036,32 @@ fn run_tui(
             memory_config.to_budget(),
         ));
 
+        // Shared pending-swap slot bridging the `memory` tool's
+        // refresh callback (which fires from the JoinSet task that
+        // dispatched the tool call) and the agent loop (which drains
+        // the slot at the top of every `turn`). When memory is
+        // disabled, we keep the option `None` so the agent loop's
+        // `set_pending_memory_index(None)` keeps the cost zero.
+        let pending_memory_index: Option<Arc<std::sync::Mutex<Option<String>>>> =
+            memory_config
+                .enabled
+                .then(|| Arc::new(std::sync::Mutex::new(None)));
+
+        // When memory is enabled, wire a [`MemoryToolProvider`] into
+        // the subagent manager so every spawned subagent's registry
+        // contains the `memory` tool. Issue #3 of PR #76 review.
+        if memory_config.enabled {
+            let provider: Arc<dyn tmg_agents::MemoryToolProvider> =
+                Arc::new(CliMemoryToolProvider {
+                    store: Arc::clone(&memory_store),
+                    pending: pending_memory_index.clone(),
+                });
+            subagent_manager
+                .lock()
+                .await
+                .set_memory_tool_provider(Some(provider));
+        }
+
         // Create the tool registry: built-ins, then `memory`, then
         // spawn_agent, then the Run-scoped harness tools.
         // `register_run_tools` is the single authoritative place where
@@ -885,7 +1070,42 @@ fn run_tui(
         // one place.
         let mut registry = tmg_tools::default_registry();
         if memory_config.enabled {
-            registry.register(tmg_memory::MemoryTool::new(Arc::clone(&memory_store)));
+            // Top-level agent gets a `MemoryTool` carrying a refresh
+            // callback that re-reads the merged index after every
+            // successful write and parks the snapshot in the shared
+            // pending-swap slot. The agent loop drains the slot at
+            // the top of its next `turn` so the LLM observes the
+            // post-mutation state. Issue #4 of PR #76 review.
+            let store_for_cb = Arc::clone(&memory_store);
+            let pending_for_cb = pending_memory_index.clone();
+            let cb: tmg_memory::tool::MemoryRefreshCallback =
+                Arc::new(move |_index: &str| {
+                    let Some(slot) = pending_for_cb.as_ref() else {
+                        return;
+                    };
+                    let snapshot = match store_for_cb.read_merged_index() {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::debug!(
+                                error = %e,
+                                "memory refresh: read_merged_index failed",
+                            );
+                            return;
+                        }
+                    };
+                    match slot.lock() {
+                        Ok(mut guard) => {
+                            *guard = Some(snapshot);
+                        }
+                        Err(e) => {
+                            tracing::debug!(error = %e, "memory refresh: pending slot poisoned");
+                        }
+                    }
+                });
+            registry.register(tmg_memory::MemoryTool::with_refresh(
+                Arc::clone(&memory_store),
+                cb,
+            ));
         }
         registry.register(tmg_agents::SpawnAgentTool::with_custom_agents(
             Arc::clone(&subagent_manager),
@@ -1025,6 +1245,12 @@ fn run_tui(
         // is at or above the configured caps so the agent knows to
         // curate before adding new entries.
         if memory_config.enabled {
+            // Plug the shared pending-swap slot into the agent loop
+            // BEFORE the first turn, so post-write refreshes from
+            // `MemoryTool::with_refresh` are picked up automatically.
+            // Issue #4 of PR #76 review.
+            agent.set_pending_memory_index(pending_memory_index.clone());
+
             match memory_store.read_merged_index() {
                 Ok(index) if !index.trim().is_empty() => {
                     let report = memory_store.budget_report().ok();
@@ -1035,8 +1261,21 @@ fn run_tui(
                     {
                         payload.push_str(&nudge);
                     }
+                    let summary = format!(
+                        "merged index: {} chars / {} lines",
+                        payload.len(),
+                        payload.lines().count(),
+                    );
                     agent.set_memory_index(Some(payload));
                     agent.inject_memory_index_now();
+                    // Issue #12 of PR #76 review: record prompt-time
+                    // memory injection so log readers can audit what
+                    // the LLM saw at the start of the session.
+                    if let Some(path) = event_log.as_deref()
+                        && let Ok(mut writer) = tmg_core::EventLogWriter::open_append(path)
+                    {
+                        writer.write_memory("memory_prompt_inject", &summary);
+                    }
                 }
                 Ok(_) => {
                     // Index empty / absent: nothing to inject.

--- a/tmg-cli/src/memory_commands.rs
+++ b/tmg-cli/src/memory_commands.rs
@@ -11,6 +11,7 @@ use std::process::Command;
 use std::sync::Arc;
 
 use anyhow::{Context as _, anyhow};
+use tmg_core::EventLogWriter;
 use tmg_memory::MemoryStore;
 
 use crate::config::{MemoryConfig, TsumugiConfig};
@@ -35,12 +36,17 @@ fn make_store(config: &MemoryConfig) -> anyhow::Result<Arc<MemoryStore>> {
     clippy::print_stdout,
     reason = "CLI subcommand: this is the documented stdout surface"
 )]
-pub fn cmd_list(config: &TsumugiConfig) -> anyhow::Result<()> {
+pub fn cmd_list(config: &TsumugiConfig, event_log: Option<&Path>) -> anyhow::Result<()> {
     if !config.memory.enabled {
         return Err(anyhow!("memory is disabled in [memory].enabled"));
     }
     let store = make_store(&config.memory)?;
     let names = store.list_project().context("listing project memory")?;
+    write_memory_event(
+        event_log,
+        "memory_list",
+        &format!("{} entries", names.len()),
+    );
     if names.is_empty() {
         println!("(no memory entries yet — use `tmg memory edit <name>` or the `memory` tool)");
         return Ok(());
@@ -56,7 +62,11 @@ pub fn cmd_list(config: &TsumugiConfig) -> anyhow::Result<()> {
     clippy::print_stdout,
     reason = "CLI subcommand: this is the documented stdout surface"
 )]
-pub fn cmd_show(config: &TsumugiConfig, name: &str) -> anyhow::Result<()> {
+pub fn cmd_show(
+    config: &TsumugiConfig,
+    name: &str,
+    event_log: Option<&Path>,
+) -> anyhow::Result<()> {
     if !config.memory.enabled {
         return Err(anyhow!("memory is disabled in [memory].enabled"));
     }
@@ -64,6 +74,11 @@ pub fn cmd_show(config: &TsumugiConfig, name: &str) -> anyhow::Result<()> {
     let (entry, scope) = store
         .read(name)
         .with_context(|| format!("reading memory entry {name:?}"))?;
+    write_memory_event(
+        event_log,
+        "memory_show",
+        &format!("scope={} name={name}", scope.as_str()),
+    );
     println!(
         "[{}] {} ({}) — {}\n",
         scope.as_str(),
@@ -80,7 +95,15 @@ pub fn cmd_show(config: &TsumugiConfig, name: &str) -> anyhow::Result<()> {
 /// Missing entries are scaffolded with a frontmatter template so the
 /// user can complete the file in the editor; no entry is written
 /// before the editor exits successfully.
-pub fn cmd_edit(config: &TsumugiConfig, name: &str) -> anyhow::Result<()> {
+///
+/// `$EDITOR` is parsed as a shell-quoted argv (so values like
+/// `EDITOR="code --wait"` work); on parse failure we fall back to
+/// invoking the raw value as a single executable.
+pub fn cmd_edit(
+    config: &TsumugiConfig,
+    name: &str,
+    event_log: Option<&Path>,
+) -> anyhow::Result<()> {
     if !config.memory.enabled {
         return Err(anyhow!("memory is disabled in [memory].enabled"));
     }
@@ -94,11 +117,16 @@ pub fn cmd_edit(config: &TsumugiConfig, name: &str) -> anyhow::Result<()> {
     if !path.exists() {
         scaffold_entry(&path, name)?;
     }
-    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_owned());
-    let status = Command::new(&editor)
+    let editor_raw = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_owned());
+    let argv = split_editor_command(&editor_raw);
+    let (program, extra_args) = argv
+        .split_first()
+        .ok_or_else(|| anyhow!("EDITOR is set to an empty string"))?;
+    let status = Command::new(program)
+        .args(extra_args)
         .arg(&path)
         .status()
-        .with_context(|| format!("launching editor {editor:?}"))?;
+        .with_context(|| format!("launching editor {editor_raw:?}"))?;
     if !status.success() {
         return Err(anyhow!("editor exited with non-zero status"));
     }
@@ -110,7 +138,70 @@ pub fn cmd_edit(config: &TsumugiConfig, name: &str) -> anyhow::Result<()> {
         .with_context(|| format!("validating memory entry at {}", path.display()))?;
     // Re-sync the index row in case the description was edited.
     sync_index_row(&store, name)?;
+    write_memory_event(
+        event_log,
+        "memory_edit",
+        &format!("name={name} path={}", path.display()),
+    );
     Ok(())
+}
+
+/// Best-effort split of an `$EDITOR` value into argv. Honours simple
+/// double- and single-quoted segments so values like
+/// `EDITOR="code --wait"` parse to `["code", "--wait"]`. On any
+/// failure (e.g. unterminated quote) we fall back to the raw value as
+/// a single argv entry — which matches the previous behaviour and
+/// fails predictably if the user intended to embed flags.
+fn split_editor_command(raw: &str) -> Vec<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut chars = trimmed.chars().peekable();
+    let mut in_single = false;
+    let mut in_double = false;
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' if !in_single => {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            c if c.is_whitespace() && !in_single && !in_double => {
+                if !current.is_empty() {
+                    out.push(std::mem::take(&mut current));
+                }
+            }
+            c => current.push(c),
+        }
+    }
+    if in_single || in_double {
+        // Unterminated quote: fall back to the raw value verbatim so
+        // the operator gets a clear error from `Command::status`
+        // rather than a silently mis-split argv.
+        return vec![raw.to_owned()];
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// Best-effort write of a `tmg memory <op>` audit event. The event
+/// log is optional; a missing or unwritable path is silently
+/// tolerated because the CLI surfaces have their own stdout output.
+fn write_memory_event(event_log: Option<&Path>, op: &str, summary: &str) {
+    let Some(path) = event_log else {
+        return;
+    };
+    let Ok(mut writer) = EventLogWriter::open_append(path) else {
+        return;
+    };
+    writer.write_memory(op, summary);
 }
 
 /// Write a placeholder entry so the editor opens to a sensible
@@ -147,10 +238,14 @@ fn sync_index_row(store: &MemoryStore, name: &str) -> anyhow::Result<()> {
 }
 
 /// Resolve a memory subcommand and dispatch.
-pub fn dispatch(op: crate::MemoryCommand, config: &TsumugiConfig) -> anyhow::Result<()> {
+pub fn dispatch(
+    op: crate::MemoryCommand,
+    config: &TsumugiConfig,
+    event_log: Option<&Path>,
+) -> anyhow::Result<()> {
     match op {
-        crate::MemoryCommand::List => cmd_list(config),
-        crate::MemoryCommand::Show { name } => cmd_show(config, &name),
-        crate::MemoryCommand::Edit { name } => cmd_edit(config, &name),
+        crate::MemoryCommand::List => cmd_list(config, event_log),
+        crate::MemoryCommand::Show { name } => cmd_show(config, &name, event_log),
+        crate::MemoryCommand::Edit { name } => cmd_edit(config, &name, event_log),
     }
 }

--- a/tmg-cli/src/memory_commands.rs
+++ b/tmg-cli/src/memory_commands.rs
@@ -1,0 +1,156 @@
+//! `tmg memory ...` subcommand implementations.
+//!
+//! These commands operate on the project memory store directly (no
+//! agent loop, no LLM round-trip). They mirror the `MemoryTool` JSON
+//! API but skip the sandbox check because the operator is invoking
+//! them by hand.
+
+use std::io::Write as _;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use anyhow::{Context as _, anyhow};
+use tmg_memory::MemoryStore;
+
+use crate::config::{MemoryConfig, TsumugiConfig};
+
+/// Build a [`MemoryStore`] from the merged [`MemoryConfig`].
+///
+/// The project root is derived from the canonicalised cwd because the
+/// memory store is project-scoped: invoking `tmg memory list` in a
+/// subdirectory still resolves the project memory dir relative to the
+/// directory the user is running tmg from.
+fn make_store(config: &MemoryConfig) -> anyhow::Result<Arc<MemoryStore>> {
+    let cwd = std::env::current_dir().context("reading current working directory")?;
+    let canonical = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+    let project_dir = config.resolve_project_dir(&canonical);
+    let global_dir = config.resolve_global_dir();
+    let store = MemoryStore::with_dirs(project_dir, global_dir, config.to_budget());
+    Ok(Arc::new(store))
+}
+
+/// `tmg memory list` — print one entry name per line.
+#[expect(
+    clippy::print_stdout,
+    reason = "CLI subcommand: this is the documented stdout surface"
+)]
+pub fn cmd_list(config: &TsumugiConfig) -> anyhow::Result<()> {
+    if !config.memory.enabled {
+        return Err(anyhow!("memory is disabled in [memory].enabled"));
+    }
+    let store = make_store(&config.memory)?;
+    let names = store.list_project().context("listing project memory")?;
+    if names.is_empty() {
+        println!("(no memory entries yet — use `tmg memory edit <name>` or the `memory` tool)");
+        return Ok(());
+    }
+    for name in names {
+        println!("{name}");
+    }
+    Ok(())
+}
+
+/// `tmg memory show <name>` — print the body of one entry.
+#[expect(
+    clippy::print_stdout,
+    reason = "CLI subcommand: this is the documented stdout surface"
+)]
+pub fn cmd_show(config: &TsumugiConfig, name: &str) -> anyhow::Result<()> {
+    if !config.memory.enabled {
+        return Err(anyhow!("memory is disabled in [memory].enabled"));
+    }
+    let store = make_store(&config.memory)?;
+    let (entry, scope) = store
+        .read(name)
+        .with_context(|| format!("reading memory entry {name:?}"))?;
+    println!(
+        "[{}] {} ({}) — {}\n",
+        scope.as_str(),
+        entry.frontmatter.name,
+        entry.frontmatter.kind,
+        entry.frontmatter.description,
+    );
+    println!("{}", entry.body);
+    Ok(())
+}
+
+/// `tmg memory edit <name>` — open the entry in `$EDITOR`.
+///
+/// Missing entries are scaffolded with a frontmatter template so the
+/// user can complete the file in the editor; no entry is written
+/// before the editor exits successfully.
+pub fn cmd_edit(config: &TsumugiConfig, name: &str) -> anyhow::Result<()> {
+    if !config.memory.enabled {
+        return Err(anyhow!("memory is disabled in [memory].enabled"));
+    }
+    let store = make_store(&config.memory)?;
+    let project_dir = store.project_dir().to_owned();
+    if !project_dir.exists() {
+        std::fs::create_dir_all(&project_dir)
+            .with_context(|| format!("creating project memory dir {}", project_dir.display()))?;
+    }
+    let path = project_dir.join(format!("{name}.md"));
+    if !path.exists() {
+        scaffold_entry(&path, name)?;
+    }
+    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_owned());
+    let status = Command::new(&editor)
+        .arg(&path)
+        .status()
+        .with_context(|| format!("launching editor {editor:?}"))?;
+    if !status.success() {
+        return Err(anyhow!("editor exited with non-zero status"));
+    }
+    // Re-parse the file to validate; if the user broke the
+    // frontmatter, surface the error so they can re-open and fix.
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading {} after edit", path.display()))?;
+    tmg_memory::parse_entry(&text, &path.display().to_string())
+        .with_context(|| format!("validating memory entry at {}", path.display()))?;
+    // Re-sync the index row in case the description was edited.
+    sync_index_row(&store, name)?;
+    Ok(())
+}
+
+/// Write a placeholder entry so the editor opens to a sensible
+/// frontmatter skeleton instead of an empty file.
+fn scaffold_entry(path: &Path, name: &str) -> anyhow::Result<()> {
+    let body = format!(
+        "---\nname: {name}\ndescription: TODO one-line summary\ntype: project\n---\n\nTODO body.\n",
+    );
+    let mut file = std::fs::File::create(path)
+        .with_context(|| format!("creating scaffold at {}", path.display()))?;
+    file.write_all(body.as_bytes())
+        .with_context(|| format!("writing scaffold at {}", path.display()))?;
+    Ok(())
+}
+
+/// After an external edit, rewrite the matching `MEMORY.md` row so
+/// the description in the index always reflects the current entry.
+fn sync_index_row(store: &MemoryStore, name: &str) -> anyhow::Result<()> {
+    let (entry, _) = store
+        .read(name)
+        .with_context(|| format!("re-reading memory entry {name:?} after edit"))?;
+    // Fast path: rewrite description via update with no body change.
+    // `update` bumps `updated_at`; that's the desired side-effect of a
+    // manual edit too.
+    store
+        .update(
+            name,
+            Some(entry.frontmatter.kind),
+            Some(&entry.frontmatter.description),
+            None,
+        )
+        .with_context(|| format!("syncing index row for {name:?}"))?;
+    Ok(())
+}
+
+/// Resolve a memory subcommand and dispatch.
+pub fn dispatch(op: crate::MemoryCommand, config: &TsumugiConfig) -> anyhow::Result<()> {
+    match op {
+        crate::MemoryCommand::List => cmd_list(config),
+        crate::MemoryCommand::Show { name } => cmd_show(config, &name),
+        crate::MemoryCommand::Edit { name } => cmd_edit(config, &name),
+    }
+}


### PR DESCRIPTION
## Summary

- New `tmg-memory` crate (`store` / `entry` / `budget` / `tool` / `error`) implementing `.tsumugi/memory/MEMORY.md` index + per-topic `<name>.md` files with YAML frontmatter; the four-tag vocabulary (`user|feedback|project|reference`) is enforced at load.
- `MemoryTool` (registered in `tmg-cli::run_tui`) exposes `add` / `update` / `remove` / `read` to the LLM with path generation and `SandboxContext::check_write_access` gating; capacity caps (200 lines / 600 chars / 50 files) surface a "near capacity" nudge in tool results and in the startup system prompt.
- System-prompt integration via `tmg_core::prompt::load_prompt_files_with_memory` + `AgentLoop::set_memory_index` / `inject_memory_index_now`; `/clear` re-injects automatically. One-shot mode (`tmg --prompt`) injects the merged index too.
- Global ↔ project merge: `~/.config/tsumugi/memory/` is read-only from the agent's perspective; project entries override globals on file-name collision.
- `[memory]` section added to `TsumugiConfig` with full partial-merge support; new CLI commands `tmg memory list / show / edit`; new TUI slash commands `/memory` and `/memory show <name>`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (33 new tests added in `tmg-memory`; full suite green)
- [x] `tmg memory list` smoke test in an empty project prints the placeholder hint
- [x] `tmg memory --help` lists `list / show / edit`

### Runtime Verification
- LLM server: available
- One-shot mode: PASS
  - `tmg --prompt "Say 'memory test passed' and nothing else." --event-log /tmp/tmg-verify-oneshot.jsonl`
  - 171 events recorded, content tokens streamed, `done` reached, 0 `is_error: true` events
- TUI mode: SKIP (this PR's TUI surface is the `/memory` slash command path; covered by unit-test parsing in `tmg-skills::slash` and the synchronous dispatch logic in `App::dispatch_slash`. No model-driven workflow change to validate end-to-end here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)