### PR TITLE
tmg-search: cross-session FTS5 search + session_search tool (#53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +439,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +606,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -596,6 +629,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -978,6 +1020,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libyml"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1229,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
@@ -1504,6 +1563,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -2014,6 +2087,7 @@ dependencies = [
  "tmg-llm",
  "tmg-memory",
  "tmg-sandbox",
+ "tmg-search",
  "tmg-skills",
  "tmg-tools",
  "tmg-tui",
@@ -2113,6 +2187,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tmg-search"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "regex",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tmg-harness",
+ "tmg-sandbox",
+ "tmg-tools",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tmg-skills"
 version = "0.1.0"
 dependencies = [
@@ -2164,6 +2256,7 @@ dependencies = [
  "tmg-llm",
  "tmg-memory",
  "tmg-sandbox",
+ "tmg-search",
  "tmg-skills",
  "tmg-tools",
  "tmg-workflow",
@@ -2563,6 +2656,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/tmg-core",
     "crates/tmg-llm",
     "crates/tmg-memory",
+    "crates/tmg-search",
     "crates/tmg-tools",
     "crates/tmg-skills",
     "crates/tmg-agents",
@@ -94,6 +95,7 @@ libc = "0.2"
 tmg-core = { path = "crates/tmg-core" }
 tmg-llm = { path = "crates/tmg-llm" }
 tmg-memory = { path = "crates/tmg-memory" }
+tmg-search = { path = "crates/tmg-search" }
 tmg-tools = { path = "crates/tmg-tools" }
 tmg-skills = { path = "crates/tmg-skills" }
 tmg-agents = { path = "crates/tmg-agents" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,11 @@ rand = "0.9"
 # Regex
 regex = "1"
 
+# SQLite (FTS5 search index in tmg-search)
+# `bundled` ships sqlite3 with the crate so we don't depend on a system
+# library; the bundled build enables FTS5 by default. See issue #53.
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 # Tree-sitter (signature extraction in tmg-tools)
 tree-sitter = "0.25"
 tree-sitter-rust = "0.24"

--- a/crates/tmg-harness/src/lib.rs
+++ b/crates/tmg-harness/src/lib.rs
@@ -54,7 +54,7 @@ pub use run::{Run, RunId, RunScope, RunStatus, RunSummary};
 pub use runner::{
     DEFAULT_BOOTSTRAP_MAX_TOKENS, DEFAULT_CONTEXT_FORCE_ROTATE_THRESHOLD,
     DEFAULT_SESSION_LOG_COMPRESS_AFTER, DEFAULT_SESSION_TIMEOUT, RunProgressEvent,
-    RunProgressReceiver, RunRunner,
+    RunProgressReceiver, RunRunner, SessionEndHook,
 };
 pub use session::{Session, SessionEndTrigger, SessionHandle};
 pub use sink::HarnessStreamSink;

--- a/crates/tmg-harness/src/runner.rs
+++ b/crates/tmg-harness/src/runner.rs
@@ -92,6 +92,21 @@ pub enum RunProgressEvent {
 /// type directly.
 pub type RunProgressReceiver = mpsc::Receiver<RunProgressEvent>;
 
+/// Callback fired after a session has been finalised and persisted to
+/// disk via [`SessionLog::save`].
+///
+/// The hook receives the run id (string form) and a borrowed
+/// reference to the just-saved [`Session`] so external subsystems
+/// (e.g. the search index in `tmg-search`) can ingest the session
+/// without re-reading the JSON file. Hooks are invoked synchronously
+/// as the very last step of [`RunRunner::end_session`] /
+/// [`RunRunner::end_session_with_rotation`]; failures are logged via
+/// `tracing::warn!` and swallowed so a broken hook never aborts the
+/// session-end flow.
+///
+/// Issue #53.
+pub type SessionEndHook = Arc<dyn Fn(&str, &Session) + Send + Sync>;
+
 /// Default wall-clock budget for one harnessed session.
 ///
 /// Mirrors the CLI's `[harness] default_session_timeout` default
@@ -169,7 +184,11 @@ impl Drop for EscalationGuard<'_> {
 /// no inter-process locking around session begin/end; running multiple
 /// `tmg` processes against the same `runs_dir` can race on
 /// `session_count` updates. A locking layer is tracked as a follow-up.
-#[derive(Debug)]
+///
+/// Manually implements [`std::fmt::Debug`] because `session_end_hook`
+/// holds a boxed `Fn` closure that does not implement `Debug`. The
+/// hand-rolled formatter elides the closure but otherwise mirrors the
+/// auto-derived output.
 pub struct RunRunner {
     run: Run,
     store: Arc<RunStore>,
@@ -263,6 +282,14 @@ pub struct RunRunner {
     /// allocate the channel — the event publication path is a no-op.
     progress_tx: Option<mpsc::Sender<RunProgressEvent>>,
 
+    /// Optional callback fired after every successful session-end
+    /// `SessionLog::save`. Issue #53 — the search index registers a
+    /// hook here so the cross-session FTS5 store stays incremental.
+    ///
+    /// `None` when no consumer subscribed; hook installation is
+    /// idempotent and the most recently-installed hook wins.
+    session_end_hook: Option<SessionEndHook>,
+
     /// Concurrency gate for [`Self::escalate_to_harnessed`].
     ///
     /// Set to `true` while a promotion is in progress (or after the
@@ -280,6 +307,36 @@ pub struct RunRunner {
     /// successful upgrade has flipped `run.scope` to
     /// [`RunScope::Harnessed`].
     escalation_in_progress: AtomicBool,
+}
+
+impl std::fmt::Debug for RunRunner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RunRunner")
+            .field("run", &self.run)
+            .field("store", &self.store)
+            .field("progress", &self.progress)
+            .field("session_log", &self.session_log)
+            .field("features", &self.features)
+            .field("init_script", &self.init_script)
+            .field("active_session", &self.active_session)
+            .field("bootstrap_max_tokens", &self.bootstrap_max_tokens)
+            .field("default_session_timeout", &self.default_session_timeout)
+            .field(
+                "context_force_rotate_threshold",
+                &self.context_force_rotate_threshold,
+            )
+            .field(
+                "session_log_compress_after",
+                &self.session_log_compress_after,
+            )
+            .field("timeout_watchdog", &self.timeout_watchdog)
+            .field("timeout_config", &self.timeout_config)
+            .field("session_state", &self.session_state)
+            .field("progress_tx", &self.progress_tx)
+            .field("session_end_hook", &self.session_end_hook.is_some())
+            .field("escalation_in_progress", &self.escalation_in_progress)
+            .finish()
+    }
 }
 
 impl RunRunner {
@@ -308,7 +365,47 @@ impl RunRunner {
             timeout_config: None,
             session_state,
             progress_tx: None,
+            session_end_hook: None,
             escalation_in_progress: AtomicBool::new(false),
+        }
+    }
+
+    /// Register a callback that fires after every successful
+    /// session-end `SessionLog::save`. The hook receives the run id
+    /// and a reference to the just-saved [`Session`].
+    ///
+    /// At most one hook is installed at a time; calling this method
+    /// replaces any previously-installed hook. Pass `None` to clear.
+    /// Issue #53.
+    pub fn set_session_end_hook(&mut self, hook: Option<SessionEndHook>) {
+        self.session_end_hook = hook;
+    }
+
+    /// Whether a session-end hook is currently registered.
+    #[must_use]
+    pub fn has_session_end_hook(&self) -> bool {
+        self.session_end_hook.is_some()
+    }
+
+    /// Run the session-end hook if installed. Failures are swallowed
+    /// (log via `tracing::warn!`) so a broken hook cannot abort the
+    /// rotation flow.
+    fn fire_session_end_hook(&self, session: &Session) {
+        let Some(hook) = self.session_end_hook.as_ref() else {
+            return;
+        };
+        // The hook is `Fn(&str, &Session)` — no fallible return.
+        // Wrap in `catch_unwind` so a panicking hook is contained.
+        let run_id = self.run.id.as_str();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            hook(run_id, session);
+        }));
+        if result.is_err() {
+            tracing::warn!(
+                run_id = %run_id,
+                session = session.index,
+                "session_end_hook panicked; suppressing to keep rotation flow alive"
+            );
         }
     }
 
@@ -600,6 +697,12 @@ impl RunRunner {
         if let Some(mut session) = self.active_session.take() {
             session.end(trigger);
             self.session_log.save(&session)?;
+            // Issue #53: notify the search index (or any other
+            // subscriber) that a session was just persisted. Fired
+            // BEFORE we re-save `run.toml` so a fast-following
+            // process restart finds both the on-disk session JSON
+            // and the indexed row.
+            self.fire_session_end_hook(&session);
             // Cancel the timeout watchdog only when we actually
             // closed the active session. On an early-return path
             // (no active session, or `SessionMismatch` rejected
@@ -732,6 +835,11 @@ impl RunRunner {
             // compaction-turn machinery is plumbed through.
             session.end(trigger);
             self.session_log.save(&session)?;
+            // Issue #53: fire the search-index ingest hook before we
+            // hand control over to the rotation step so the freshly
+            // closed session is queryable as soon as
+            // `SessionEnded` is observed.
+            self.fire_session_end_hook(&session);
             // The `Session::end_trigger` is now `Some(trigger)`; clone
             // it back out for the published event.
             session
@@ -1212,6 +1320,82 @@ mod tests {
             .unwrap_or_else(|| panic!("session 1 should exist"));
         assert_eq!(session.end_trigger, Some(SessionEndTrigger::Completed));
         assert!(session.ended_at.is_some());
+    }
+
+    /// Issue #53: a registered session-end hook fires once per
+    /// `end_session` with the persisted [`Session`] and the run id.
+    #[test]
+    fn end_session_fires_session_end_hook() {
+        use std::sync::Mutex;
+        let (_tmp, mut runner) = make_runner();
+        let observed: Arc<Mutex<Vec<(String, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let observed_for_hook = Arc::clone(&observed);
+        let hook: SessionEndHook = Arc::new(move |run_id: &str, session: &Session| {
+            observed_for_hook
+                .lock()
+                .unwrap_or_else(|e| panic!("{e}"))
+                .push((run_id.to_owned(), session.index));
+        });
+        runner.set_session_end_hook(Some(hook));
+        assert!(runner.has_session_end_hook());
+
+        let handle = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        runner
+            .end_session(&handle, SessionEndTrigger::Completed)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let observed = observed.lock().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            observed.len(),
+            1,
+            "expected one hook fire, got {observed:?}"
+        );
+        assert_eq!(observed[0].1, 1);
+    }
+
+    /// Issue #53: clearing the session-end hook with `None`
+    /// disables the callback for subsequent `end_session` calls.
+    #[test]
+    fn cleared_session_end_hook_does_not_fire() {
+        use std::sync::Mutex;
+        let (_tmp, mut runner) = make_runner();
+        let observed: Arc<Mutex<u32>> = Arc::new(Mutex::new(0));
+        let observed_for_hook = Arc::clone(&observed);
+        runner.set_session_end_hook(Some(Arc::new(move |_run_id, _session| {
+            *observed_for_hook.lock().unwrap_or_else(|e| panic!("{e}")) += 1;
+        })));
+        runner.set_session_end_hook(None);
+        assert!(!runner.has_session_end_hook());
+
+        let handle = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        runner
+            .end_session(&handle, SessionEndTrigger::Completed)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(*observed.lock().unwrap_or_else(|e| panic!("{e}")), 0);
+    }
+
+    /// Issue #53: a panicking session-end hook is contained and does
+    /// not abort the rotation flow.
+    #[test]
+    fn panicking_session_end_hook_is_contained() {
+        let (_tmp, mut runner) = make_runner();
+        let hook: SessionEndHook = Arc::new(|_run_id, _session| {
+            panic!("intentional panic in hook");
+        });
+        runner.set_session_end_hook(Some(hook));
+
+        let handle = runner.begin_session().unwrap_or_else(|e| panic!("{e}"));
+        // The end_session call must NOT propagate the hook panic.
+        runner
+            .end_session(&handle, SessionEndTrigger::Completed)
+            .unwrap_or_else(|e| panic!("{e}"));
+        // Session was still persisted.
+        let entries = runner
+            .session_log()
+            .list()
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(entries.len(), 1);
     }
 
     #[test]

--- a/crates/tmg-search/Cargo.toml
+++ b/crates/tmg-search/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "tmg-search"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tmg-harness = { workspace = true }
+tmg-sandbox = { workspace = true }
+tmg-tools = { workspace = true }
+chrono = { workspace = true }
+regex = { workspace = true }
+# `bundled` ships sqlite3 with the crate so we don't depend on a system
+# library; the bundled build enables FTS5 by default, which is the core
+# of the cross-session index. See issue #53.
+rusqlite = { version = "0.32", features = ["bundled"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+
+[lints]
+workspace = true

--- a/crates/tmg-search/Cargo.toml
+++ b/crates/tmg-search/Cargo.toml
@@ -11,18 +11,15 @@ tmg-sandbox = { workspace = true }
 tmg-tools = { workspace = true }
 chrono = { workspace = true }
 regex = { workspace = true }
-# `bundled` ships sqlite3 with the crate so we don't depend on a system
-# library; the bundled build enables FTS5 by default, which is the core
-# of the cross-session index. See issue #53.
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [lints]
 workspace = true

--- a/crates/tmg-search/src/error.rs
+++ b/crates/tmg-search/src/error.rs
@@ -46,6 +46,16 @@ pub enum SearchError {
         /// Human-readable description.
         message: String,
     },
+
+    /// The connection mutex was poisoned by a panic in another thread.
+    /// The index handle is unusable from this point on; the caller
+    /// should reopen the index or surface the failure to the user.
+    #[error("search index mutex poisoned: {context}")]
+    MutexPoisoned {
+        /// What the search code was attempting when the mutex was
+        /// found poisoned.
+        context: String,
+    },
 }
 
 impl SearchError {
@@ -77,6 +87,13 @@ impl SearchError {
     pub fn invalid_query(message: impl Into<String>) -> Self {
         Self::InvalidQuery {
             message: message.into(),
+        }
+    }
+
+    /// Build an [`SearchError::MutexPoisoned`].
+    pub fn mutex_poisoned(context: impl Into<String>) -> Self {
+        Self::MutexPoisoned {
+            context: context.into(),
         }
     }
 }

--- a/crates/tmg-search/src/error.rs
+++ b/crates/tmg-search/src/error.rs
@@ -1,0 +1,82 @@
+//! Error type for the tmg-search crate.
+
+use std::path::PathBuf;
+
+/// Errors produced by the search index and ingest paths.
+///
+/// The crate uses `thiserror` 2.x — one variant per failure shape so
+/// callers can distinguish "DB couldn't be opened" from "the schema
+/// version is incompatible" without string matching.
+#[derive(Debug, thiserror::Error)]
+pub enum SearchError {
+    /// Generic I/O failure with the path that was being touched.
+    #[error("io error at {path}: {source}")]
+    Io {
+        /// The file or directory that was being accessed.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// `SQLite` returned an error.
+    #[error("sqlite error: {context}: {source}")]
+    Sqlite {
+        /// What the search code was doing when sqlite failed (e.g.
+        /// `"opening state.db"`).
+        context: String,
+        /// The underlying rusqlite error.
+        #[source]
+        source: rusqlite::Error,
+    },
+
+    /// JSON serialization or deserialization failed.
+    #[error("json error: {context}: {source}")]
+    Json {
+        /// What the search code was doing.
+        context: String,
+        /// Underlying `serde_json` error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// A search query parameter was invalid (e.g. `limit < 1`).
+    #[error("invalid query parameter: {message}")]
+    InvalidQuery {
+        /// Human-readable description.
+        message: String,
+    },
+}
+
+impl SearchError {
+    /// Build an [`SearchError::Io`] from a path + source pair.
+    pub fn io(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        Self::Io {
+            path: path.into(),
+            source,
+        }
+    }
+
+    /// Build an [`SearchError::Sqlite`] with a context string.
+    pub fn sqlite(context: impl Into<String>, source: rusqlite::Error) -> Self {
+        Self::Sqlite {
+            context: context.into(),
+            source,
+        }
+    }
+
+    /// Build an [`SearchError::Json`] with a context string.
+    pub fn json(context: impl Into<String>, source: serde_json::Error) -> Self {
+        Self::Json {
+            context: context.into(),
+            source,
+        }
+    }
+
+    /// Build an [`SearchError::InvalidQuery`].
+    pub fn invalid_query(message: impl Into<String>) -> Self {
+        Self::InvalidQuery {
+            message: message.into(),
+        }
+    }
+}

--- a/crates/tmg-search/src/index.rs
+++ b/crates/tmg-search/src/index.rs
@@ -117,11 +117,19 @@ impl SearchScope {
 
 /// Schema version pinned in the `meta` key/value table. Bumping this
 /// triggers a migration path on next [`SearchIndex::open`].
-const SCHEMA_VERSION: i64 = 1;
+///
+/// - **v1**: initial schema (`sessions` / `sessions_fts` / `turns` /
+///   `turns_fts`).
+/// - **v2**: adds `sessions.started_at_unix INTEGER` so the `since`
+///   filter compares Unix epoch numerics rather than RFC3339 strings
+///   (avoids `Z` vs `+00:00` skew).
+const SCHEMA_VERSION: i64 = 2;
 
-/// Persistent search index. Cloning a [`SearchIndex`] is cheap
-/// (`Arc`-style) and produces another handle to the same underlying
-/// connection mutex.
+/// Persistent search index.
+///
+/// [`SearchIndex`] is **not** `Clone`. Callers that need to share the
+/// index between async tasks should wrap it in [`std::sync::Arc`] (the
+/// CLI's hot path already does this).
 ///
 /// The connection is wrapped in a `Mutex<Connection>` because rusqlite
 /// connections are `!Sync`. Concurrent callers serialize on the
@@ -187,19 +195,36 @@ impl SearchIndex {
     /// Open or create the index at `db_path`, running migrations as
     /// needed.
     ///
-    /// Creates parent directories if missing. The schema is laid down
-    /// idempotently on first open; subsequent opens verify the
-    /// `schema_version` value and refuse to proceed when the on-disk
-    /// version is newer than [`SCHEMA_VERSION`] — we never
-    /// auto-downgrade.
+    /// Creates parent directories if missing. The parent directory is
+    /// then canonicalised so that the stored `path` resolves any
+    /// symlink / `..` segments — a misconfigured
+    /// `[search] db_path = "../../etc/state.db"` ends up rooted at
+    /// the real on-disk location after creation rather than at a
+    /// surface-level traversal target. The file name itself is taken
+    /// verbatim because the file does not exist yet on first open.
+    ///
+    /// The schema is laid down idempotently on first open; subsequent
+    /// opens verify the `schema_version` value and refuse to proceed
+    /// when the on-disk version is newer than [`SCHEMA_VERSION`] — we
+    /// never auto-downgrade.
     pub fn open(db_path: impl AsRef<Path>) -> Result<Self, SearchError> {
-        let path = db_path.as_ref().to_path_buf();
-        if let Some(parent) = path.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| SearchError::io(parent.to_path_buf(), e))?;
-        }
+        let raw_path = db_path.as_ref().to_path_buf();
+        // Resolve to an absolute, symlink-free location so stored
+        // diagnostics and the on-disk handle always agree.
+        let path = match (raw_path.parent(), raw_path.file_name()) {
+            (Some(parent), Some(name)) if !parent.as_os_str().is_empty() => {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| SearchError::io(parent.to_path_buf(), e))?;
+                let canonical_parent = std::fs::canonicalize(parent)
+                    .map_err(|e| SearchError::io(parent.to_path_buf(), e))?;
+                canonical_parent.join(name)
+            }
+            // No parent (e.g. relative path with just a filename) or
+            // no filename component — fall back to the raw path. The
+            // sqlite `Connection::open` call below will surface any
+            // remaining issue.
+            _ => raw_path,
+        };
         let conn = Connection::open(&path).map_err(|e| SearchError::sqlite("open db", e))?;
         // Reasonable defaults for a single-writer process: WAL
         // tolerates concurrent reads while ingest is writing.
@@ -237,6 +262,7 @@ impl SearchIndex {
                 run_id TEXT NOT NULL,
                 session_num INTEGER NOT NULL,
                 started_at TEXT NOT NULL,
+                started_at_unix INTEGER NOT NULL DEFAULT 0,
                 ended_at TEXT,
                 trigger TEXT,
                 summary TEXT,
@@ -300,9 +326,12 @@ impl SearchIndex {
                     source: rusqlite::Error::InvalidQuery,
                 });
             }
-            Some(_v) => {
-                // Future migration path: bump the stored value here.
-                // For schema v1 there is nothing to migrate.
+            Some(v) => {
+                // Run forward migrations. Each step is idempotent so
+                // a partially-failed migration can be retried.
+                if v < 2 {
+                    Self::migrate_v1_to_v2(conn)?;
+                }
                 conn.execute(
                     "UPDATE meta SET value = ?1 WHERE key = 'schema_version'",
                     params![SCHEMA_VERSION.to_string()],
@@ -310,6 +339,45 @@ impl SearchIndex {
                 .map_err(|e| SearchError::sqlite("update schema_version", e))?;
             }
         }
+        Ok(())
+    }
+
+    /// v1 -> v2: add `sessions.started_at_unix` so the `since` filter
+    /// can compare numerics instead of RFC3339 strings (avoids `Z` vs
+    /// `+00:00` skew). Backfills existing rows by parsing the
+    /// `started_at` text column; rows that fail to parse are left at 0
+    /// and will simply be considered "before any cutoff".
+    fn migrate_v1_to_v2(conn: &Connection) -> Result<(), SearchError> {
+        // The CREATE TABLE above already includes the column for fresh
+        // databases. For pre-existing v1 databases we have to ALTER.
+        // SQLite's `ALTER TABLE ... ADD COLUMN` is no-op-safe via the
+        // PRAGMA check below.
+        let has_col: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'started_at_unix'",
+                [],
+                |row| row.get::<_, i64>(0).map(|n| n > 0),
+            )
+            .map_err(|e| SearchError::sqlite("check started_at_unix column", e))?;
+        if !has_col {
+            conn.execute(
+                "ALTER TABLE sessions ADD COLUMN started_at_unix INTEGER NOT NULL DEFAULT 0",
+                [],
+            )
+            .map_err(|e| SearchError::sqlite("add started_at_unix column", e))?;
+        }
+        // Backfill: parse any rows whose started_at_unix is still 0.
+        // We do this in SQL via `strftime('%s', ...)` — sqlite accepts
+        // ISO8601 with `Z` or numeric offsets and produces the Unix
+        // epoch as a string, which we cast to integer.
+        conn.execute(
+            "UPDATE sessions \
+                 SET started_at_unix = CAST(strftime('%s', started_at) AS INTEGER) \
+                 WHERE started_at_unix = 0 \
+                   AND strftime('%s', started_at) IS NOT NULL",
+            [],
+        )
+        .map_err(|e| SearchError::sqlite("backfill started_at_unix", e))?;
         Ok(())
     }
 
@@ -327,6 +395,7 @@ impl SearchIndex {
         // tokenised URLs.
         let files_modified = redact_secrets(&files_modified);
         let started_at = session.started_at.to_rfc3339();
+        let started_at_unix = session.started_at.timestamp();
         let ended_at = session.ended_at.as_ref().map(DateTime::to_rfc3339);
         let trigger = session.end_trigger.as_ref().map(|t| match t {
             tmg_harness::SessionEndTrigger::Completed => "completed".to_owned(),
@@ -346,11 +415,11 @@ impl SearchIndex {
 
         // Upsert the row. We delete the old FTS row first and re-insert
         // because external-content FTS5 doesn't auto-track UPDATEs.
-        tx.execute(
-            "DELETE FROM sessions WHERE run_id = ?1 AND session_num = ?2",
-            params![run_id, session.index],
-        )
-        .map_err(|e| SearchError::sqlite("delete old sessions row", e))?;
+        // CRITICAL: the FTS5 cleanup must run **before** the base
+        // `sessions` row is deleted, because the rowid lookup subquery
+        // joins back to `sessions`. Reversing the order leaves an
+        // orphan FTS row and causes UNIQUE rowid conflicts on the
+        // subsequent INSERT (see issue #53 review feedback).
         tx.execute(
             "DELETE FROM sessions_fts WHERE rowid IN (
                 SELECT rowid FROM sessions WHERE run_id = ?1 AND session_num = ?2
@@ -358,16 +427,22 @@ impl SearchIndex {
             params![run_id, session.index],
         )
         .map_err(|e| SearchError::sqlite("delete old sessions_fts row", e))?;
+        tx.execute(
+            "DELETE FROM sessions WHERE run_id = ?1 AND session_num = ?2",
+            params![run_id, session.index],
+        )
+        .map_err(|e| SearchError::sqlite("delete old sessions row", e))?;
 
         tx.execute(
             "INSERT INTO sessions(
-                run_id, session_num, started_at, ended_at, trigger,
-                summary, files_modified, tool_calls_count
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                run_id, session_num, started_at, started_at_unix,
+                ended_at, trigger, summary, files_modified, tool_calls_count
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
                 run_id,
                 session.index,
                 started_at,
+                started_at_unix,
                 ended_at,
                 trigger,
                 summary,
@@ -471,6 +546,29 @@ impl SearchIndex {
         Ok(count > 0)
     }
 
+    /// Load every `(run_id, session_num)` pair currently in the index
+    /// into a [`HashSet`] for in-memory lookup during a rebuild scan.
+    /// Avoids the O(N) `SELECT COUNT(*)` round-trip per file that
+    /// [`Self::has_session`] would incur.
+    fn existing_session_keys(
+        &self,
+    ) -> Result<std::collections::HashSet<(String, u32)>, SearchError> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn
+            .prepare("SELECT run_id, session_num FROM sessions")
+            .map_err(|e| SearchError::sqlite("prepare existing_session_keys", e))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+            })
+            .map_err(|e| SearchError::sqlite("execute existing_session_keys", e))?;
+        let mut set = std::collections::HashSet::new();
+        for r in rows {
+            set.insert(r.map_err(|e| SearchError::sqlite("read existing_session_keys", e))?);
+        }
+        Ok(set)
+    }
+
     /// Walk `runs_dir`, find every `session_NNN.json`, and ingest those
     /// not already in the DB. Returns the count of newly-ingested
     /// sessions.
@@ -478,11 +576,19 @@ impl SearchIndex {
     /// Files that fail to parse or contain malformed JSON are logged
     /// via `tracing::warn!` and skipped — a single corrupt session
     /// must not stop the rebuild from progressing.
+    ///
+    /// To avoid one `SELECT COUNT(*)` per file, this method loads the
+    /// full set of indexed `(run_id, session_num)` pairs into memory
+    /// up front and checks against that set. The membership map is
+    /// kept up-to-date in-memory as new rows are ingested, so a
+    /// duplicate session log inside the same scan still skips
+    /// correctly.
     pub fn rebuild_from_disk(&self, runs_dir: impl AsRef<Path>) -> Result<usize, SearchError> {
         let root = runs_dir.as_ref();
         if !root.exists() {
             return Ok(0);
         }
+        let mut existing = self.existing_session_keys()?;
         let mut ingested = 0usize;
         let read = std::fs::read_dir(root).map_err(|e| SearchError::io(root, e))?;
         for entry in read {
@@ -540,7 +646,8 @@ impl SearchIndex {
                         continue;
                     }
                 };
-                if self.has_session(run_id, session.index)? {
+                let key = (run_id.to_owned(), session.index);
+                if existing.contains(&key) {
                     continue;
                 }
                 if let Err(e) = self.ingest_session(run_id, &session) {
@@ -551,6 +658,7 @@ impl SearchIndex {
                     );
                     continue;
                 }
+                existing.insert(key);
                 ingested = ingested.saturating_add(1);
             }
         }
@@ -578,7 +686,9 @@ impl SearchIndex {
             return Err(SearchError::invalid_query("query must not be empty"));
         }
         let limit = limit.clamp(1, 200);
-        let since_str = since.as_ref().map(DateTime::to_rfc3339);
+        // Use Unix epoch for time comparison so the filter is robust
+        // against `Z` vs `+00:00` formatting drift in the text column.
+        let since_unix = since.as_ref().map(DateTime::timestamp);
 
         let conn = self.lock_conn()?;
         let mut hits: Vec<SearchHit> = Vec::new();
@@ -590,7 +700,7 @@ impl SearchIndex {
                        FROM sessions_fts
                        JOIN sessions s ON s.rowid = sessions_fts.rowid
                        WHERE sessions_fts MATCH ?1
-                         AND (?2 IS NULL OR s.started_at >= ?2)
+                         AND (?2 IS NULL OR s.started_at_unix >= ?2)
                        ORDER BY bm25(sessions_fts) ASC
                        LIMIT ?3";
             let mut stmt = conn
@@ -598,7 +708,7 @@ impl SearchIndex {
                 .map_err(|e| SearchError::sqlite("prepare summary query", e))?;
             let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
             let rows = stmt
-                .query_map(params![query, since_str, limit_i64], |row| {
+                .query_map(params![query, since_unix, limit_i64], |row| {
                     let raw_score: f64 = row.get(5)?;
                     Ok(SearchHit {
                         run_id: row.get(0)?,
@@ -627,7 +737,7 @@ impl SearchIndex {
                        JOIN turns t ON t.rowid = turns_fts.rowid
                        LEFT JOIN sessions s ON s.run_id = t.run_id AND s.session_num = t.session_num
                        WHERE turns_fts MATCH ?1
-                         AND (?2 IS NULL OR s.started_at IS NULL OR s.started_at >= ?2)
+                         AND (?2 IS NULL OR s.started_at_unix IS NULL OR s.started_at_unix >= ?2)
                        ORDER BY bm25(turns_fts) ASC
                        LIMIT ?3";
             let mut stmt = conn
@@ -635,7 +745,7 @@ impl SearchIndex {
                 .map_err(|e| SearchError::sqlite("prepare turns query", e))?;
             let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
             let rows = stmt
-                .query_map(params![query, since_str, limit_i64], |row| {
+                .query_map(params![query, since_unix, limit_i64], |row| {
                     let raw_score: f64 = row.get(5)?;
                     Ok(SearchHit {
                         run_id: row.get(0)?,
@@ -693,12 +803,13 @@ impl SearchIndex {
     }
 
     /// Lock the connection mutex, mapping a poisoned mutex to a
-    /// [`SearchError`].
+    /// dedicated [`SearchError::MutexPoisoned`] variant so callers can
+    /// distinguish "another thread panicked" from a real sqlite
+    /// failure.
     fn lock_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>, SearchError> {
-        self.conn.lock().map_err(|_poison| SearchError::Sqlite {
-            context: "search index mutex poisoned".to_owned(),
-            source: rusqlite::Error::InvalidQuery,
-        })
+        self.conn
+            .lock()
+            .map_err(|_poison| SearchError::mutex_poisoned("search index connection"))
     }
 }
 
@@ -894,5 +1005,135 @@ mod tests {
             .query("   ", 10, SearchScope::Summary, None)
             .expect_err("must reject empty query");
         assert!(matches!(err, SearchError::InvalidQuery { .. }));
+    }
+
+    /// Regression test for issue #53 review feedback (HIGH #1):
+    /// previously, `ingest_session` deleted the base `sessions` row
+    /// before running the FTS5 cleanup whose subquery joined back to
+    /// `sessions`. The subquery returned zero rows so the old FTS row
+    /// stuck around, then the next INSERT into `sessions_fts`
+    /// collided on rowid (or, with external-content FTS, left
+    /// orphaned rows that bloated the index).
+    ///
+    /// Re-ingesting the same `(run_id, session_num)` twice must:
+    /// - succeed both times,
+    /// - leave exactly one row in `sessions` and one in `sessions_fts`,
+    /// - reflect the latest summary text in subsequent queries.
+    #[test]
+    fn reingest_same_session_keeps_one_row_in_sessions_and_fts() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+
+        // First ingest with summary A.
+        let mut s1 = session_with_summary(7, "first revision: noisy summary");
+        s1.started_at = Utc::now() - Duration::hours(1);
+        idx.ingest_session("run-zzz", &s1)
+            .expect("first ingest must succeed");
+
+        // Same `(run_id, session_num)` again with a different summary.
+        let mut s2 = session_with_summary(7, "revised summary covers oauth");
+        s2.started_at = Utc::now();
+        idx.ingest_session("run-zzz", &s2)
+            .expect("re-ingest must succeed (would fail on rowid collision pre-fix)");
+
+        // Direct row-count assertions on both tables.
+        let sessions_count: i64 = {
+            let conn = idx.lock_conn().expect("lock");
+            conn.query_row(
+                "SELECT COUNT(*) FROM sessions WHERE run_id = ?1 AND session_num = ?2",
+                params!["run-zzz", 7],
+                |row| row.get(0),
+            )
+            .expect("count sessions")
+        };
+        assert_eq!(sessions_count, 1, "exactly one base row expected");
+
+        let fts_count: i64 = {
+            let conn = idx.lock_conn().expect("lock");
+            conn.query_row(
+                "SELECT COUNT(*) FROM sessions_fts WHERE rowid IN (
+                    SELECT rowid FROM sessions WHERE run_id = ?1 AND session_num = ?2
+                )",
+                params!["run-zzz", 7],
+                |row| row.get(0),
+            )
+            .expect("count sessions_fts")
+        };
+        assert_eq!(
+            fts_count, 1,
+            "exactly one FTS row expected; pre-fix this would be 0 (orphan) or >1"
+        );
+
+        // Sanity: query reflects the latest summary, not the initial
+        // one. If the FTS update path were broken, the old row's
+        // tokens would still match.
+        let hits_old = idx
+            .query("noisy", 10, SearchScope::Summary, None)
+            .expect("query old");
+        assert!(
+            hits_old.is_empty(),
+            "old summary must not match: {hits_old:?}"
+        );
+        let hits_new = idx
+            .query("oauth", 10, SearchScope::Summary, None)
+            .expect("query new");
+        assert_eq!(hits_new.len(), 1);
+        assert!(hits_new[0].summary.contains("oauth"), "{hits_new:?}");
+    }
+
+    /// Regression test for issue #53 review feedback (MEDIUM #3): the
+    /// original `since` implementation compared RFC3339 strings, so a
+    /// row stored with `+00:00` would not be matched by a cutoff
+    /// rendered with `Z` (or vice versa). With the v2 schema we
+    /// compare Unix epoch integers, which is invariant under
+    /// formatting drift.
+    #[test]
+    fn since_filter_handles_mixed_timezone_formatting() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+
+        // We can't directly choose `Z` vs `+00:00` in chrono's
+        // `to_rfc3339` output (it picks one), but the canonical safe
+        // check is that two timestamps an hour apart with different
+        // serializations both filter correctly through `since`.
+        let now = Utc::now();
+        let mut older = session_with_summary(1, "old oauth bug");
+        older.started_at = now - Duration::hours(2);
+        idx.ingest_session("run-tz", &older).expect("old ingest");
+        let mut newer = session_with_summary(2, "new oauth fix");
+        newer.started_at = now;
+        idx.ingest_session("run-tz", &newer).expect("new ingest");
+
+        // Cutoff one hour ago — should pick up only the newer row.
+        let cutoff = now - Duration::hours(1);
+        let hits = idx
+            .query("oauth", 10, SearchScope::Summary, Some(cutoff))
+            .expect("since query");
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].session_num, 2);
+
+        // Now corrupt one row's `started_at` text to use a different
+        // formatting (`+00:00` instead of `Z`). The string column
+        // becomes inconsistent with what chrono produced, but the
+        // numeric `started_at_unix` column stays correct, so the
+        // since filter must still return the same hit set.
+        {
+            let conn = idx.lock_conn().expect("lock");
+            conn.execute(
+                "UPDATE sessions SET started_at = REPLACE(started_at, 'Z', '+00:00') \
+                 WHERE run_id = ?1",
+                params!["run-tz"],
+            )
+            .expect("rewrite started_at");
+        }
+        let hits2 = idx
+            .query("oauth", 10, SearchScope::Summary, Some(cutoff))
+            .expect("since query 2");
+        assert_eq!(
+            hits2.len(),
+            1,
+            "since filter must still find the recent row after format drift: {hits2:?}"
+        );
+        assert_eq!(hits2[0].session_num, 2);
     }
 }

--- a/crates/tmg-search/src/index.rs
+++ b/crates/tmg-search/src/index.rs
@@ -1,0 +1,898 @@
+//! [`SearchIndex`]: `SQLite` + FTS5 store of session summaries and turn
+//! transcripts.
+//!
+//! The index lives at `<project_root>/.tsumugi/state.db` and is
+//! populated through two paths:
+//!
+//! - **Session-end hook**: the harness calls
+//!   [`SearchIndex::ingest_session`] after writing
+//!   `session_NNN.json`. This is the live path that keeps the DB
+//!   incremental.
+//! - **Rebuild scan**: [`SearchIndex::rebuild_from_disk`] walks every
+//!   `.tsumugi/runs/*/session_log/*.json` and ingests anything whose
+//!   `(run_id, session_num)` pair is not yet present. Used by the
+//!   `tmg search rebuild` CLI subcommand and on first startup so a
+//!   pre-existing project picks up its history.
+//!
+//! Schema (also documented in issue #53):
+//!
+//! ```sql
+//! CREATE TABLE sessions (
+//!     run_id TEXT NOT NULL,
+//!     session_num INTEGER NOT NULL,
+//!     started_at TEXT NOT NULL,
+//!     ended_at TEXT,
+//!     trigger TEXT,                        -- SessionEndTrigger tag
+//!     summary TEXT,                        -- redacted summary text
+//!     files_modified TEXT,                 -- JSON array
+//!     tool_calls_count INTEGER,
+//!     PRIMARY KEY (run_id, session_num)
+//! );
+//! CREATE VIRTUAL TABLE sessions_fts USING fts5(
+//!     summary, files_modified,
+//!     content='sessions', content_rowid='rowid'
+//! );
+//! CREATE TABLE turns (
+//!     run_id TEXT NOT NULL,
+//!     session_num INTEGER NOT NULL,
+//!     turn_num INTEGER NOT NULL,
+//!     user_input TEXT,
+//!     agent_text TEXT,
+//!     tool_calls TEXT,
+//!     PRIMARY KEY (run_id, session_num, turn_num)
+//! );
+//! CREATE VIRTUAL TABLE turns_fts USING fts5(
+//!     user_input, agent_text,
+//!     content='turns', content_rowid='rowid'
+//! );
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use rusqlite::{Connection, OptionalExtension as _, params};
+use serde::{Deserialize, Serialize};
+use tmg_harness::Session;
+
+use crate::error::SearchError;
+use crate::redact::redact_secrets;
+
+/// Search-result row returned by [`SearchIndex::query`].
+///
+/// `score` is the BM25 ranking value sqlite reports — lower is more
+/// relevant in FTS5's convention. We invert it to a positive
+/// "relevance" before returning so ranking sorts naturally; the raw
+/// BM25 score is preserved when callers need to pass it back into
+/// sqlite.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchHit {
+    /// The owning run's id (string form).
+    pub run_id: String,
+    /// Session sequence number within the run.
+    pub session_num: u32,
+    /// When the session started (ISO8601 / RFC3339).
+    pub started_at: String,
+    /// Free-form summary text, possibly empty.
+    pub summary: String,
+    /// FTS5 snippet with `<mark>...</mark>` highlights around match
+    /// terms. Empty when the row matched only on the summary column
+    /// and the snippet helper found nothing in the configured
+    /// extraction window.
+    pub snippet: String,
+    /// Inverted BM25 score (higher is more relevant).
+    pub score: f64,
+}
+
+/// Search scope — which FTS table(s) to consult.
+///
+/// `Summary` only hits `sessions_fts`, `Turns` only hits `turns_fts`,
+/// and `All` does both and unions the results by `(run_id,
+/// session_num)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchScope {
+    /// Match against per-session summary text.
+    Summary,
+    /// Match against turn-level user / agent / tool text.
+    Turns,
+    /// Match both tables; deduplicated by `(run_id, session_num)`.
+    All,
+}
+
+impl SearchScope {
+    /// Parse a scope string from the tool / CLI surface.
+    ///
+    /// Accepts `"summary"`, `"turns"`, `"all"`. Empty or unknown values
+    /// fall back to [`SearchScope::All`] so a partial / new caller is
+    /// never blocked on the most permissive option.
+    #[must_use]
+    pub fn parse(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "summary" => Self::Summary,
+            "turns" => Self::Turns,
+            _ => Self::All,
+        }
+    }
+}
+
+/// Schema version pinned in the `meta` key/value table. Bumping this
+/// triggers a migration path on next [`SearchIndex::open`].
+const SCHEMA_VERSION: i64 = 1;
+
+/// Persistent search index. Cloning a [`SearchIndex`] is cheap
+/// (`Arc`-style) and produces another handle to the same underlying
+/// connection mutex.
+///
+/// The connection is wrapped in a `Mutex<Connection>` because rusqlite
+/// connections are `!Sync`. Concurrent callers serialize on the
+/// mutex; a future enhancement could move to a connection pool.
+pub struct SearchIndex {
+    /// Mutex-guarded connection. `Box::leak` is not required because
+    /// the index struct owns the connection.
+    conn: Mutex<Connection>,
+    /// On-disk path of the database file. Kept for diagnostics
+    /// (`tmg search stats`) and error reporting.
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for SearchIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The `conn` mutex wraps a `rusqlite::Connection` which is not
+        // `Debug`; surface the path only and finish non-exhaustive so
+        // the elision is visible at the call site.
+        f.debug_struct("SearchIndex")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Snapshot of DB statistics for `tmg search stats`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchStats {
+    /// Number of indexed sessions.
+    pub sessions: u64,
+    /// Number of indexed turns.
+    pub turns: u64,
+    /// Size of the on-disk database file in bytes (0 when the file
+    /// doesn't exist yet).
+    pub size_bytes: u64,
+    /// Path to the database file.
+    pub db_path: PathBuf,
+}
+
+/// One turn record fed into [`SearchIndex::ingest_turn`]. Strings are
+/// redacted before insertion.
+///
+/// We keep this structure here rather than mirroring [`Session`]'s
+/// turn schema because the harness's `session_NNN.json` does **not**
+/// currently persist per-turn text — that is the trajectory recorder
+/// (#55). Until that lands, the only ingest path is "summary only",
+/// which is honoured by [`SearchIndex::ingest_session`] (it writes a
+/// row into `sessions` but no rows into `turns`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TurnRecord {
+    /// Sequence number within the session.
+    pub turn_num: u32,
+    /// Verbatim user input that opened the turn (may be empty for
+    /// agent-only turns, e.g. self-reflection).
+    pub user_input: String,
+    /// Agent's response text after redaction.
+    pub agent_text: String,
+    /// JSON-serialized tool call array (the same shape the agent loop
+    /// already produces).
+    pub tool_calls: String,
+}
+
+impl SearchIndex {
+    /// Open or create the index at `db_path`, running migrations as
+    /// needed.
+    ///
+    /// Creates parent directories if missing. The schema is laid down
+    /// idempotently on first open; subsequent opens verify the
+    /// `schema_version` value and refuse to proceed when the on-disk
+    /// version is newer than [`SCHEMA_VERSION`] — we never
+    /// auto-downgrade.
+    pub fn open(db_path: impl AsRef<Path>) -> Result<Self, SearchError> {
+        let path = db_path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| SearchError::io(parent.to_path_buf(), e))?;
+        }
+        let conn = Connection::open(&path).map_err(|e| SearchError::sqlite("open db", e))?;
+        // Reasonable defaults for a single-writer process: WAL
+        // tolerates concurrent reads while ingest is writing.
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .map_err(|e| SearchError::sqlite("set journal_mode", e))?;
+        conn.pragma_update(None, "synchronous", "NORMAL")
+            .map_err(|e| SearchError::sqlite("set synchronous", e))?;
+
+        Self::ensure_schema(&conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+            path,
+        })
+    }
+
+    /// Borrow the on-disk path (used by `tmg search stats`).
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Apply the schema (idempotent). Bumping [`SCHEMA_VERSION`] lands
+    /// here as a `match` on the stored version.
+    fn ensure_schema(conn: &Connection) -> Result<(), SearchError> {
+        // Single-shot multi-statement SQL via `execute_batch`. The
+        // FTS5 virtual tables use `content=` external-content syntax
+        // so we maintain the FTS rows manually with INSERT/DELETE
+        // triggers (avoids the FTS table doubling DB size).
+        let sql = "
+            CREATE TABLE IF NOT EXISTS meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS sessions (
+                run_id TEXT NOT NULL,
+                session_num INTEGER NOT NULL,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                trigger TEXT,
+                summary TEXT,
+                files_modified TEXT,
+                tool_calls_count INTEGER,
+                PRIMARY KEY (run_id, session_num)
+            );
+            CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts USING fts5(
+                summary,
+                files_modified,
+                content='sessions',
+                content_rowid='rowid'
+            );
+            CREATE TABLE IF NOT EXISTS turns (
+                run_id TEXT NOT NULL,
+                session_num INTEGER NOT NULL,
+                turn_num INTEGER NOT NULL,
+                user_input TEXT,
+                agent_text TEXT,
+                tool_calls TEXT,
+                PRIMARY KEY (run_id, session_num, turn_num)
+            );
+            CREATE VIRTUAL TABLE IF NOT EXISTS turns_fts USING fts5(
+                user_input,
+                agent_text,
+                content='turns',
+                content_rowid='rowid'
+            );
+        ";
+        conn.execute_batch(sql)
+            .map_err(|e| SearchError::sqlite("create schema", e))?;
+
+        // Read or initialise schema_version.
+        let stored: Option<i64> = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'schema_version'",
+                [],
+                |row| {
+                    row.get::<_, String>(0)
+                        .map(|s| s.parse::<i64>().unwrap_or(0))
+                },
+            )
+            .optional()
+            .map_err(|e| SearchError::sqlite("read schema_version", e))?;
+
+        match stored {
+            None => {
+                conn.execute(
+                    "INSERT INTO meta(key, value) VALUES('schema_version', ?1)",
+                    params![SCHEMA_VERSION.to_string()],
+                )
+                .map_err(|e| SearchError::sqlite("write schema_version", e))?;
+            }
+            Some(v) if v == SCHEMA_VERSION => {}
+            Some(v) if v > SCHEMA_VERSION => {
+                return Err(SearchError::Sqlite {
+                    context: format!(
+                        "on-disk schema_version {v} is newer than supported {SCHEMA_VERSION}; \
+                         upgrade tsumugi or delete state.db to rebuild"
+                    ),
+                    source: rusqlite::Error::InvalidQuery,
+                });
+            }
+            Some(_v) => {
+                // Future migration path: bump the stored value here.
+                // For schema v1 there is nothing to migrate.
+                conn.execute(
+                    "UPDATE meta SET value = ?1 WHERE key = 'schema_version'",
+                    params![SCHEMA_VERSION.to_string()],
+                )
+                .map_err(|e| SearchError::sqlite("update schema_version", e))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Insert (or replace) the session row with redacted text. Existing
+    /// turns for the same `(run_id, session_num)` are left untouched.
+    ///
+    /// Returns `Ok(())` even when the summary is empty — the row is
+    /// still indexed so `rebuild_from_disk` does not re-process it on
+    /// every startup.
+    pub fn ingest_session(&self, run_id: &str, session: &Session) -> Result<(), SearchError> {
+        let summary = redact_secrets(&session.summary);
+        let files_modified = serde_json::to_string(&session.files_modified)
+            .map_err(|e| SearchError::json("serialize files_modified", e))?;
+        // Redact filenames too — paths sometimes embed credentials in
+        // tokenised URLs.
+        let files_modified = redact_secrets(&files_modified);
+        let started_at = session.started_at.to_rfc3339();
+        let ended_at = session.ended_at.as_ref().map(DateTime::to_rfc3339);
+        let trigger = session.end_trigger.as_ref().map(|t| match t {
+            tmg_harness::SessionEndTrigger::Completed => "completed".to_owned(),
+            tmg_harness::SessionEndTrigger::UserCancelled => "user_cancelled".to_owned(),
+            tmg_harness::SessionEndTrigger::Rotated { .. } => "rotated".to_owned(),
+            tmg_harness::SessionEndTrigger::Errored { .. } => "errored".to_owned(),
+            tmg_harness::SessionEndTrigger::UserExit => "user_exit".to_owned(),
+            tmg_harness::SessionEndTrigger::ContextRotation => "context_rotation".to_owned(),
+            tmg_harness::SessionEndTrigger::Timeout => "timeout".to_owned(),
+            tmg_harness::SessionEndTrigger::UserNewSession => "user_new_session".to_owned(),
+        });
+
+        let conn = self.lock_conn()?;
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| SearchError::sqlite("begin tx", e))?;
+
+        // Upsert the row. We delete the old FTS row first and re-insert
+        // because external-content FTS5 doesn't auto-track UPDATEs.
+        tx.execute(
+            "DELETE FROM sessions WHERE run_id = ?1 AND session_num = ?2",
+            params![run_id, session.index],
+        )
+        .map_err(|e| SearchError::sqlite("delete old sessions row", e))?;
+        tx.execute(
+            "DELETE FROM sessions_fts WHERE rowid IN (
+                SELECT rowid FROM sessions WHERE run_id = ?1 AND session_num = ?2
+            )",
+            params![run_id, session.index],
+        )
+        .map_err(|e| SearchError::sqlite("delete old sessions_fts row", e))?;
+
+        tx.execute(
+            "INSERT INTO sessions(
+                run_id, session_num, started_at, ended_at, trigger,
+                summary, files_modified, tool_calls_count
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                run_id,
+                session.index,
+                started_at,
+                ended_at,
+                trigger,
+                summary,
+                files_modified,
+                session.tool_calls_count,
+            ],
+        )
+        .map_err(|e| SearchError::sqlite("insert sessions row", e))?;
+
+        let rowid: i64 = tx
+            .query_row(
+                "SELECT rowid FROM sessions WHERE run_id = ?1 AND session_num = ?2",
+                params![run_id, session.index],
+                |row| row.get(0),
+            )
+            .map_err(|e| SearchError::sqlite("read sessions rowid", e))?;
+        tx.execute(
+            "INSERT INTO sessions_fts(rowid, summary, files_modified) VALUES (?1, ?2, ?3)",
+            params![rowid, summary, files_modified],
+        )
+        .map_err(|e| SearchError::sqlite("insert sessions_fts row", e))?;
+
+        tx.commit()
+            .map_err(|e| SearchError::sqlite("commit tx", e))?;
+        Ok(())
+    }
+
+    /// Insert one turn record into the index. Both `user_input` and
+    /// `agent_text` are run through [`redact_secrets`] before
+    /// insertion.
+    ///
+    /// Used by the trajectory recorder (#55); the live session-end
+    /// hook in this issue only writes session rows.
+    pub fn ingest_turn(
+        &self,
+        run_id: &str,
+        session_num: u32,
+        turn: &TurnRecord,
+    ) -> Result<(), SearchError> {
+        let user_input = redact_secrets(&turn.user_input);
+        let agent_text = redact_secrets(&turn.agent_text);
+        let tool_calls = redact_secrets(&turn.tool_calls);
+        let conn = self.lock_conn()?;
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| SearchError::sqlite("begin tx (turn)", e))?;
+        tx.execute(
+            "DELETE FROM turns_fts WHERE rowid IN (
+                SELECT rowid FROM turns WHERE run_id = ?1 AND session_num = ?2 AND turn_num = ?3
+            )",
+            params![run_id, session_num, turn.turn_num],
+        )
+        .map_err(|e| SearchError::sqlite("delete old turns_fts row", e))?;
+        tx.execute(
+            "DELETE FROM turns WHERE run_id = ?1 AND session_num = ?2 AND turn_num = ?3",
+            params![run_id, session_num, turn.turn_num],
+        )
+        .map_err(|e| SearchError::sqlite("delete old turns row", e))?;
+        tx.execute(
+            "INSERT INTO turns(run_id, session_num, turn_num, user_input, agent_text, tool_calls)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                run_id,
+                session_num,
+                turn.turn_num,
+                user_input,
+                agent_text,
+                tool_calls,
+            ],
+        )
+        .map_err(|e| SearchError::sqlite("insert turn row", e))?;
+        let rowid: i64 = tx
+            .query_row(
+                "SELECT rowid FROM turns WHERE run_id = ?1 AND session_num = ?2 AND turn_num = ?3",
+                params![run_id, session_num, turn.turn_num],
+                |row| row.get(0),
+            )
+            .map_err(|e| SearchError::sqlite("read turn rowid", e))?;
+        tx.execute(
+            "INSERT INTO turns_fts(rowid, user_input, agent_text) VALUES (?1, ?2, ?3)",
+            params![rowid, user_input, agent_text],
+        )
+        .map_err(|e| SearchError::sqlite("insert turns_fts row", e))?;
+        tx.commit()
+            .map_err(|e| SearchError::sqlite("commit turn tx", e))?;
+        Ok(())
+    }
+
+    /// Whether the DB already has a row for `(run_id, session_num)`.
+    /// Used by [`Self::rebuild_from_disk`] to skip already-indexed
+    /// sessions.
+    pub fn has_session(&self, run_id: &str, session_num: u32) -> Result<bool, SearchError> {
+        let conn = self.lock_conn()?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE run_id = ?1 AND session_num = ?2",
+                params![run_id, session_num],
+                |row| row.get(0),
+            )
+            .map_err(|e| SearchError::sqlite("count sessions", e))?;
+        Ok(count > 0)
+    }
+
+    /// Walk `runs_dir`, find every `session_NNN.json`, and ingest those
+    /// not already in the DB. Returns the count of newly-ingested
+    /// sessions.
+    ///
+    /// Files that fail to parse or contain malformed JSON are logged
+    /// via `tracing::warn!` and skipped — a single corrupt session
+    /// must not stop the rebuild from progressing.
+    pub fn rebuild_from_disk(&self, runs_dir: impl AsRef<Path>) -> Result<usize, SearchError> {
+        let root = runs_dir.as_ref();
+        if !root.exists() {
+            return Ok(0);
+        }
+        let mut ingested = 0usize;
+        let read = std::fs::read_dir(root).map_err(|e| SearchError::io(root, e))?;
+        for entry in read {
+            let entry = entry.map_err(|e| SearchError::io(root, e))?;
+            let one_run = entry.path();
+            if !one_run.is_dir() {
+                continue;
+            }
+            let Some(run_id) = one_run.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let session_log_dir = one_run.join(tmg_harness::SESSION_LOG_DIRNAME);
+            if !session_log_dir.exists() {
+                continue;
+            }
+            let session_files = std::fs::read_dir(&session_log_dir)
+                .map_err(|e| SearchError::io(session_log_dir.clone(), e))?;
+            for f in session_files {
+                let f = f.map_err(|e| SearchError::io(session_log_dir.clone(), e))?;
+                let path = f.path();
+                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                if !name.starts_with("session_")
+                    || !std::path::Path::new(name)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+                {
+                    continue;
+                }
+                // session_summaries.json is a sibling, not a
+                // session_NNN file — skip explicitly.
+                if name == "session_summaries.json" {
+                    continue;
+                }
+                let raw = match std::fs::read_to_string(&path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::warn!(
+                            file = %path.display(),
+                            error = %e,
+                            "skipping unreadable session log"
+                        );
+                        continue;
+                    }
+                };
+                let session: Session = match serde_json::from_str(&raw) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(
+                            file = %path.display(),
+                            error = %e,
+                            "skipping unparsable session log"
+                        );
+                        continue;
+                    }
+                };
+                if self.has_session(run_id, session.index)? {
+                    continue;
+                }
+                if let Err(e) = self.ingest_session(run_id, &session) {
+                    tracing::warn!(
+                        file = %path.display(),
+                        error = %e,
+                        "failed to ingest session into search index"
+                    );
+                    continue;
+                }
+                ingested = ingested.saturating_add(1);
+            }
+        }
+        Ok(ingested)
+    }
+
+    /// Run a search query against the configured `scope`.
+    ///
+    /// `query` is an FTS5 MATCH expression — operators (`AND`, `OR`,
+    /// `NEAR`, prefix `*`) work as documented by `SQLite`. `limit` is
+    /// clamped to `[1, 200]`. `since`, when provided, restricts the
+    /// result to sessions that started at or after the given instant.
+    ///
+    /// Results are ordered by inverted BM25 (most-relevant first) and
+    /// deduplicated by `(run_id, session_num)` when `scope ==
+    /// SearchScope::All`.
+    pub fn query(
+        &self,
+        query: &str,
+        limit: usize,
+        scope: SearchScope,
+        since: Option<DateTime<Utc>>,
+    ) -> Result<Vec<SearchHit>, SearchError> {
+        if query.trim().is_empty() {
+            return Err(SearchError::invalid_query("query must not be empty"));
+        }
+        let limit = limit.clamp(1, 200);
+        let since_str = since.as_ref().map(DateTime::to_rfc3339);
+
+        let conn = self.lock_conn()?;
+        let mut hits: Vec<SearchHit> = Vec::new();
+
+        if matches!(scope, SearchScope::Summary | SearchScope::All) {
+            let sql = "SELECT s.run_id, s.session_num, s.started_at, s.summary,
+                              snippet(sessions_fts, 0, '<mark>', '</mark>', '...', 16),
+                              bm25(sessions_fts)
+                       FROM sessions_fts
+                       JOIN sessions s ON s.rowid = sessions_fts.rowid
+                       WHERE sessions_fts MATCH ?1
+                         AND (?2 IS NULL OR s.started_at >= ?2)
+                       ORDER BY bm25(sessions_fts) ASC
+                       LIMIT ?3";
+            let mut stmt = conn
+                .prepare(sql)
+                .map_err(|e| SearchError::sqlite("prepare summary query", e))?;
+            let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+            let rows = stmt
+                .query_map(params![query, since_str, limit_i64], |row| {
+                    let raw_score: f64 = row.get(5)?;
+                    Ok(SearchHit {
+                        run_id: row.get(0)?,
+                        session_num: row.get(1)?,
+                        started_at: row.get(2)?,
+                        summary: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
+                        snippet: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+                        score: -raw_score,
+                    })
+                })
+                .map_err(|e| SearchError::sqlite("execute summary query", e))?;
+            for r in rows {
+                hits.push(r.map_err(|e| SearchError::sqlite("read summary row", e))?);
+            }
+        }
+
+        if matches!(scope, SearchScope::Turns | SearchScope::All) {
+            let sql = "SELECT t.run_id, t.session_num,
+                              COALESCE((SELECT s.started_at FROM sessions s
+                                        WHERE s.run_id = t.run_id AND s.session_num = t.session_num), ''),
+                              COALESCE((SELECT s.summary FROM sessions s
+                                        WHERE s.run_id = t.run_id AND s.session_num = t.session_num), ''),
+                              snippet(turns_fts, 1, '<mark>', '</mark>', '...', 16),
+                              bm25(turns_fts)
+                       FROM turns_fts
+                       JOIN turns t ON t.rowid = turns_fts.rowid
+                       LEFT JOIN sessions s ON s.run_id = t.run_id AND s.session_num = t.session_num
+                       WHERE turns_fts MATCH ?1
+                         AND (?2 IS NULL OR s.started_at IS NULL OR s.started_at >= ?2)
+                       ORDER BY bm25(turns_fts) ASC
+                       LIMIT ?3";
+            let mut stmt = conn
+                .prepare(sql)
+                .map_err(|e| SearchError::sqlite("prepare turns query", e))?;
+            let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+            let rows = stmt
+                .query_map(params![query, since_str, limit_i64], |row| {
+                    let raw_score: f64 = row.get(5)?;
+                    Ok(SearchHit {
+                        run_id: row.get(0)?,
+                        session_num: row.get(1)?,
+                        started_at: row.get::<_, Option<String>>(2)?.unwrap_or_default(),
+                        summary: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
+                        snippet: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+                        score: -raw_score,
+                    })
+                })
+                .map_err(|e| SearchError::sqlite("execute turns query", e))?;
+            for r in rows {
+                hits.push(r.map_err(|e| SearchError::sqlite("read turns row", e))?);
+            }
+        }
+
+        // Deduplicate by `(run_id, session_num)` when both tables were
+        // queried, keeping the highest-scoring hit per session.
+        if matches!(scope, SearchScope::All) {
+            hits.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            let mut seen: std::collections::HashSet<(String, u32)> =
+                std::collections::HashSet::new();
+            hits.retain(|h| seen.insert((h.run_id.clone(), h.session_num)));
+        } else {
+            hits.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+        }
+        hits.truncate(limit);
+        Ok(hits)
+    }
+
+    /// Compute aggregate stats for `tmg search stats`.
+    pub fn stats(&self) -> Result<SearchStats, SearchError> {
+        let conn = self.lock_conn()?;
+        let sessions: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+            .map_err(|e| SearchError::sqlite("count sessions", e))?;
+        let turns: i64 = conn
+            .query_row("SELECT COUNT(*) FROM turns", [], |row| row.get(0))
+            .map_err(|e| SearchError::sqlite("count turns", e))?;
+        let size_bytes = std::fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0);
+        Ok(SearchStats {
+            sessions: u64::try_from(sessions).unwrap_or(0),
+            turns: u64::try_from(turns).unwrap_or(0),
+            size_bytes,
+            db_path: self.path.clone(),
+        })
+    }
+
+    /// Lock the connection mutex, mapping a poisoned mutex to a
+    /// [`SearchError`].
+    fn lock_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>, SearchError> {
+        self.conn.lock().map_err(|_poison| SearchError::Sqlite {
+            context: "search index mutex poisoned".to_owned(),
+            source: rusqlite::Error::InvalidQuery,
+        })
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test assertions use expect for clearer messages"
+)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+    use tempfile::TempDir;
+    use tmg_harness::{SessionEndTrigger, SessionLog};
+
+    fn fresh_index(tmp: &TempDir) -> SearchIndex {
+        SearchIndex::open(tmp.path().join("state.db")).expect("open index")
+    }
+
+    fn session_with_summary(index: u32, summary: &str) -> Session {
+        let mut s = Session::begin(index);
+        s.summary = summary.to_owned();
+        s.tool_calls_count = 3;
+        s.files_modified.push("src/foo.rs".to_owned());
+        s.end(SessionEndTrigger::Completed);
+        s
+    }
+
+    #[test]
+    fn open_creates_schema_and_idempotent() {
+        let tmp = TempDir::new().expect("tempdir");
+        let _idx = fresh_index(&tmp);
+        // Reopen should not error.
+        let _idx2 = fresh_index(&tmp);
+    }
+
+    #[test]
+    fn ingest_then_query_summary_roundtrip() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+        let s = session_with_summary(1, "implemented OAuth callback handler in axum");
+        idx.ingest_session("run-aaa", &s).expect("ingest");
+
+        let hits = idx
+            .query("OAuth", 10, SearchScope::Summary, None)
+            .expect("query");
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].run_id, "run-aaa");
+        assert_eq!(hits[0].session_num, 1);
+        assert!(hits[0].snippet.contains("<mark>OAuth</mark>"), "{hits:?}");
+    }
+
+    #[test]
+    fn ingest_session_redacts_secrets_in_summary() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+        let s = session_with_summary(1, "deployed with key AKIAIOSFODNN7EXAMPLE during rollout");
+        idx.ingest_session("run-aaa", &s).expect("ingest");
+        let hits = idx
+            .query("rollout", 10, SearchScope::Summary, None)
+            .expect("query");
+        assert_eq!(hits.len(), 1);
+        assert!(!hits[0].summary.contains("AKIAIOSFODNN7EXAMPLE"));
+        assert!(hits[0].summary.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn empty_summary_still_indexes() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+        let s = session_with_summary(1, "");
+        idx.ingest_session("run-aaa", &s).expect("ingest");
+        assert!(idx.has_session("run-aaa", 1).expect("has"));
+    }
+
+    #[test]
+    fn since_filter_excludes_older_sessions() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+        let mut old = session_with_summary(1, "early oauth bug");
+        old.started_at = Utc::now() - Duration::days(30);
+        idx.ingest_session("run-aaa", &old).expect("old");
+        let mut new = session_with_summary(2, "recent oauth fix");
+        new.started_at = Utc::now();
+        idx.ingest_session("run-aaa", &new).expect("new");
+
+        let cutoff = Utc::now() - Duration::days(1);
+        let hits = idx
+            .query("oauth", 10, SearchScope::Summary, Some(cutoff))
+            .expect("query");
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].session_num, 2);
+    }
+
+    #[test]
+    fn scope_summary_only_misses_turn_text() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+        let s = session_with_summary(1, "");
+        idx.ingest_session("run-aaa", &s).expect("ingest session");
+
+        idx.ingest_turn(
+            "run-aaa",
+            1,
+            &TurnRecord {
+                turn_num: 1,
+                user_input: "tell me about webhooks".to_owned(),
+                agent_text: "webhooks are HTTP callbacks".to_owned(),
+                tool_calls: "[]".to_owned(),
+            },
+        )
+        .expect("ingest turn");
+
+        let hits_summary = idx
+            .query("webhooks", 10, SearchScope::Summary, None)
+            .expect("summary query");
+        assert!(
+            hits_summary.is_empty(),
+            "summary scope must not match turn text: {hits_summary:?}"
+        );
+        let hits_turns = idx
+            .query("webhooks", 10, SearchScope::Turns, None)
+            .expect("turns query");
+        assert_eq!(hits_turns.len(), 1);
+        let hits_all = idx
+            .query("webhooks", 10, SearchScope::All, None)
+            .expect("all query");
+        assert_eq!(hits_all.len(), 1);
+    }
+
+    #[test]
+    fn rebuild_from_disk_picks_up_unindexed_sessions() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root_runs = tmp.path().join("runs");
+        let run_id = "run-bbb";
+        let one_run = root_runs.join(run_id);
+        let log = SessionLog::new(one_run.join(tmg_harness::SESSION_LOG_DIRNAME));
+        let mut s = Session::begin(1);
+        s.summary = "rebuilt projects via search index".to_owned();
+        s.end(SessionEndTrigger::Completed);
+        log.save(&s).expect("save session");
+
+        let idx = SearchIndex::open(tmp.path().join("state.db")).expect("open");
+        let count = idx.rebuild_from_disk(&root_runs).expect("rebuild");
+        assert_eq!(count, 1);
+        // Re-running rebuild is a no-op now.
+        let again = idx.rebuild_from_disk(&root_runs).expect("rebuild2");
+        assert_eq!(again, 0);
+        assert!(idx.has_session(run_id, 1).expect("has"));
+    }
+
+    #[test]
+    fn stats_reports_counts() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+        let s = session_with_summary(1, "stat me");
+        idx.ingest_session("run-aaa", &s).expect("ingest");
+        let stats = idx.stats().expect("stats");
+        assert_eq!(stats.sessions, 1);
+        assert_eq!(stats.turns, 0);
+        assert!(stats.size_bytes > 0);
+        assert!(stats.db_path.ends_with("state.db"));
+    }
+
+    /// Acceptance check for issue #53: simulating one-shot mode (no
+    /// runner, no session-end hook) leaves the DB completely empty.
+    /// The CLI's `run_prompt` path follows this contract — it never
+    /// constructs a [`RunRunner`] and therefore cannot register the
+    /// hook that drives [`SearchIndex::ingest_session`]. This test
+    /// pins that invariant at the index layer: opening a fresh DB and
+    /// not calling any ingest method must yield zero rows.
+    #[test]
+    fn one_shot_mode_does_not_ingest() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+        // Simulate one-shot mode: index is open, but no hook fires
+        // because no runner was registered. Querying must return empty.
+        let stats = idx.stats().expect("stats");
+        assert_eq!(stats.sessions, 0);
+        assert_eq!(stats.turns, 0);
+        // A query against an empty index returns zero hits (not an
+        // error, since the FTS table exists).
+        let hits = idx
+            .query("anything", 10, SearchScope::All, None)
+            .expect("query");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn empty_query_is_invalid_param() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = fresh_index(&tmp);
+        let err = idx
+            .query("   ", 10, SearchScope::Summary, None)
+            .expect_err("must reject empty query");
+        assert!(matches!(err, SearchError::InvalidQuery { .. }));
+    }
+}

--- a/crates/tmg-search/src/lib.rs
+++ b/crates/tmg-search/src/lib.rs
@@ -1,0 +1,38 @@
+//! tmg-search: cross-session full-text search for the tsumugi agent.
+//!
+//! Provides:
+//!
+//! - [`SearchIndex`] — `SQLite` + FTS5 store of session summaries (and
+//!   optional turn transcripts) at `<project>/.tsumugi/state.db`.
+//! - [`SessionSearchTool`] — agent-facing tool wired into the standard
+//!   [`tmg_tools::ToolRegistry`].
+//! - [`redact_secrets`] — credential-masking helper shared with the
+//!   trajectory recorder (#55).
+//!
+//! Issue #53 motivates the design: the agent needs a way to ask
+//! "have I solved this before?" without depending on the full memory
+//! curation flow (#52). The search layer is "raw indexed history",
+//! while memory is "curated long-term knowledge"; they are
+//! complementary.
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use tmg_search::{SearchIndex, SessionSearchTool};
+//!
+//! let index = Arc::new(SearchIndex::open(".tsumugi/state.db")?);
+//! let mut registry = tmg_tools::default_registry();
+//! registry.register(SessionSearchTool::new(Arc::clone(&index)));
+//! # Ok::<(), tmg_search::SearchError>(())
+//! ```
+
+pub mod error;
+pub mod index;
+pub mod redact;
+pub mod tool;
+
+pub use error::SearchError;
+pub use index::{SearchHit, SearchIndex, SearchScope, SearchStats, TurnRecord};
+pub use redact::{REDACTION_TOKEN, redact_secrets};
+pub use tool::{SESSION_SEARCH_TOOL_NAME, SessionSearchTool};

--- a/crates/tmg-search/src/redact.rs
+++ b/crates/tmg-search/src/redact.rs
@@ -1,0 +1,181 @@
+//! Secret-redaction helpers shared by the search index ingestion path
+//! and the trajectory recorder (issue #55).
+//!
+//! [`redact_secrets`] runs the input through a series of regex patterns
+//! that match well-known credential shapes (AWS access keys, `OpenAI`
+//! `sk-` keys, `GitHub` PATs) plus a generic high-entropy fallback for
+//! tokens that don't fit any specific format. Authorization headers
+//! get a dedicated pattern so the bearer value is masked even when the
+//! payload is otherwise innocuous.
+//!
+//! All matches are replaced with the literal string [`REDACTION_TOKEN`];
+//! the surrounding text is preserved so search snippets still convey
+//! the topic of a leak even after redaction.
+//!
+//! # Determinism
+//!
+//! The compiled regex set is cached behind [`std::sync::OnceLock`] so
+//! repeated calls share the same compiled state. [`redact_secrets`] is
+//! pure: same input → same output.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+/// Replacement token that takes the place of every redacted match.
+///
+/// Chosen to be eye-catching but parseable as ASCII so search hits
+/// containing redacted text don't break on unicode segmentation.
+pub const REDACTION_TOKEN: &str = "[REDACTED]";
+
+/// Run the secret-shaped patterns from [`patterns()`] over `text` in
+/// order and return a fresh `String` with every match replaced by
+/// [`REDACTION_TOKEN`].
+///
+/// The function is `O(N * P)` in the size of `text` and the number of
+/// patterns; the patterns themselves are cheap (no backtracking) so
+/// the cost is dominated by the per-byte scan. Pre-allocating the
+/// output buffer would be a micro-optimisation we leave to a follow-up.
+#[must_use]
+pub fn redact_secrets(text: &str) -> String {
+    let mut current = text.to_owned();
+    for pattern in patterns() {
+        current = pattern.replace_all(&current, REDACTION_TOKEN).into_owned();
+    }
+    current
+}
+
+/// Compile the regex set on first call and cache it for subsequent
+/// calls. Order matters: more specific patterns run first so a generic
+/// high-entropy token detector cannot eat a structured AWS key before
+/// the dedicated AWS pattern fires.
+fn patterns() -> &'static [Regex] {
+    static PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
+    PATTERNS.get_or_init(|| {
+        // Each pattern is compiled once and stored in a `Vec<Regex>`.
+        // `Regex::new` only fails on a malformed pattern string; the
+        // strings here are constants under our control, so a panic
+        // here would mean the source itself is broken — surfacing a
+        // panic at first-use is acceptable for a static initialiser.
+        // Use `expect` rather than `unwrap_or_else(panic!)` so the
+        // failure includes a distinguishing message.
+        #[expect(
+            clippy::expect_used,
+            reason = "static-initialiser regex compilation; failure is a compile-time-equivalent bug"
+        )]
+        let v = vec![
+            // Authorization header values. Capture the prefix and
+            // replace the entire header → value range so callers see
+            // `Authorization: [REDACTED]` rather than a partial mask.
+            Regex::new(r"(?i)Authorization:\s*[A-Za-z]+\s+[A-Za-z0-9._~+/=\-]+")
+                .expect("compile Authorization header pattern"),
+            // AWS access key id. Always 20 chars total: `AKIA` + 16.
+            // Anchored on `\b` to avoid matching inside random hex
+            // dumps that happen to contain `AKIA`.
+            Regex::new(r"\bAKIA[A-Z0-9]{16,}\b").expect("compile AWS access key id pattern"),
+            // OpenAI-style secret key (`sk-` prefix, ≥32 alnum chars).
+            Regex::new(r"\bsk-[A-Za-z0-9]{32,}\b").expect("compile OpenAI sk- pattern"),
+            // GitHub personal access token (`ghp_` prefix, 36 chars).
+            Regex::new(r"\bghp_[A-Za-z0-9]{36,}\b").expect("compile GitHub PAT pattern"),
+            // Generic high-entropy token. Matches a run of ≥40
+            // alphanumerics / `_` / `-`. Runs LAST so the structured
+            // patterns above win when their prefix is present.
+            Regex::new(r"\b[A-Za-z0-9_\-]{40,}\b").expect("compile generic high-entropy pattern"),
+        ];
+        v
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_aws_access_key() {
+        let input = "deploy uses AKIAIOSFODNN7EXAMPLE for prod";
+        let out = redact_secrets(input);
+        assert!(
+            !out.contains("AKIAIOSFODNN7EXAMPLE"),
+            "AWS key not redacted: {out}"
+        );
+        assert!(out.contains(REDACTION_TOKEN), "{out}");
+        assert!(out.contains("deploy uses"));
+    }
+
+    #[test]
+    fn redacts_openai_sk_key() {
+        let input = "OPENAI_KEY=sk-abcdefghijklmnopqrstuvwxyz1234567890ABCD";
+        let out = redact_secrets(input);
+        assert!(!out.contains("sk-abcdefghijkl"), "{out}");
+        assert!(out.contains(REDACTION_TOKEN), "{out}");
+    }
+
+    #[test]
+    fn redacts_github_pat() {
+        let input = "token: ghp_abcdefghijklmnopqrstuvwxyz0123456789AB extra";
+        let out = redact_secrets(input);
+        assert!(!out.contains("ghp_abcdefghijkl"), "{out}");
+        assert!(out.contains(REDACTION_TOKEN), "{out}");
+        assert!(out.contains("extra"), "tail preserved: {out}");
+    }
+
+    #[test]
+    fn redacts_authorization_header() {
+        let input = "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+        let out = redact_secrets(input);
+        assert!(!out.contains("eyJhbGciOiJ"), "{out}");
+        assert!(out.contains(REDACTION_TOKEN), "{out}");
+    }
+
+    #[test]
+    fn redacts_generic_high_entropy_token() {
+        // 50-char alphanumeric blob — neither AWS nor sk- nor ghp_,
+        // but still high-entropy enough that we treat it as secret.
+        let input = "session=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijxxxx other=ok";
+        let out = redact_secrets(input);
+        assert!(out.contains(REDACTION_TOKEN), "{out}");
+        assert!(out.contains("other=ok"), "tail preserved: {out}");
+    }
+
+    /// Five-pattern smoke test: one input, one output, every redactor
+    /// fires at least once. Acceptance criterion in issue #53 calls for
+    /// "5 unit test patterns"; this consolidates them so adding a sixth
+    /// pattern only needs one line.
+    #[test]
+    fn five_pattern_acceptance_check() {
+        let input = "AKIAIOSFODNN7EXAMPLE \
+                     sk-abcdefghijklmnopqrstuvwxyz1234567890ABCD \
+                     ghp_abcdefghijklmnopqrstuvwxyz0123456789AB \
+                     Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 \
+                     session=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijxxxx";
+        let out = redact_secrets(input);
+        // Every original secret must be gone.
+        for needle in [
+            "AKIAIOSFODNN7EXAMPLE",
+            "sk-abcdefghijkl",
+            "ghp_abcdefghijkl",
+            "eyJhbGciOiJ",
+            "session=ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        ] {
+            assert!(!out.contains(needle), "leaked {needle}: {out}");
+        }
+        // At least 4 redaction tokens (Authorization eats its full
+        // span, the generic catches both leftovers — count is at
+        // least the number of distinct patterns).
+        let tokens = out.matches(REDACTION_TOKEN).count();
+        assert!(tokens >= 4, "expected ≥4 redactions, got {tokens}: {out}");
+    }
+
+    #[test]
+    fn leaves_innocuous_text_untouched() {
+        let input = "lorem ipsum dolor sit amet";
+        assert_eq!(redact_secrets(input), input);
+    }
+
+    #[test]
+    fn idempotent_on_already_redacted() {
+        let once = redact_secrets("ghp_abcdefghijklmnopqrstuvwxyz0123456789AB");
+        let twice = redact_secrets(&once);
+        assert_eq!(once, twice);
+    }
+}

--- a/crates/tmg-search/src/redact.rs
+++ b/crates/tmg-search/src/redact.rs
@@ -3,14 +3,41 @@
 //!
 //! [`redact_secrets`] runs the input through a series of regex patterns
 //! that match well-known credential shapes (AWS access keys, `OpenAI`
-//! `sk-` keys, `GitHub` PATs) plus a generic high-entropy fallback for
-//! tokens that don't fit any specific format. Authorization headers
-//! get a dedicated pattern so the bearer value is masked even when the
-//! payload is otherwise innocuous.
+//! `sk-` keys, `GitHub` PATs) plus a *credential-context* fallback for
+//! long tokens that follow `token=`, `key=`, `secret=`, `password=`,
+//! etc. Authorization headers get a dedicated pattern so the bearer
+//! value is masked even when the payload is otherwise innocuous.
+//!
+//! # Generic-token tradeoff
+//!
+//! An earlier draft used `\b[A-Za-z0-9_\-]{40,}\b` as a catch-all for
+//! "any long random string". This had a high false-positive rate: it
+//! ate 40-char git SHAs, SHA-256 hashes, base64 image data, content
+//! hashes — all of which are perfectly fine to keep in the search
+//! index. A summary like "rebased on commit `abc1234567890123456789012345678901234567`"
+//! would lose the SHA, making the entry far less useful.
+//!
+//! The current rule fires only when the long token is *introduced* by
+//! a credential-shaped prefix (case-insensitive `token=`, `key=`,
+//! `secret=`, `password=`, `pwd=`, `apikey=`, `auth=`, plus the
+//! whitespace-separated variants). This deliberately misses tokens
+//! that appear "naked" in free text — the rationale is that an actual
+//! credential almost always has a clue word next to it (env-var
+//! assignment, JSON key, CLI flag), whereas hashes do not. False
+//! negatives here are acceptable; false positives are not, because
+//! they silently destroy useful context in summaries.
 //!
 //! All matches are replaced with the literal string [`REDACTION_TOKEN`];
 //! the surrounding text is preserved so search snippets still convey
 //! the topic of a leak even after redaction.
+//!
+//! # Known limitations
+//!
+//! - The `Authorization:` header pattern stops at line breaks. Multi-
+//!   line continuations (rare in practice) only redact the first line.
+//! - Naked credentials in free text without a prefix word are not
+//!   caught; structured-shape patterns (AWS / `OpenAI` / `GitHub`) cover
+//!   the common branded cases.
 //!
 //! # Determinism
 //!
@@ -77,10 +104,23 @@ fn patterns() -> &'static [Regex] {
             Regex::new(r"\bsk-[A-Za-z0-9]{32,}\b").expect("compile OpenAI sk- pattern"),
             // GitHub personal access token (`ghp_` prefix, 36 chars).
             Regex::new(r"\bghp_[A-Za-z0-9]{36,}\b").expect("compile GitHub PAT pattern"),
-            // Generic high-entropy token. Matches a run of ≥40
-            // alphanumerics / `_` / `-`. Runs LAST so the structured
-            // patterns above win when their prefix is present.
-            Regex::new(r"\b[A-Za-z0-9_\-]{40,}\b").expect("compile generic high-entropy pattern"),
+            // Credential-context long token. Matches a long run of
+            // alphanumerics / `_` / `-` ONLY when it sits behind a
+            // credential-shaped prefix (case-insensitive). This avoids
+            // eating git SHAs and content hashes in free text; see the
+            // module-level comment for the rationale.
+            //
+            // Captured prefixes: `token`, `secret`, `key`, `apikey`,
+            // `api_key`, `auth`, `password`, `pwd`, `passwd`. The
+            // separator may be `=`, `:`, or whitespace. We replace
+            // the whole match (prefix included) so the redaction
+            // marker reads e.g. `[REDACTED]` rather than
+            // `token=[REDACTED]`. Both forms are acceptable; we go
+            // with full-replace because it's more conservative.
+            Regex::new(
+                r"(?i)\b(?:api[_-]?key|secret|token|auth|password|pwd|passwd|key)\s*[:=]\s*[A-Za-z0-9_\-]{20,}\b",
+            )
+            .expect("compile credential-context long-token pattern"),
         ];
         v
     })
@@ -128,13 +168,45 @@ mod tests {
     }
 
     #[test]
-    fn redacts_generic_high_entropy_token() {
-        // 50-char alphanumeric blob — neither AWS nor sk- nor ghp_,
-        // but still high-entropy enough that we treat it as secret.
-        let input = "session=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijxxxx other=ok";
+    fn redacts_credential_context_long_token() {
+        // 50-char alphanumeric blob with a credential-shaped prefix —
+        // neither AWS nor sk- nor ghp_, but the `token=` introducer
+        // makes it unambiguously secret.
+        let input = "token=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijxxxx other=ok";
         let out = redact_secrets(input);
         assert!(out.contains(REDACTION_TOKEN), "{out}");
         assert!(out.contains("other=ok"), "tail preserved: {out}");
+        assert!(
+            !out.contains("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+            "long token leaked: {out}"
+        );
+    }
+
+    /// Regression check for review feedback (issue #53): the pre-fix
+    /// generic redactor ate plain git SHAs and SHA-256 hashes,
+    /// destroying useful context like commit references in summaries.
+    /// The credential-context rule must NOT fire on hashes or SHAs
+    /// in free text.
+    #[test]
+    fn preserves_git_sha_and_content_hashes() {
+        // 40-char hex git SHA in a sentence.
+        let sha40 = "abc1234567890123456789012345678901234567";
+        let input1 = format!("rebased on commit {sha40} cleanly");
+        let out1 = redact_secrets(&input1);
+        assert!(out1.contains(sha40), "git SHA was redacted: {out1}");
+
+        // 64-char hex SHA-256 (e.g. from a checksum file).
+        let sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let input2 = format!("checksum: {sha256}");
+        let out2 = redact_secrets(&input2);
+        assert!(out2.contains(sha256), "SHA-256 was redacted: {out2}");
+
+        // Long base64-shaped identifier in free text (no credential
+        // prefix). Must survive.
+        let blob = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmn";
+        let input3 = format!("uploaded blob {blob} to cache");
+        let out3 = redact_secrets(&input3);
+        assert!(out3.contains(blob), "blob hash was redacted: {out3}");
     }
 
     /// Five-pattern smoke test: one input, one output, every redactor
@@ -147,7 +219,7 @@ mod tests {
                      sk-abcdefghijklmnopqrstuvwxyz1234567890ABCD \
                      ghp_abcdefghijklmnopqrstuvwxyz0123456789AB \
                      Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 \
-                     session=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijxxxx";
+                     token=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijxxxx";
         let out = redact_secrets(input);
         // Every original secret must be gone.
         for needle in [
@@ -155,13 +227,12 @@ mod tests {
             "sk-abcdefghijkl",
             "ghp_abcdefghijkl",
             "eyJhbGciOiJ",
-            "session=ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            "token=ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         ] {
             assert!(!out.contains(needle), "leaked {needle}: {out}");
         }
         // At least 4 redaction tokens (Authorization eats its full
-        // span, the generic catches both leftovers — count is at
-        // least the number of distinct patterns).
+        // span; the credential-context rule catches the token= line).
         let tokens = out.matches(REDACTION_TOKEN).count();
         assert!(tokens >= 4, "expected ≥4 redactions, got {tokens}: {out}");
     }

--- a/crates/tmg-search/src/tool.rs
+++ b/crates/tmg-search/src/tool.rs
@@ -114,69 +114,94 @@ impl Tool for SessionSearchTool {
         params: JsonValue,
         _ctx: &'a SandboxContext,
     ) -> Pin<Box<dyn Future<Output = Result<ToolResult, ToolError>> + Send + 'a>> {
-        let result = self.execute_inner(&params);
-        Box::pin(std::future::ready(result))
-    }
-}
+        // `_ctx` is intentionally unused: the search index lives at the
+        // well-known internal path `<project>/.tsumugi/state.db` and is
+        // canonicalised to the project root by `SearchIndex::open`,
+        // not by per-tool sandbox checks. We don't take user-supplied
+        // paths through this tool so there is no path-traversal surface
+        // here that a sandbox check would defend.
+        let index_opt = self.index.clone();
+        Box::pin(async move {
+            // Parse params synchronously (cheap, no I/O).
+            let Some(index) = index_opt else {
+                return Ok(ToolResult::error(
+                    "session_search is disabled: enable [search] in tsumugi.toml",
+                ));
+            };
+            let Some(query) = params.get("query").and_then(JsonValue::as_str) else {
+                return Err(ToolError::invalid_params(
+                    "missing required parameter: query",
+                ));
+            };
+            let query = query.to_owned();
+            let limit = params
+                .get("limit")
+                .and_then(JsonValue::as_u64)
+                .map_or(10_usize, |n| usize::try_from(n).unwrap_or(10));
+            let scope = params
+                .get("scope")
+                .and_then(JsonValue::as_str)
+                .map_or(SearchScope::All, SearchScope::parse);
+            let since = match params.get("since").and_then(JsonValue::as_str) {
+                Some(s) => match DateTime::parse_from_rfc3339(s) {
+                    Ok(dt) => Some(dt.with_timezone(&chrono::Utc)),
+                    Err(e) => {
+                        return Err(ToolError::invalid_params(format!(
+                            "invalid since timestamp {s:?}: {e}"
+                        )));
+                    }
+                },
+                None => None,
+            };
 
-impl SessionSearchTool {
-    fn execute_inner(&self, params: &JsonValue) -> Result<ToolResult, ToolError> {
-        let Some(index) = self.index.as_ref() else {
-            return Ok(ToolResult::error(
-                "session_search is disabled: enable [search] in tsumugi.toml",
-            ));
-        };
-        let Some(query) = params.get("query").and_then(JsonValue::as_str) else {
-            return Err(ToolError::invalid_params(
-                "missing required parameter: query",
-            ));
-        };
-        let limit = params
-            .get("limit")
-            .and_then(JsonValue::as_u64)
-            .map_or(10_usize, |n| usize::try_from(n).unwrap_or(10));
-        let scope = params
-            .get("scope")
-            .and_then(JsonValue::as_str)
-            .map_or(SearchScope::All, SearchScope::parse);
-        let since = match params.get("since").and_then(JsonValue::as_str) {
-            Some(s) => match DateTime::parse_from_rfc3339(s) {
-                Ok(dt) => Some(dt.with_timezone(&chrono::Utc)),
+            // Run the actual SQLite query off the tokio worker so a
+            // slow FTS5 scan can't block neighbour tasks. The blocking
+            // task owns its own clone of the `Arc<SearchIndex>` so the
+            // future stays `Send`.
+            let query_for_blocking = query.clone();
+            let join_result = tokio::task::spawn_blocking(move || {
+                index.query(&query_for_blocking, limit, scope, since)
+            })
+            .await;
+            let result = match join_result {
+                Ok(r) => r,
                 Err(e) => {
-                    return Err(ToolError::invalid_params(format!(
-                        "invalid since timestamp {s:?}: {e}"
+                    // JoinError: the blocking task panicked or was
+                    // cancelled. Surface as a soft error so the agent
+                    // can keep going.
+                    return Ok(ToolResult::error(format!(
+                        "session_search task panicked or was cancelled: {e}"
                     )));
                 }
-            },
-            None => None,
-        };
+            };
 
-        match index.query(query, limit, scope, since) {
-            Ok(hits) => {
-                // Serialize the structured hit list as the tool's
-                // output. The agent loop already JSON-pretty-prints
-                // tool results in the activity pane; emitting JSON
-                // here preserves machine-parseability for scripts.
-                let payload = serde_json::to_string_pretty(&hits)
-                    .map_err(|e| ToolError::json("serialize search hits", e))?;
-                if hits.is_empty() {
-                    Ok(ToolResult::success(format!(
-                        "no matches for query {query:?}\n\n{payload}"
-                    )))
-                } else {
-                    Ok(ToolResult::success(payload))
+            match result {
+                Ok(hits) => {
+                    // Serialize the structured hit list as the tool's
+                    // output. The agent loop already JSON-pretty-prints
+                    // tool results in the activity pane; emitting JSON
+                    // here preserves machine-parseability for scripts.
+                    let payload = serde_json::to_string_pretty(&hits)
+                        .map_err(|e| ToolError::json("serialize search hits", e))?;
+                    if hits.is_empty() {
+                        Ok(ToolResult::success(format!(
+                            "no matches for query {query:?}\n\n{payload}"
+                        )))
+                    } else {
+                        Ok(ToolResult::success(payload))
+                    }
+                }
+                Err(crate::error::SearchError::InvalidQuery { message }) => {
+                    Err(ToolError::invalid_params(message))
+                }
+                Err(other) => {
+                    // Treat infrastructure failures (DB locked, schema
+                    // mismatch, ...) as soft errors so the agent can
+                    // recover or move on.
+                    Ok(ToolResult::error(format!("session_search failed: {other}")))
                 }
             }
-            Err(crate::error::SearchError::InvalidQuery { message }) => {
-                Err(ToolError::invalid_params(message))
-            }
-            Err(other) => {
-                // Treat infrastructure failures (DB locked, schema
-                // mismatch, ...) as soft errors so the agent can
-                // recover or move on.
-                Ok(ToolResult::error(format!("session_search failed: {other}")))
-            }
-        }
+        })
     }
 }
 

--- a/crates/tmg-search/src/tool.rs
+++ b/crates/tmg-search/src/tool.rs
@@ -1,0 +1,275 @@
+//! [`SessionSearchTool`]: agent-facing FTS5 search over historical
+//! sessions.
+//!
+//! Wraps a shared [`SearchIndex`] and exposes the JSON shape promised
+//! by issue #53:
+//!
+//! ```text
+//! Tool: session_search
+//! Parameters: {
+//!   "query": "<FTS5 query>",
+//!   "limit": 10,
+//!   "scope": "summary" | "turns" | "all",
+//!   "since": "<ISO8601>"
+//! }
+//! ```
+//!
+//! Result: `[{run_id, session_num, started_at, summary, snippet, score}]`.
+//!
+//! Full turn payloads are intentionally **not** returned here — the
+//! agent should follow up with `file_read` against
+//! `.tsumugi/runs/<id>/session_log/session_NNN.json` when it wants the
+//! verbatim transcript. This keeps the search hit small enough to fit
+//! in the context window even for noisy queries.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use chrono::DateTime;
+use serde_json::Value as JsonValue;
+use tmg_sandbox::SandboxContext;
+use tmg_tools::error::ToolError;
+use tmg_tools::types::{Tool, ToolResult};
+
+use crate::index::{SearchIndex, SearchScope};
+
+/// Tool name as registered in [`tmg_tools::ToolRegistry`].
+pub const SESSION_SEARCH_TOOL_NAME: &str = "session_search";
+
+/// Wrapper that adapts [`SearchIndex`] to the [`Tool`] trait.
+///
+/// The index is held behind `Option<Arc<SearchIndex>>` so the tool can
+/// be registered unconditionally; when the index is `None` (e.g. the
+/// search feature is disabled, or the DB couldn't be opened) the tool
+/// returns a soft `ToolResult::error` rather than failing hard. This
+/// matches the issue's "DB unavailable → tool returns soft error"
+/// requirement.
+pub struct SessionSearchTool {
+    index: Option<Arc<SearchIndex>>,
+}
+
+impl SessionSearchTool {
+    /// Construct a tool around a live index.
+    #[must_use]
+    pub fn new(index: Arc<SearchIndex>) -> Self {
+        Self { index: Some(index) }
+    }
+
+    /// Construct a tool that always returns a soft error. Used when
+    /// the search feature is disabled at config time so the agent
+    /// still sees the tool surface but every call short-circuits.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self { index: None }
+    }
+}
+
+impl Tool for SessionSearchTool {
+    fn name(&self) -> &'static str {
+        SESSION_SEARCH_TOOL_NAME
+    }
+
+    fn description(&self) -> &'static str {
+        "Search past session summaries and turn transcripts (full-text via SQLite FTS5). \
+         Use this before tackling a problem to see if you've already solved something similar. \
+         Returns run_id, session_num, summary, and a highlighted snippet — read the full \
+         session via `file_read` on `.tsumugi/runs/<run_id>/session_log/session_NNN.json` \
+         for verbatim turn text."
+    }
+
+    fn parameters_schema(&self) -> JsonValue {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "FTS5 MATCH query. Operators: AND, OR, NEAR, prefix `*`."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 200,
+                    "default": 10,
+                    "description": "Maximum number of hits to return (clamped to 200)."
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["summary", "turns", "all"],
+                    "default": "all",
+                    "description": "Which FTS table(s) to consult."
+                },
+                "since": {
+                    "type": "string",
+                    "description": "Optional ISO8601 / RFC3339 timestamp; only sessions started \
+                                    at or after this time are returned."
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute<'a>(
+        &'a self,
+        params: JsonValue,
+        _ctx: &'a SandboxContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ToolResult, ToolError>> + Send + 'a>> {
+        let result = self.execute_inner(&params);
+        Box::pin(std::future::ready(result))
+    }
+}
+
+impl SessionSearchTool {
+    fn execute_inner(&self, params: &JsonValue) -> Result<ToolResult, ToolError> {
+        let Some(index) = self.index.as_ref() else {
+            return Ok(ToolResult::error(
+                "session_search is disabled: enable [search] in tsumugi.toml",
+            ));
+        };
+        let Some(query) = params.get("query").and_then(JsonValue::as_str) else {
+            return Err(ToolError::invalid_params(
+                "missing required parameter: query",
+            ));
+        };
+        let limit = params
+            .get("limit")
+            .and_then(JsonValue::as_u64)
+            .map_or(10_usize, |n| usize::try_from(n).unwrap_or(10));
+        let scope = params
+            .get("scope")
+            .and_then(JsonValue::as_str)
+            .map_or(SearchScope::All, SearchScope::parse);
+        let since = match params.get("since").and_then(JsonValue::as_str) {
+            Some(s) => match DateTime::parse_from_rfc3339(s) {
+                Ok(dt) => Some(dt.with_timezone(&chrono::Utc)),
+                Err(e) => {
+                    return Err(ToolError::invalid_params(format!(
+                        "invalid since timestamp {s:?}: {e}"
+                    )));
+                }
+            },
+            None => None,
+        };
+
+        match index.query(query, limit, scope, since) {
+            Ok(hits) => {
+                // Serialize the structured hit list as the tool's
+                // output. The agent loop already JSON-pretty-prints
+                // tool results in the activity pane; emitting JSON
+                // here preserves machine-parseability for scripts.
+                let payload = serde_json::to_string_pretty(&hits)
+                    .map_err(|e| ToolError::json("serialize search hits", e))?;
+                if hits.is_empty() {
+                    Ok(ToolResult::success(format!(
+                        "no matches for query {query:?}\n\n{payload}"
+                    )))
+                } else {
+                    Ok(ToolResult::success(payload))
+                }
+            }
+            Err(crate::error::SearchError::InvalidQuery { message }) => {
+                Err(ToolError::invalid_params(message))
+            }
+            Err(other) => {
+                // Treat infrastructure failures (DB locked, schema
+                // mismatch, ...) as soft errors so the agent can
+                // recover or move on.
+                Ok(ToolResult::error(format!("session_search failed: {other}")))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test assertions use expect for clearer messages"
+)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use tmg_harness::{Session, SessionEndTrigger};
+
+    fn make_index(tmp: &TempDir) -> Arc<SearchIndex> {
+        Arc::new(SearchIndex::open(tmp.path().join("state.db")).expect("open"))
+    }
+
+    #[tokio::test]
+    async fn search_returns_hits_as_json() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = make_index(&tmp);
+        let mut s = Session::begin(1);
+        s.summary = "fixed OAuth callback redirect loop".to_owned();
+        s.end(SessionEndTrigger::Completed);
+        idx.ingest_session("run-aaa", &s).expect("ingest");
+
+        let tool = SessionSearchTool::new(Arc::clone(&idx));
+        let ctx = SandboxContext::test_default();
+        let res = tool
+            .execute(serde_json::json!({"query": "OAuth"}), &ctx)
+            .await
+            .expect("execute");
+        assert!(!res.is_error, "{}", res.output);
+        // JSON-parseable.
+        let parsed: serde_json::Value = serde_json::from_str(&res.output).expect("output is JSON");
+        let arr = parsed.as_array().expect("array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["run_id"], "run-aaa");
+        assert_eq!(arr[0]["session_num"], 1);
+    }
+
+    #[tokio::test]
+    async fn disabled_tool_returns_soft_error() {
+        let tool = SessionSearchTool::disabled();
+        let ctx = SandboxContext::test_default();
+        let res = tool
+            .execute(serde_json::json!({"query": "anything"}), &ctx)
+            .await
+            .expect("execute");
+        assert!(res.is_error);
+        assert!(res.output.contains("disabled"), "{}", res.output);
+    }
+
+    #[tokio::test]
+    async fn missing_query_is_invalid_params() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = make_index(&tmp);
+        let tool = SessionSearchTool::new(idx);
+        let ctx = SandboxContext::test_default();
+        let err = tool
+            .execute(serde_json::json!({}), &ctx)
+            .await
+            .expect_err("missing query");
+        assert!(matches!(err, ToolError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn invalid_since_is_invalid_params() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = make_index(&tmp);
+        let tool = SessionSearchTool::new(idx);
+        let ctx = SandboxContext::test_default();
+        let err = tool
+            .execute(
+                serde_json::json!({"query": "x", "since": "not-a-timestamp"}),
+                &ctx,
+            )
+            .await
+            .expect_err("bad since");
+        assert!(matches!(err, ToolError::InvalidParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn empty_results_still_succeed() {
+        let tmp = TempDir::new().expect("tempdir");
+        let idx = make_index(&tmp);
+        let tool = SessionSearchTool::new(idx);
+        let ctx = SandboxContext::test_default();
+        let res = tool
+            .execute(serde_json::json!({"query": "nothing matches"}), &ctx)
+            .await
+            .expect("execute");
+        assert!(!res.is_error, "{}", res.output);
+        assert!(res.output.contains("no matches"));
+    }
+}

--- a/crates/tmg-skills/src/slash.rs
+++ b/crates/tmg-skills/src/slash.rs
@@ -125,6 +125,11 @@ pub fn parse_slash_command(input: &str) -> SlashParseResult {
         "workflows" => return Ok(Some(SlashCommand::ListWorkflows)),
         "run" => return parse_run_subcommand(args.as_deref()).map(Some),
         "memory" => return Ok(Some(parse_memory_subcommand(args.as_deref()))),
+        "search" => {
+            return Ok(Some(SlashCommand::Search {
+                query: args.unwrap_or_default(),
+            }));
+        }
         _ => {}
     }
 

--- a/crates/tmg-skills/src/types.rs
+++ b/crates/tmg-skills/src/types.rs
@@ -267,4 +267,13 @@ pub enum SlashCommand {
         /// Topic name.
         name: String,
     },
+
+    // ---- /search (issue #53) --------------------------------------------
+    /// `/search <query>` — full-text search the cross-session index.
+    /// Result is rendered into the Activity Pane as a system message.
+    Search {
+        /// FTS5 MATCH expression. Empty when the user typed `/search`
+        /// with no body — surfaced as a usage hint by the dispatcher.
+        query: String,
+    },
 }

--- a/crates/tmg-tui/Cargo.toml
+++ b/crates/tmg-tui/Cargo.toml
@@ -11,6 +11,7 @@ tmg-llm = { workspace = true }
 tmg-agents = { workspace = true }
 tmg-harness = { workspace = true }
 tmg-memory = { workspace = true }
+tmg-search = { workspace = true }
 tmg-skills = { workspace = true }
 tmg-workflow = { workspace = true }
 ratatui = { workspace = true }

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -9,6 +9,7 @@ use tmg_core::{AgentLoop, CoreError, StreamSink, format_context_usage};
 use tmg_harness::{HarnessStreamSink, RunProgressEvent, RunRunner, RunSummary};
 use tmg_llm::Role;
 use tmg_memory::MemoryStore;
+use tmg_search::SearchIndex;
 use tmg_skills::{SkillMeta, SlashCommand};
 use tmg_workflow::{WorkflowMeta, WorkflowProgress};
 use tokio::sync::Mutex;
@@ -279,6 +280,12 @@ pub struct App {
     /// the registry so the TUI display path and the LLM's tool calls
     /// see exactly the same on-disk state.
     memory_store: Option<Arc<MemoryStore>>,
+
+    /// Optional cross-session search index for the `/search` slash
+    /// command (issue #53). Shared with [`tmg_search::SessionSearchTool`]
+    /// on the registry so the TUI display path and the LLM tool see the
+    /// same on-disk state.
+    search_index: Option<Arc<SearchIndex>>,
 }
 
 impl App {
@@ -324,6 +331,7 @@ impl App {
             skills: Vec::new(),
             pending_slash: None,
             memory_store: None,
+            search_index: None,
         }
     }
 
@@ -332,6 +340,12 @@ impl App {
     /// LLM. When unset (or `None`), `/memory` reports memory disabled.
     pub fn set_memory_store(&mut self, store: Arc<MemoryStore>) {
         self.memory_store = Some(store);
+    }
+
+    /// Install the shared search index so `/search <query>` can render
+    /// results inline. When unset, `/search` reports search disabled.
+    pub fn set_search_index(&mut self, index: Arc<SearchIndex>) {
+        self.search_index = Some(index);
     }
 
     /// Dequeue any pending async slash command so the event loop can
@@ -840,6 +854,9 @@ impl App {
             SlashCommand::MemoryShow { name } => {
                 self.show_memory_entry(&name);
             }
+            SlashCommand::Search { query } => {
+                self.show_search_results(&query);
+            }
             // The /run family and /<skill> need async work (harness
             // mutex, workflow tools). Defer to the event loop.
             other @ (SlashCommand::RunStart { .. }
@@ -997,6 +1014,54 @@ impl App {
             }
             Err(e) => {
                 self.error_message = Some(format!("memory: {e}"));
+            }
+        }
+    }
+
+    /// Render search results from the cross-session index in the chat
+    /// pane. Issue #53 — `/search <query>` slash command.
+    fn show_search_results(&mut self, query: &str) {
+        let trimmed = query.trim();
+        if trimmed.is_empty() {
+            self.chat_entries.push(ChatEntry {
+                role: Role::System,
+                text: "Usage: /search <FTS5 query>".to_owned(),
+            });
+            return;
+        }
+        let Some(index) = self.search_index.as_ref() else {
+            self.error_message =
+                Some("search is disabled; enable [search] in tsumugi.toml".to_owned());
+            return;
+        };
+        match index.query(trimmed, 10, tmg_search::SearchScope::All, None) {
+            Ok(hits) if hits.is_empty() => {
+                self.chat_entries.push(ChatEntry {
+                    role: Role::System,
+                    text: format!("(no matches for {trimmed:?})"),
+                });
+            }
+            Ok(hits) => {
+                let mut text = format!("Search results for {trimmed:?}:\n\n");
+                for hit in &hits {
+                    let _ = writeln!(
+                        text,
+                        "[{:.3}] {}#{}  {}\n  summary: {}\n  snippet: {}\n",
+                        hit.score,
+                        hit.run_id,
+                        hit.session_num,
+                        hit.started_at,
+                        hit.summary,
+                        hit.snippet,
+                    );
+                }
+                self.chat_entries.push(ChatEntry {
+                    role: Role::System,
+                    text,
+                });
+            }
+            Err(e) => {
+                self.error_message = Some(format!("search: {e}"));
             }
         }
     }

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -33,6 +33,7 @@ use tmg_agents::{CustomAgentDef, SubagentManager};
 use tmg_core::AgentLoop;
 use tmg_harness::{RunProgressReceiver, RunRunner, RunSummary};
 use tmg_memory::MemoryStore;
+use tmg_search::SearchIndex;
 use tmg_skills::SkillMeta;
 use tmg_workflow::{WorkflowMeta, WorkflowProgress};
 use tokio::sync::{Mutex, mpsc};
@@ -95,6 +96,7 @@ pub async fn run(
     workflows: Vec<WorkflowMeta>,
     skills: Vec<SkillMeta>,
     memory_store: Option<Arc<MemoryStore>>,
+    search_index: Option<Arc<SearchIndex>>,
 ) -> Result<(), TuiError> {
     // Pre-warm the syntect bundle off the rendering thread. Loading
     // `SyntaxSet::load_defaults_newlines` + `ThemeSet::load_defaults`
@@ -173,6 +175,10 @@ pub async fn run(
 
     if let Some(store) = memory_store {
         app.set_memory_store(store);
+    }
+
+    if let Some(idx) = search_index {
+        app.set_search_index(idx);
     }
 
     let result = event::run_event_loop(&mut terminal, &mut app, cancel).await;

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -31,6 +31,7 @@ tmg-harness = { workspace = true }
 tmg-llm = { workspace = true }
 tmg-memory = { workspace = true }
 tmg-sandbox = { workspace = true }
+tmg-search = { workspace = true }
 tmg-skills = { workspace = true }
 tmg-tools = { workspace = true }
 tmg-tui = { workspace = true }

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -550,6 +550,40 @@ fn parse_humantime_duration(field: &str, value: &str) -> Result<std::time::Durat
         })
 }
 
+/// Partial `[search]` config — fields are `Option` so a partial layer
+/// can override one knob without resetting the others. Issue #53.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PartialSearchConfig {
+    pub enabled: Option<bool>,
+    pub db_path: Option<PathBuf>,
+    pub ingest_on_session_end: Option<bool>,
+}
+
+impl PartialSearchConfig {
+    fn merge_from(&mut self, other: &Self) {
+        if other.enabled.is_some() {
+            self.enabled = other.enabled;
+        }
+        if other.db_path.is_some() {
+            self.db_path.clone_from(&other.db_path);
+        }
+        if other.ingest_on_session_end.is_some() {
+            self.ingest_on_session_end = other.ingest_on_session_end;
+        }
+    }
+
+    fn into_final(self) -> SearchConfig {
+        let defaults = SearchConfig::default();
+        SearchConfig {
+            enabled: self.enabled.unwrap_or(defaults.enabled),
+            db_path: self.db_path.unwrap_or(defaults.db_path),
+            ingest_on_session_end: self
+                .ingest_on_session_end
+                .unwrap_or(defaults.ingest_on_session_end),
+        }
+    }
+}
+
 /// Partial top-level config used for deserialization and merging.
 ///
 /// Partial memory config used for deserialization / merging. Each
@@ -618,6 +652,8 @@ struct PartialTsumugiConfig {
     pub workflow: PartialWorkflowConfig,
     #[serde(default)]
     pub memory: PartialMemoryConfig,
+    #[serde(default)]
+    pub search: PartialSearchConfig,
 }
 
 impl PartialTsumugiConfig {
@@ -631,6 +667,7 @@ impl PartialTsumugiConfig {
         self.harness.merge_from(&other.harness);
         self.workflow.merge_from(&other.workflow);
         self.memory.merge_from(&other.memory);
+        self.search.merge_from(&other.search);
     }
 
     /// Apply environment variable overrides (`TMG_*` prefix).
@@ -915,6 +952,7 @@ impl PartialTsumugiConfig {
             harness: self.harness.into_final()?,
             workflow: self.workflow.into_final()?,
             memory: self.memory.into_final(),
+            search: self.search.into_final(),
         })
     }
 }
@@ -1254,6 +1292,10 @@ pub struct TsumugiConfig {
     /// Memory layer settings (issue #52).
     #[serde(default)]
     pub memory: MemoryConfig,
+
+    /// Cross-session search layer settings (issue #53).
+    #[serde(default)]
+    pub search: SearchConfig,
 }
 
 /// `[memory]` section: project-scoped persistent memory configuration.
@@ -1351,6 +1393,65 @@ impl MemoryConfig {
             index_max_lines: self.index_max_lines,
             entry_max_chars: self.entry_max_chars,
             total_files_limit: self.total_files_limit,
+        }
+    }
+}
+
+/// `[search]` section: cross-session search index configuration.
+///
+/// Issue #53. The search layer indexes session summaries (and turn
+/// transcripts once #55 lands) into a `SQLite` + FTS5 store at
+/// `db_path`. The hook that ingests sessions on the session-end path
+/// is gated by `ingest_on_session_end`; the master switch `enabled`
+/// gates both the hook and the `session_search` tool registration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchConfig {
+    /// Master switch — `false` keeps the tool unregistered and skips
+    /// session-end ingestion entirely.
+    #[serde(default = "default_search_enabled")]
+    pub enabled: bool,
+    /// `SQLite` database path, relative to the project root or absolute.
+    /// Defaults to `.tsumugi/state.db`.
+    #[serde(default = "default_search_db_path")]
+    pub db_path: PathBuf,
+    /// Fire the search-index ingest hook on every session-end
+    /// `SessionLog::save`. When `false`, the only path that populates
+    /// the DB is the `tmg search rebuild` CLI command (or startup
+    /// rebuild scan).
+    #[serde(default = "default_search_ingest_on_session_end")]
+    pub ingest_on_session_end: bool,
+}
+
+const fn default_search_enabled() -> bool {
+    true
+}
+
+fn default_search_db_path() -> PathBuf {
+    PathBuf::from(".tsumugi/state.db")
+}
+
+const fn default_search_ingest_on_session_end() -> bool {
+    true
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_search_enabled(),
+            db_path: default_search_db_path(),
+            ingest_on_session_end: default_search_ingest_on_session_end(),
+        }
+    }
+}
+
+impl SearchConfig {
+    /// Resolve `db_path` against `project_root` for relative paths.
+    #[must_use]
+    pub fn resolve_db_path(&self, project_root: &Path) -> PathBuf {
+        if self.db_path.is_absolute() {
+            self.db_path.clone()
+        } else {
+            project_root.join(&self.db_path)
         }
     }
 }

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -682,23 +682,24 @@ fn run_prompt(
         // session-end hook is registered and `ingest_session` is never
         // called. The agent gets a search tool over whatever the TUI /
         // workflow paths previously indexed.
-        let search_index_for_oneshot: Option<Arc<tmg_search::SearchIndex>> =
-            if search_config.enabled {
-                let db_path = search_config.resolve_db_path(&canonical_cwd);
-                match tmg_search::SearchIndex::open(&db_path) {
-                    Ok(idx) => Some(Arc::new(idx)),
-                    Err(e) => {
-                        tracing::warn!(
-                            path = %db_path.display(),
-                            error = %e,
-                            "failed to open search index for one-shot prompt; tool returns soft errors"
-                        );
-                        None
-                    }
+        let search_index_for_oneshot: Option<Arc<tmg_search::SearchIndex>> = if search_config
+            .enabled
+        {
+            let db_path = search_config.resolve_db_path(&canonical_cwd);
+            match tmg_search::SearchIndex::open(&db_path) {
+                Ok(idx) => Some(Arc::new(idx)),
+                Err(e) => {
+                    tracing::warn!(
+                        path = %db_path.display(),
+                        error = %e,
+                        "failed to open search index for one-shot prompt; tool returns soft errors"
+                    );
+                    None
                 }
-            } else {
-                None
-            };
+            }
+        } else {
+            None
+        };
 
         // Build the tool registry: built-ins + (optionally) the memory
         // tool. No subagent registration in one-shot mode because

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -19,7 +19,7 @@ mod pool_setup;
 mod run_commands;
 mod workflow_commands;
 
-use config::{HarnessConfig, SandboxConfigSection, TsumugiConfig};
+use config::{HarnessConfig, SandboxConfigSection, SearchConfig, TsumugiConfig};
 
 /// tsumugi - a local-LLM-powered coding agent
 #[derive(Parser, Debug)]
@@ -111,6 +111,36 @@ enum Command {
         #[command(subcommand)]
         op: MemoryCommand,
     },
+    /// Cross-session full-text search over indexed session logs (issue #53).
+    Search {
+        /// Sub-operation on the search index.
+        #[command(subcommand)]
+        op: SearchCommand,
+    },
+}
+
+/// Operations under `tmg search`. Issue #53.
+#[derive(Subcommand, Debug)]
+enum SearchCommand {
+    /// Run an FTS5 query against the indexed session log.
+    Query {
+        /// FTS5 MATCH expression.
+        query: String,
+        /// Maximum number of hits to return (clamped to 1..=200).
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+        /// Restrict the search to one of `summary` / `turns` / `all`.
+        #[arg(long, default_value = "all")]
+        scope: String,
+        /// Optional ISO8601 / RFC3339 lower bound on `started_at`.
+        #[arg(long)]
+        since: Option<String>,
+    },
+    /// Re-ingest every `session_NNN.json` under the project's runs
+    /// directory that is not yet present in the index.
+    Rebuild,
+    /// Print DB statistics (size, session / turn counts).
+    Stats,
 }
 
 /// Operations under `tmg memory`. Issue #52.
@@ -295,6 +325,7 @@ fn main() -> anyhow::Result<()> {
         Some(Command::Memory { op }) => {
             dispatch_memory_command(op, &config, cli.event_log.as_deref())
         }
+        Some(Command::Search { op }) => dispatch_search_command(op, &config),
         None => {
             if let Some(prompt) = cli.prompt {
                 run_prompt(
@@ -303,6 +334,7 @@ fn main() -> anyhow::Result<()> {
                     &prompt,
                     cli.event_log.as_deref(),
                     &config.memory,
+                    &config.search,
                     &config.sandbox,
                     context_config,
                     config.llm.tool_calling,
@@ -319,6 +351,7 @@ fn main() -> anyhow::Result<()> {
                     &config.workflow,
                     &config.skills,
                     &config.memory,
+                    &config.search,
                     config.llm.subagent_pool.as_ref(),
                     None,
                 )
@@ -373,6 +406,102 @@ fn dispatch_memory_command(
     event_log: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     memory_commands::dispatch(op, config, event_log)
+}
+
+/// Dispatch one `tmg search <op>` invocation. Issue #53.
+fn dispatch_search_command(op: SearchCommand, config: &TsumugiConfig) -> anyhow::Result<()> {
+    let cwd = std::env::current_dir().context("reading current working directory")?;
+    let canonical_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+    if !config.search.enabled {
+        anyhow::bail!("[search] is disabled in tsumugi.toml; enable it before running tmg search");
+    }
+    let db_path = config.search.resolve_db_path(&canonical_cwd);
+    let index = tmg_search::SearchIndex::open(&db_path)
+        .with_context(|| format!("opening search index at {}", db_path.display()))?;
+
+    match op {
+        SearchCommand::Query {
+            query,
+            limit,
+            scope,
+            since,
+        } => search_commands_query(&index, &query, limit, &scope, since.as_deref()),
+        SearchCommand::Rebuild => search_commands_rebuild(&index, config, &canonical_cwd),
+        SearchCommand::Stats => search_commands_stats(&index),
+    }
+}
+
+#[expect(
+    clippy::print_stdout,
+    reason = "stdout is the contract for `tmg search` CLI output"
+)]
+fn search_commands_query(
+    index: &tmg_search::SearchIndex,
+    query: &str,
+    limit: usize,
+    scope: &str,
+    since: Option<&str>,
+) -> anyhow::Result<()> {
+    let scope = tmg_search::SearchScope::parse(scope);
+    let since_dt = match since {
+        Some(s) => Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .with_context(|| format!("parsing --since {s:?}"))?
+                .with_timezone(&chrono::Utc),
+        ),
+        None => None,
+    };
+    let hits = index
+        .query(query, limit, scope, since_dt)
+        .context("running search query")?;
+    if hits.is_empty() {
+        println!("(no matches for query {query:?})");
+        return Ok(());
+    }
+    for hit in hits {
+        println!(
+            "[{:.3}] {}#{}  {}\n  summary: {}\n  snippet: {}\n",
+            hit.score, hit.run_id, hit.session_num, hit.started_at, hit.summary, hit.snippet,
+        );
+    }
+    Ok(())
+}
+
+#[expect(
+    clippy::print_stdout,
+    reason = "stdout is the contract for `tmg search` CLI output"
+)]
+fn search_commands_rebuild(
+    index: &tmg_search::SearchIndex,
+    config: &TsumugiConfig,
+    cwd: &std::path::Path,
+) -> anyhow::Result<()> {
+    let runs_dir = if config.harness.runs_dir.is_absolute() {
+        config.harness.runs_dir.clone()
+    } else {
+        cwd.join(&config.harness.runs_dir)
+    };
+    let count = index
+        .rebuild_from_disk(&runs_dir)
+        .context("rebuilding search index from disk")?;
+    println!(
+        "ingested {count} new session(s) from {}",
+        runs_dir.display()
+    );
+    Ok(())
+}
+
+#[expect(
+    clippy::print_stdout,
+    reason = "stdout is the contract for `tmg search` CLI output"
+)]
+fn search_commands_stats(index: &tmg_search::SearchIndex) -> anyhow::Result<()> {
+    let stats = index.stats().context("reading search index stats")?;
+    println!("db_path:  {}", stats.db_path.display());
+    println!("size:     {} bytes", stats.size_bytes);
+    println!("sessions: {}", stats.sessions);
+    println!("turns:    {}", stats.turns);
+    Ok(())
 }
 
 // `load_memory_index_for_prompt` was the bespoke helper used by the
@@ -452,6 +581,7 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
                 &config.workflow,
                 &config.skills,
                 &config.memory,
+                &config.search,
                 config.llm.subagent_pool.as_ref(),
                 resolved.as_ref(),
             )
@@ -513,6 +643,7 @@ fn run_prompt(
     prompt: &str,
     event_log: Option<&std::path::Path>,
     memory_config: &config::MemoryConfig,
+    search_config: &SearchConfig,
     sandbox_config: &SandboxConfigSection,
     context_config: tmg_core::ContextConfig,
     tool_calling_mode: tmg_llm::ToolCallingMode,
@@ -545,6 +676,30 @@ fn run_prompt(
             sandbox_config.to_sandbox_config(&canonical_cwd),
         ));
 
+        // Issue #53: open the cross-session search index for read-only
+        // use in one-shot mode. The DB is **never** written to from
+        // here — one-shot mode does not construct a `RunRunner`, so no
+        // session-end hook is registered and `ingest_session` is never
+        // called. The agent gets a search tool over whatever the TUI /
+        // workflow paths previously indexed.
+        let search_index_for_oneshot: Option<Arc<tmg_search::SearchIndex>> =
+            if search_config.enabled {
+                let db_path = search_config.resolve_db_path(&canonical_cwd);
+                match tmg_search::SearchIndex::open(&db_path) {
+                    Ok(idx) => Some(Arc::new(idx)),
+                    Err(e) => {
+                        tracing::warn!(
+                            path = %db_path.display(),
+                            error = %e,
+                            "failed to open search index for one-shot prompt; tool returns soft errors"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
         // Build the tool registry: built-ins + (optionally) the memory
         // tool. No subagent registration in one-shot mode because
         // there's no Run/Workflow/Subagent context here; the goal is
@@ -553,6 +708,18 @@ fn run_prompt(
         let mut registry = tmg_tools::default_registry();
         if memory_config.enabled {
             registry.register(tmg_memory::MemoryTool::new(Arc::clone(&memory_store)));
+        }
+        // Issue #53: register the cross-session search tool in
+        // one-shot mode so the agent can still query historical
+        // sessions even though no new sessions are being ingested
+        // (one-shot mode never constructs a RunRunner). Index opening
+        // is best-effort — a failure surfaces as a soft tool error.
+        if search_config.enabled
+            && let Some(idx) = search_index_for_oneshot.as_ref()
+        {
+            registry.register(tmg_search::SessionSearchTool::new(Arc::clone(idx)));
+        } else if search_config.enabled {
+            registry.register(tmg_search::SessionSearchTool::disabled());
         }
 
         let mut agent = tmg_core::AgentLoop::with_context_config(
@@ -802,6 +969,7 @@ fn run_tui(
     workflow_config: &tmg_workflow::WorkflowConfig,
     skills_config: &tmg_skills::SkillsConfig,
     memory_config: &config::MemoryConfig,
+    search_config: &SearchConfig,
     subagent_pool: Option<&tmg_llm::PoolConfig>,
     explicit_run_id: Option<&tmg_harness::RunId>,
 ) -> anyhow::Result<()> {
@@ -916,6 +1084,58 @@ fn run_tui(
                 );
             }
         });
+
+        // Cross-session search index (issue #53). Initialise the SQLite
+        // + FTS5 store under `<project>/.tsumugi/state.db`, run the
+        // startup rebuild scan so any session_log files written before
+        // the search feature was wired are picked up, then install a
+        // session-end hook on the runner so live sessions stream into
+        // the index. Failures in any of these steps degrade gracefully
+        // — the index becomes `None`, the tool reports a soft error,
+        // and the rest of the agent flow continues normally.
+        let search_index: Option<Arc<tmg_search::SearchIndex>> = if search_config.enabled {
+            let db_path = search_config.resolve_db_path(&canonical_cwd);
+            match tmg_search::SearchIndex::open(&db_path) {
+                Ok(idx) => {
+                    let runs_dir_for_rebuild = store.runs_dir().to_path_buf();
+                    if let Err(e) = idx.rebuild_from_disk(&runs_dir_for_rebuild) {
+                        tracing::warn!(
+                            error = %e,
+                            "search index rebuild_from_disk failed; continuing with whatever was indexed"
+                        );
+                    }
+                    Some(Arc::new(idx))
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        path = %db_path.display(),
+                        error = %e,
+                        "failed to open search index; session_search tool will return soft errors"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        if search_config.enabled
+            && search_config.ingest_on_session_end
+            && let Some(index) = search_index.as_ref()
+        {
+            let index_for_hook = Arc::clone(index);
+            let hook: tmg_harness::SessionEndHook =
+                Arc::new(move |run_id: &str, session: &tmg_harness::Session| {
+                    if let Err(e) = index_for_hook.ingest_session(run_id, session) {
+                        tracing::warn!(
+                            run_id = %run_id,
+                            session = session.index,
+                            error = %e,
+                            "search index ingest failed at session end"
+                        );
+                    }
+                });
+            runner.set_session_end_hook(Some(hook));
+        }
 
         let session_handle = runner
             .begin_session()
@@ -1111,6 +1331,20 @@ fn run_tui(
             Arc::clone(&subagent_manager),
             custom_agent_defs.clone(),
         ));
+        // Issue #53: register the cross-session FTS5 search tool when
+        // enabled. When the index couldn't be opened we still register
+        // a `disabled` tool so the LLM gets a soft error rather than a
+        // missing-tool dispatch failure.
+        if search_config.enabled {
+            match search_index.as_ref() {
+                Some(idx) => {
+                    registry.register(tmg_search::SessionSearchTool::new(Arc::clone(idx)));
+                }
+                None => {
+                    registry.register(tmg_search::SessionSearchTool::disabled());
+                }
+            }
+        }
         register_run_tools(&mut registry, Arc::clone(&runner)).await;
 
         // Workflow discovery + `run_workflow` / `workflow_status` tool
@@ -1340,6 +1574,7 @@ fn run_tui(
         } else {
             None
         };
+        let search_index_for_tui = search_index.as_ref().map(Arc::clone);
         let tui_result = tmg_tui::run(
             agent,
             model,
@@ -1356,6 +1591,7 @@ fn run_tui(
             workflow_metas.clone(),
             skill_metas,
             memory_store_for_tui,
+            search_index_for_tui,
         )
         .await;
 


### PR DESCRIPTION
## Summary

- Adds a new `tmg-search` crate that maintains a SQLite + FTS5 index of session summaries at `<project>/.tsumugi/state.db`, populated incrementally via a `SessionEndHook` on `RunRunner` and refilled on startup by a `rebuild_from_disk` walk.
- Exposes a `session_search` tool (FTS5 MATCH + bm25 + snippet highlights), `tmg search {query,rebuild,stats}` CLI subcommands, and a `/search <query>` TUI slash command. Adds a `[search]` config section.
- Redacts AWS / OpenAI / GitHub / Authorization / generic high-entropy tokens via a shared `redact_secrets` helper before anything hits the DB.

Closes #53.

## Implementation notes

- One-shot mode never constructs a `RunRunner`, so no session-end hook is wired and `ingest_session` is never called from that path. The `session_search` tool is still registered for read-only queries.
- `rusqlite` 0.32 is added to `[workspace.dependencies]` with the `bundled` feature; FTS5 ships in the bundled SQLite build, no extra feature flag needed (the issue's draft `fts5` feature does not exist on rusqlite 0.32).
- The runner now hand-rolls its `Debug` impl because `SessionEndHook` is `Arc<dyn Fn>`.
- A panicking hook is contained via `catch_unwind` so a broken subscriber cannot abort session rotation.
- Future `turns` ingest is reserved for #55 (trajectory recorder); the schema is laid down now so #55 only needs the producer side.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` — 23 tests in `tmg-search`, 208 in `tmg-harness` including 3 new hook tests
- [x] `tmg search stats` / `tmg search rebuild` / `tmg search query` work against an empty and populated DB
- [x] One-shot agent loop sees the `session_search` tool and dispatches it (verified via `--event-log`)
- [x] TUI run end-to-end with three rotated sessions populates the SQLite DB through the session-end hook (`sessions = 4` after the run)

### Runtime Verification
- LLM server: available
- One-shot mode: PASS
  - Events: 22 tokens, 1 `session_search` tool call, 1 tool_result, 0 errors, `done` reached
- TUI mode: PASS (session-end hook fired across 3 rotated sessions; `state.db` populated to 4 indexed sessions; no terminal escape leaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)