### PR TITLE
tmg-trajectory: RL/SFT trajectory recorder + tmg trajectory CLI (#55)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -466,6 +468,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -970,6 +983,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,7 +1039,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1207,7 +1233,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1235,6 +1261,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -1466,6 +1498,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -1950,6 +1991,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2142,7 @@ dependencies = [
  "tmg-search",
  "tmg-skills",
  "tmg-tools",
+ "tmg-trajectory",
  "tmg-tui",
  "tmg-workflow",
  "tokio",
@@ -2244,6 +2297,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tmg-trajectory"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "regex",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "tmg-core",
+ "tmg-harness",
+ "tmg-search",
+ "tokio",
+ "toml",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
 name = "tmg-tui"
 version = "0.1.0"
 dependencies = [
@@ -2262,6 +2335,7 @@ dependencies = [
  "tmg-search",
  "tmg-skills",
  "tmg-tools",
+ "tmg-trajectory",
  "tmg-workflow",
  "tokio",
  "tokio-util",
@@ -3212,6 +3286,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3328,3 +3412,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/tmg-tui",
     "crates/tmg-harness",
     "crates/tmg-workflow",
+    "crates/tmg-trajectory",
     "tmg-cli",
 ]
 
@@ -96,6 +97,10 @@ proptest = "1"
 landlock = "0.4"
 libc = "0.2"
 
+# Archive (tmg-trajectory bundle)
+tar = "0.4"
+zstd = "0.13"
+
 # Workspace crates
 tmg-core = { path = "crates/tmg-core" }
 tmg-llm = { path = "crates/tmg-llm" }
@@ -108,6 +113,7 @@ tmg-sandbox = { path = "crates/tmg-sandbox" }
 tmg-tui = { path = "crates/tmg-tui" }
 tmg-harness = { path = "crates/tmg-harness" }
 tmg-workflow = { path = "crates/tmg-workflow" }
+tmg-trajectory = { path = "crates/tmg-trajectory" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ eventsource-stream = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+toml_edit = "0.22"
 serde_yml = "0.0.12"
 
 # TUI

--- a/crates/tmg-trajectory/Cargo.toml
+++ b/crates/tmg-trajectory/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tmg-trajectory"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+tmg-core = { workspace = true }
+tmg-harness = { workspace = true }
+tmg-search = { workspace = true }
+chrono = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tar = { workspace = true }
+zstd = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+toml = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tmg-trajectory/src/bundle.rs
+++ b/crates/tmg-trajectory/src/bundle.rs
@@ -1,0 +1,141 @@
+//! `tmg trajectory bundle`: pack every trajectory file into one
+//! `tar.zst` archive.
+//!
+//! ## Format choice
+//!
+//! tar+zstd is the canonical "binary blob" format the ML community
+//! consumes (`HuggingFace` `datasets`, Atropos, TRL, torchdata). We
+//! prefer `tar` (uncompressed in-archive) wrapped in a zstd stream
+//! over `.tar.gz` for the higher ratio on JSONL — JSONL has long
+//! repeated key sequences (`{"type":"assistant"`...) that zstd
+//! exploits well.
+//!
+//! ## Layout
+//!
+//! Inside the archive, every member uses
+//! `<run_id>/session_NNN.jsonl` so consumers can group sessions by
+//! run without parsing the records.
+
+use std::fs::File;
+use std::io::Write as _;
+use std::path::Path;
+
+use tar::Builder;
+
+use crate::config::TrajectoryConfig;
+use crate::error::TrajectoryError;
+use crate::export::list_trajectories;
+
+/// Pack every trajectory under `runs_dir` into a `tar.zst` archive at
+/// `out_path`.
+///
+/// `compression_level` is the zstd quality level (1..=22). The default
+/// passed by the CLI is `3`, which matches the `zstd` CLI default.
+///
+/// # Errors
+///
+/// Returns [`TrajectoryError::Bundle`] on tar/zstd failure and
+/// [`TrajectoryError::Io`] on filesystem failure.
+pub fn bundle(
+    runs_dir: &Path,
+    config: &TrajectoryConfig,
+    out_path: &Path,
+    compression_level: i32,
+) -> Result<u32, TrajectoryError> {
+    let entries = list_trajectories(runs_dir, config)?;
+    if entries.is_empty() {
+        return Err(TrajectoryError::Bundle {
+            path: out_path.to_path_buf(),
+            message: "no trajectories found to bundle".into(),
+        });
+    }
+    if let Some(parent) = out_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).map_err(|e| TrajectoryError::io(parent, e))?;
+    }
+    let out_file = File::create(out_path).map_err(|e| TrajectoryError::io(out_path, e))?;
+    // The zstd encoder writes a stream into the underlying writer; we
+    // wrap it in a tar Builder so the call sequence is
+    // `tar::append → zstd::write → fs::write`. Calling
+    // `Encoder::finish()` is required to emit the trailing zstd frame.
+    let encoder = zstd::stream::write::Encoder::new(out_file, compression_level)
+        .map_err(|e| TrajectoryError::bundle(out_path, format!("creating zstd encoder: {e}")))?;
+    let mut tar = Builder::new(encoder);
+    let mut count: u32 = 0;
+    for entry in &entries {
+        let archive_name = format!("{}/session_{:03}.jsonl", entry.run_id, entry.session_num);
+        tar.append_path_with_name(&entry.path, &archive_name)
+            .map_err(|e| {
+                TrajectoryError::bundle(
+                    &entry.path,
+                    format!("appending to tar as {archive_name}: {e}"),
+                )
+            })?;
+        count = count.saturating_add(1);
+    }
+    let encoder = tar
+        .into_inner()
+        .map_err(|e| TrajectoryError::bundle(out_path, format!("finalising tar: {e}")))?;
+    let mut out_file = encoder
+        .finish()
+        .map_err(|e| TrajectoryError::bundle(out_path, format!("finalising zstd: {e}")))?;
+    out_file
+        .flush()
+        .map_err(|e| TrajectoryError::io(out_path, e))?;
+    Ok(count)
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use std::io::Read as _;
+    use tempfile::TempDir;
+
+    /// End-to-end: create a fake trajectory, bundle, then read the
+    /// archive back via the standard zstd + tar APIs and verify the
+    /// expected member is present.
+    #[test]
+    fn bundle_creates_valid_tar_zst() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let runs_dir = tmp.path().join("runs");
+        let traj_dir = runs_dir.join("abc12345").join("trajectories");
+        std::fs::create_dir_all(&traj_dir).unwrap_or_else(|e| panic!("{e}"));
+        let session = traj_dir.join("session_001.jsonl");
+        std::fs::write(&session, "{\"type\":\"meta\"}\n").unwrap_or_else(|e| panic!("{e}"));
+
+        let out_path = tmp.path().join("traj.tar.zst");
+        let count = bundle(&runs_dir, &TrajectoryConfig::default(), &out_path, 3)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(count, 1);
+        assert!(out_path.exists());
+
+        let f = File::open(&out_path).unwrap_or_else(|e| panic!("{e}"));
+        let dec = zstd::stream::read::Decoder::new(f).unwrap_or_else(|e| panic!("{e}"));
+        let mut tar_reader = tar::Archive::new(dec);
+        let mut found = false;
+        for entry in tar_reader.entries().unwrap_or_else(|e| panic!("{e}")) {
+            let mut entry = entry.unwrap_or_else(|e| panic!("{e}"));
+            let path_owned = entry.path().unwrap_or_else(|e| panic!("{e}")).into_owned();
+            assert_eq!(path_owned.to_string_lossy(), "abc12345/session_001.jsonl");
+            let mut body = String::new();
+            entry
+                .read_to_string(&mut body)
+                .unwrap_or_else(|e| panic!("{e}"));
+            assert!(body.contains(r#""type":"meta""#), "{body}");
+            found = true;
+        }
+        assert!(found, "expected one archive entry");
+    }
+
+    #[test]
+    fn bundle_errors_when_no_trajectories() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let runs_dir = tmp.path().join("runs");
+        std::fs::create_dir_all(&runs_dir).unwrap_or_else(|e| panic!("{e}"));
+        let out_path = tmp.path().join("empty.tar.zst");
+        let result = bundle(&runs_dir, &TrajectoryConfig::default(), &out_path, 3);
+        assert!(matches!(result, Err(TrajectoryError::Bundle { .. })));
+    }
+}

--- a/crates/tmg-trajectory/src/config.rs
+++ b/crates/tmg-trajectory/src/config.rs
@@ -18,9 +18,11 @@
 //! validates extra patterns at construction so a bad regex surfaces
 //! before the first session.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+
+use crate::error::TrajectoryError;
 
 /// Rendering policy for tool-result records.
 ///
@@ -102,14 +104,102 @@ impl Default for TrajectoryConfig {
 
 impl TrajectoryConfig {
     /// Resolve the output directory for one run dir, returning the
-    /// absolute path the recorder writes into. Relative `output_dir`
-    /// values are joined onto `run_dir`; absolute values are honoured
-    /// verbatim (rare but lets operators redirect to a network mount).
+    /// absolute path the recorder writes into.
+    ///
+    /// Relative `output_dir` values are joined onto `run_dir`;
+    /// absolute values are honoured verbatim (rare but lets operators
+    /// redirect to a network mount).
+    ///
+    /// **No sandbox check is performed.** Callers that need to enforce
+    /// "trajectories live under the project root" must use
+    /// [`Self::resolve_output_dir_within`] — see its rustdoc for the
+    /// contract.
     #[must_use]
-    pub fn resolve_output_dir(&self, run_dir: &std::path::Path) -> PathBuf {
+    pub fn resolve_output_dir(&self, run_dir: &Path) -> PathBuf {
         let p = PathBuf::from(&self.output_dir);
         if p.is_absolute() { p } else { run_dir.join(p) }
     }
+
+    /// Resolve the output directory like [`Self::resolve_output_dir`]
+    /// but reject paths that escape the supplied `project_root`.
+    ///
+    /// # Contract
+    ///
+    /// On success the returned path is guaranteed to be a descendant
+    /// (or equal to) the canonicalised `project_root`. Symlinks in the
+    /// configured `output_dir` are resolved before comparison so a
+    /// user cannot escape the project root via `..` or via a symlink
+    /// pointing outside the tree.
+    ///
+    /// This is the recommended entry point for the live recorder —
+    /// the live agent loop already operates inside a sandbox bound to
+    /// the project root, so an absolute `output_dir` pointing
+    /// elsewhere should be rejected at config-load time rather than
+    /// silently falling outside Landlock's reach on macOS or other
+    /// non-Linux platforms.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TrajectoryError::InvalidConfig`] when:
+    /// - `project_root` does not exist or cannot be canonicalised, or
+    /// - the resolved output dir, after best-effort canonicalisation,
+    ///   does not fall under the canonical `project_root`.
+    pub fn resolve_output_dir_within(
+        &self,
+        project_root: &Path,
+        run_dir: &Path,
+    ) -> Result<PathBuf, TrajectoryError> {
+        let resolved = self.resolve_output_dir(run_dir);
+        let canonical_root = project_root.canonicalize().map_err(|e| {
+            TrajectoryError::InvalidConfig(format!(
+                "canonicalising project root {}: {e}",
+                project_root.display(),
+            ))
+        })?;
+        // The resolved dir does not necessarily exist yet; canonicalise
+        // the deepest existing ancestor and rejoin the tail. This
+        // matches what `std::fs::canonicalize` would have produced if
+        // the directory existed.
+        let canonical_resolved = canonicalise_or_existing_ancestor(&resolved);
+        if canonical_resolved.starts_with(&canonical_root) {
+            Ok(resolved)
+        } else {
+            Err(TrajectoryError::InvalidConfig(format!(
+                "trajectory output_dir {} resolves outside project root {}",
+                resolved.display(),
+                canonical_root.display(),
+            )))
+        }
+    }
+}
+
+/// Canonicalise `path`, falling back to canonicalising the deepest
+/// ancestor that actually exists and re-joining the unresolved tail.
+/// Used by [`TrajectoryConfig::resolve_output_dir_within`] so the
+/// check works even before the trajectory directory has been created.
+fn canonicalise_or_existing_ancestor(path: &Path) -> PathBuf {
+    if let Ok(canonical) = path.canonicalize() {
+        return canonical;
+    }
+    let mut existing: Option<&Path> = None;
+    let mut ancestor = path.parent();
+    while let Some(p) = ancestor {
+        if p.exists() {
+            existing = Some(p);
+            break;
+        }
+        ancestor = p.parent();
+    }
+    let Some(existing) = existing else {
+        return path.to_path_buf();
+    };
+    let Ok(canonical_existing) = existing.canonicalize() else {
+        return path.to_path_buf();
+    };
+    let Ok(tail) = path.strip_prefix(existing) else {
+        return path.to_path_buf();
+    };
+    canonical_existing.join(tail)
 }
 
 #[cfg(test)]
@@ -155,5 +245,47 @@ mod tests {
         );
         c.output_dir = "/elsewhere".into();
         assert_eq!(c.resolve_output_dir(run_dir), PathBuf::from("/elsewhere"));
+    }
+
+    /// Sandbox check — a relative `output_dir` under the project root
+    /// resolves successfully.
+    #[test]
+    fn resolve_output_dir_within_accepts_in_root() {
+        let tmp = tempfile::TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let project_root = tmp.path();
+        let run_dir = project_root.join(".tsumugi/runs/abc");
+        std::fs::create_dir_all(&run_dir).unwrap_or_else(|e| panic!("{e}"));
+        let c = TrajectoryConfig::default();
+        let out = c
+            .resolve_output_dir_within(project_root, &run_dir)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(out.ends_with("trajectories"), "{}", out.display());
+    }
+
+    /// Sandbox check — an absolute `output_dir` pointing outside the
+    /// project root is rejected with [`TrajectoryError::InvalidConfig`].
+    #[test]
+    fn resolve_output_dir_within_rejects_escape() {
+        let tmp = tempfile::TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let project_root = tmp.path();
+        let run_dir = project_root.join(".tsumugi/runs/abc");
+        std::fs::create_dir_all(&run_dir).unwrap_or_else(|e| panic!("{e}"));
+        // A separate tempdir that is *not* under the project root.
+        let escape = tempfile::TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let c = TrajectoryConfig {
+            output_dir: escape.path().to_string_lossy().into_owned(),
+            ..TrajectoryConfig::default()
+        };
+        let result = c.resolve_output_dir_within(project_root, &run_dir);
+        match result {
+            Err(TrajectoryError::InvalidConfig(msg)) => {
+                assert!(
+                    msg.contains("outside project root"),
+                    "unexpected message: {msg}"
+                );
+            }
+            Ok(p) => panic!("expected error, got Ok({})", p.display()),
+            Err(other) => panic!("expected InvalidConfig, got {other:?}"),
+        }
     }
 }

--- a/crates/tmg-trajectory/src/config.rs
+++ b/crates/tmg-trajectory/src/config.rs
@@ -1,0 +1,159 @@
+//! `[trajectory]` configuration for `tsumugi.toml`.
+//!
+//! The crate carries its own config struct so the CLI's
+//! `tsumugi.toml` parser can wire it in directly via
+//! `#[serde(default)]` without depending on a third helper.
+//!
+//! # Defaults
+//!
+//! Every knob defaults to the privacy-preserving option:
+//!
+//! - `enabled = false` — opt-in only.
+//! - `output_dir = "trajectories"` — under each run dir.
+//! - `include_thinking = false` — keep size manageable.
+//! - `include_tool_results = "redacted"` — never ship raw tool output.
+//! - `redact_extra_patterns = []` — empty list.
+//!
+//! Operators flip individual knobs in `tsumugi.toml`; the recorder
+//! validates extra patterns at construction so a bad regex surfaces
+//! before the first session.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Rendering policy for tool-result records.
+///
+/// The variants live behind a small enum (rather than a free-form
+/// string) so the CLI surfaces clap-side validation errors with the
+/// list of accepted values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolResultMode {
+    /// Pass the tool output through verbatim. Use only when the
+    /// operator has accepted that the trajectory will contain raw
+    /// payloads (handy for offline analysis on a trusted machine).
+    Full,
+    /// Redact via the shared regex set + `redact_extra_patterns`.
+    /// This is the default and the recommended setting for shipping
+    /// trajectories outside the recording machine.
+    #[default]
+    Redacted,
+    /// Replace the payload with a one-line placeholder of the form
+    /// `"<N chars, ok|err>"`. Useful when the conversation flow
+    /// matters for training but the actual tool output is sensitive.
+    SummaryOnly,
+}
+
+/// `[trajectory]` configuration block.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TrajectoryConfig {
+    /// Master switch — `false` keeps the recorder unconstructed and
+    /// no files are written.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// Output directory **relative to each run dir**. The default
+    /// `"trajectories"` produces files at
+    /// `.tsumugi/runs/<run-id>/trajectories/session_NNN.jsonl`.
+    #[serde(default = "default_output_dir")]
+    pub output_dir: String,
+
+    /// Include the assistant's `thinking` / reasoning block in the
+    /// trajectory. `false` (default) keeps file size manageable;
+    /// `true` is desirable for SFT training datasets.
+    #[serde(default = "default_include_thinking")]
+    pub include_thinking: bool,
+
+    /// How to render tool-result payloads. See [`ToolResultMode`].
+    #[serde(default)]
+    pub include_tool_results: ToolResultMode,
+
+    /// Operator-supplied additional redaction patterns. Each entry
+    /// must be a valid Rust [`regex`] pattern. Compilation is
+    /// validated at recorder construction.
+    #[serde(default)]
+    pub redact_extra_patterns: Vec<String>,
+}
+
+const fn default_enabled() -> bool {
+    false
+}
+
+fn default_output_dir() -> String {
+    "trajectories".to_owned()
+}
+
+const fn default_include_thinking() -> bool {
+    false
+}
+
+impl Default for TrajectoryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            output_dir: default_output_dir(),
+            include_thinking: default_include_thinking(),
+            include_tool_results: ToolResultMode::Redacted,
+            redact_extra_patterns: Vec::new(),
+        }
+    }
+}
+
+impl TrajectoryConfig {
+    /// Resolve the output directory for one run dir, returning the
+    /// absolute path the recorder writes into. Relative `output_dir`
+    /// values are joined onto `run_dir`; absolute values are honoured
+    /// verbatim (rare but lets operators redirect to a network mount).
+    #[must_use]
+    pub fn resolve_output_dir(&self, run_dir: &std::path::Path) -> PathBuf {
+        let p = PathBuf::from(&self.output_dir);
+        if p.is_absolute() { p } else { run_dir.join(p) }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_privacy_preserving() {
+        let c = TrajectoryConfig::default();
+        assert!(!c.enabled);
+        assert_eq!(c.output_dir, "trajectories");
+        assert!(!c.include_thinking);
+        assert_eq!(c.include_tool_results, ToolResultMode::Redacted);
+        assert!(c.redact_extra_patterns.is_empty());
+    }
+
+    #[test]
+    fn parses_full_toml_block() {
+        let toml_src = r#"
+            enabled = true
+            output_dir = "/var/log/tsumugi/traj"
+            include_thinking = true
+            include_tool_results = "summary_only"
+            redact_extra_patterns = ["A-[0-9]+"]
+        "#;
+        let parsed: TrajectoryConfig =
+            toml::from_str(toml_src).unwrap_or_else(|e| panic!("parse: {e}"));
+        assert!(parsed.enabled);
+        assert_eq!(parsed.output_dir, "/var/log/tsumugi/traj");
+        assert!(parsed.include_thinking);
+        assert_eq!(parsed.include_tool_results, ToolResultMode::SummaryOnly);
+        assert_eq!(parsed.redact_extra_patterns, vec!["A-[0-9]+"]);
+    }
+
+    #[test]
+    fn resolve_output_dir_handles_relative_and_absolute() {
+        let mut c = TrajectoryConfig::default();
+        let run_dir = std::path::Path::new("/runs/abc");
+        assert_eq!(
+            c.resolve_output_dir(run_dir),
+            PathBuf::from("/runs/abc/trajectories")
+        );
+        c.output_dir = "/elsewhere".into();
+        assert_eq!(c.resolve_output_dir(run_dir), PathBuf::from("/elsewhere"));
+    }
+}

--- a/crates/tmg-trajectory/src/error.rs
+++ b/crates/tmg-trajectory/src/error.rs
@@ -1,0 +1,81 @@
+//! Error types for the trajectory crate.
+//!
+//! The crate's surface follows the workspace convention: a single
+//! [`TrajectoryError`] enum covers every failure mode (I/O, JSON
+//! serialisation, regex compilation in user-supplied extra patterns,
+//! and archive bundling). Construction sites add `#[from]`-driven
+//! conversions so most call sites only need a `?`.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Errors emitted by the trajectory recorder, exporter, and bundle
+/// command paths.
+#[derive(Debug, Error)]
+pub enum TrajectoryError {
+    /// I/O failure (open, write, mkdir, rename).
+    ///
+    /// The wrapped path identifies the file or directory the operation
+    /// was targeting; the inner [`std::io::Error`] preserves the
+    /// platform error code.
+    #[error("I/O error at {path}: {source}")]
+    Io {
+        /// File or directory the operation targeted.
+        path: PathBuf,
+        /// The underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// JSON serialisation / deserialisation failure.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// User-supplied `redact_extra_patterns` did not compile.
+    #[error("invalid extra redaction pattern {pattern:?}: {source}")]
+    InvalidRedactionPattern {
+        /// The bad pattern, surfaced verbatim so operators can locate
+        /// it in their config.
+        pattern: String,
+        /// Underlying regex compile error.
+        #[source]
+        source: regex::Error,
+    },
+
+    /// Archive (tar / zstd) failure during `tmg trajectory bundle`.
+    #[error("bundle error at {path}: {message}")]
+    Bundle {
+        /// Path the archive op was operating on (the output archive,
+        /// or a member it was trying to read).
+        path: PathBuf,
+        /// Free-form context message.
+        message: String,
+    },
+
+    /// Configuration value rejected at validation time.
+    #[error("invalid trajectory config: {0}")]
+    InvalidConfig(String),
+}
+
+impl TrajectoryError {
+    /// Build an [`TrajectoryError::Io`] from a path and an
+    /// [`std::io::Error`]. Mirrors the helper pattern used in
+    /// [`tmg_harness::HarnessError`].
+    #[must_use]
+    pub fn io(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        Self::Io {
+            path: path.into(),
+            source,
+        }
+    }
+
+    /// Build an [`TrajectoryError::Bundle`] error.
+    #[must_use]
+    pub fn bundle(path: impl Into<PathBuf>, message: impl Into<String>) -> Self {
+        Self::Bundle {
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+}

--- a/crates/tmg-trajectory/src/export.rs
+++ b/crates/tmg-trajectory/src/export.rs
@@ -177,12 +177,7 @@ fn export_one_run(
         if !session.summary.is_empty() {
             recorder.record_user(&session.summary)?;
         }
-        if event_log_path.as_ref().is_some_and(|p| p.exists()) {
-            #[expect(
-                clippy::unwrap_used,
-                reason = "is_some_and() above guarantees Some; ergonomic borrow"
-            )]
-            let path = event_log_path.as_ref().unwrap();
+        if let Some(path) = event_log_path.as_ref().filter(|p| p.exists()) {
             replay_event_log(path, &recorder)?;
         } else {
             had_fallback = true;
@@ -258,6 +253,22 @@ enum EventEnvelopeKind {
     Other,
 }
 
+/// Replay an `--event-log` JSONL file into trajectory records.
+///
+/// # Tool-call / tool-result pairing
+///
+/// The event log does not carry call ids, so this function synthesises
+/// sequential `export_call_N` ids and matches `tool_result` events to
+/// the oldest pending `tool_call` of the same name (FIFO by tool
+/// name). This works well in practice but is **not** guaranteed to
+/// match the live recorder's ids — concurrent calls of the same tool
+/// can be paired in a different order from the live agent loop.
+///
+/// When the event log is truncated (e.g. the process was killed
+/// mid-turn), some `tool_call` events will have no matching
+/// `tool_result`. This function emits a `tracing::warn!` at the end
+/// of replay listing how many calls remained unmatched so callers can
+/// detect the truncation case in their logs.
 fn replay_event_log(path: &Path, recorder: &Recorder) -> Result<(), TrajectoryError> {
     let raw = std::fs::read_to_string(path).map_err(|e| TrajectoryError::io(path, e))?;
     let mut current_thinking = String::new();
@@ -343,6 +354,17 @@ fn replay_event_log(path: &Path, recorder: &Recorder) -> Result<(), TrajectoryEr
             Some(current_thinking.as_str())
         };
         recorder.record_assistant(&current_text, thinking, &current_calls)?;
+    }
+    // Surface truncation / orphaned-call situations so callers can
+    // tell the difference between a clean replay and one where the
+    // event log was cut short. The `export_call_N` ids in
+    // `pending_calls` will never appear in any `tool_result` record
+    // produced by this run.
+    if !pending_calls.is_empty() {
+        tracing::warn!(
+            remaining = pending_calls.len(),
+            "event log truncated; tool_calls without matching tool_results",
+        );
     }
     Ok(())
 }
@@ -435,14 +457,6 @@ pub fn open_recorder_for_session(
 ) -> Result<Recorder, TrajectoryError> {
     let path = trajectory_path(run_dir, &config.output_dir, session_index);
     Recorder::create(path, config)
-}
-
-/// Render a trivially-formatted `Verdict` outcome string from a
-/// session-end trigger. Public so callers (e.g. the CLI session-end
-/// path) emit identical labels.
-#[must_use]
-pub fn record_outcome_label_pub(trigger: &tmg_harness::SessionEndTrigger) -> String {
-    super::record_outcome_label(trigger)
 }
 
 /// Push a [`TrajectoryRecord`] into a recorder by variant. Lets

--- a/crates/tmg-trajectory/src/export.rs
+++ b/crates/tmg-trajectory/src/export.rs
@@ -1,0 +1,580 @@
+//! Reconstruct trajectories from existing on-disk artifacts.
+//!
+//! When the `[trajectory]` feature was enabled mid-project, earlier
+//! runs only have `session_log/session_NNN.json` (and, if the user ran
+//! with `--event-log`, the corresponding event log) on disk. This
+//! module rebuilds an approximate trajectory from those artifacts.
+//!
+//! ## Granularity tradeoff
+//!
+//! - When **only** `session_log/*.json` is present, the export
+//!   collapses each session into a `meta` + `system` (placeholder) +
+//!   `user` (the recorded summary) + `verdict` quadruple. This is
+//!   marked "summary-only" in the meta record's `outcome` field so
+//!   downstream converters can decide whether to drop it.
+//!
+//! - When the matching `event_log/*.jsonl` (issue #50 / #52) is
+//!   present, the export replays the event stream into per-round
+//!   `assistant` + `tool_call` + `tool_result` records. The event
+//!   log does not carry the original user message, so we still
+//!   borrow `session.summary` for one synthetic `user` record at the
+//!   top of the file.
+//!
+//! Either way the reconstructed file is a *close approximation*, not
+//! a verbatim copy of what the live recorder would have produced.
+//! That is acceptable for the SFT/RL training use-case where coarse
+//! conversation flow is more useful than no signal at all.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use tmg_harness::{Run, RunStore, SessionLog};
+
+use crate::config::TrajectoryConfig;
+use crate::error::TrajectoryError;
+use crate::record::{
+    MetaRecord, SystemRecord, ToolCallRecord, ToolResultRecord, TrajectoryRecord, UserRecord,
+    VerdictRecord,
+};
+use crate::recorder::{Recorder, trajectory_path};
+use crate::redact::Redactor;
+
+/// Filter for `tmg trajectory export` selecting which runs to process.
+///
+/// Mirrors the CLI flags: `--run <id>`, `--all`, `--since <ISO8601>`.
+#[derive(Debug, Clone, Default)]
+pub struct ExportFilter {
+    /// Specific run id to export. `None` means "use the other knobs".
+    pub run_id: Option<String>,
+    /// When `true`, every run in the store is exported.
+    pub all: bool,
+    /// Lower bound on `Run::created_at`. When `Some` and `all = false`,
+    /// only runs newer than this are exported.
+    pub since: Option<DateTime<Utc>>,
+}
+
+/// Outcome of a single export run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportSummary {
+    /// Run id we exported for.
+    pub run_id: String,
+    /// Number of session trajectories written.
+    pub sessions_exported: u32,
+    /// `true` when the export found at least one `session_log` entry
+    /// without an `event_log` neighbour and used summary-only fallback.
+    pub had_summary_only_fallback: bool,
+}
+
+/// Top-level entry point for `tmg trajectory export`.
+///
+/// `out_dir` is the destination root: each exported session is written
+/// under `<out_dir>/<run-id>/session_NNN.jsonl`. When `out_dir` is
+/// `None`, the CLI default is `<run_dir>/<config.output_dir>/` (i.e.
+/// the same location the live recorder would use), so re-export is
+/// idempotent.
+///
+/// # Errors
+///
+/// Returns [`TrajectoryError`] on filesystem / JSON failure or
+/// configuration errors.
+pub fn export(
+    store: &RunStore,
+    filter: &ExportFilter,
+    out_dir: Option<&Path>,
+    config: &TrajectoryConfig,
+) -> Result<Vec<ExportSummary>, TrajectoryError> {
+    let runs = collect_runs(store, filter)?;
+    let redactor = Redactor::with_extras(config.redact_extra_patterns.iter())?;
+    let mut summaries = Vec::with_capacity(runs.len());
+    for run in runs {
+        let run_dir = store.run_dir(&run.id);
+        let dest = match out_dir {
+            Some(d) => d.join(run.id.as_str()),
+            None => config.resolve_output_dir(&run_dir),
+        };
+        let summary = export_one_run(&run, &run_dir, &dest, config, &redactor)?;
+        summaries.push(summary);
+    }
+    Ok(summaries)
+}
+
+fn collect_runs(store: &RunStore, filter: &ExportFilter) -> Result<Vec<Run>, TrajectoryError> {
+    if let Some(id) = &filter.run_id {
+        let parsed = tmg_harness::RunId::parse(id.clone())
+            .map_err(|e| TrajectoryError::InvalidConfig(format!("invalid run id {id:?}: {e}")))?;
+        let run = store
+            .load(&parsed)
+            .map_err(|e| TrajectoryError::InvalidConfig(format!("loading run {id:?}: {e}")))?;
+        return Ok(vec![run]);
+    }
+    let summaries = store
+        .list()
+        .map_err(|e| TrajectoryError::InvalidConfig(format!("listing runs: {e}")))?;
+    let mut out = Vec::with_capacity(summaries.len());
+    for summary in summaries {
+        if let Some(since) = filter.since
+            && summary.created_at < since
+        {
+            continue;
+        }
+        match store.load(&summary.id) {
+            Ok(run) => out.push(run),
+            Err(e) => {
+                tracing::warn!(run_id = %summary.id, error = %e, "skipping run that failed to load");
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn export_one_run(
+    run: &Run,
+    run_dir: &Path,
+    dest_dir: &Path,
+    config: &TrajectoryConfig,
+    redactor: &Redactor,
+) -> Result<ExportSummary, TrajectoryError> {
+    std::fs::create_dir_all(dest_dir).map_err(|e| TrajectoryError::io(dest_dir, e))?;
+    let session_log = SessionLog::new(run_dir.join("session_log"));
+    let entries = session_log
+        .list()
+        .map_err(|e| TrajectoryError::InvalidConfig(format!("listing session log: {e}")))?;
+    let mut had_fallback = false;
+    let mut count: u32 = 0;
+    for entry in entries {
+        let session = match session_log.load(entry.index) {
+            Ok(Some(s)) => s,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::warn!(index = entry.index, error = %e, "skipping unreadable session log");
+                continue;
+            }
+        };
+        let event_log_path = candidate_event_log(run_dir, entry.index);
+        let traj_path = dest_dir.join(format!("session_{:03}.jsonl", entry.index));
+        // Open per-session recorder. Reuse the redactor so we don't
+        // recompile the regex set per session.
+        let recorder = Recorder::with_redactor(&traj_path, config.clone(), redactor.clone())?;
+
+        let scope_label = run.scope.label().to_owned();
+        let model = "unknown".to_owned(); // session_log does not record the model name.
+        recorder.record_meta(MetaRecord {
+            run_id: run.id.as_str().to_owned(),
+            session_num: session.index,
+            model,
+            scope: scope_label,
+            started_at: session.started_at,
+            ended_at: session.ended_at,
+            outcome: session
+                .end_trigger
+                .as_ref()
+                .map(super::record_outcome_label),
+        })?;
+        recorder.record_system(
+            "(reconstructed from session_log; original system prompt unavailable)",
+        )?;
+        if !session.summary.is_empty() {
+            recorder.record_user(&session.summary)?;
+        }
+        if event_log_path.as_ref().is_some_and(|p| p.exists()) {
+            #[expect(
+                clippy::unwrap_used,
+                reason = "is_some_and() above guarantees Some; ergonomic borrow"
+            )]
+            let path = event_log_path.as_ref().unwrap();
+            replay_event_log(path, &recorder)?;
+        } else {
+            had_fallback = true;
+        }
+        recorder.record_verdict(
+            &session
+                .end_trigger
+                .as_ref()
+                .map_or_else(|| "unknown".to_owned(), super::record_outcome_label),
+            session.features_marked_passing.clone(),
+        )?;
+        recorder.flush()?;
+        count = count.saturating_add(1);
+    }
+    Ok(ExportSummary {
+        run_id: run.id.as_str().to_owned(),
+        sessions_exported: count,
+        had_summary_only_fallback: had_fallback,
+    })
+}
+
+/// Best-effort lookup for an event-log neighbour of a session.
+///
+/// Convention: a TUI / CLI session writes its event log to a path
+/// supplied by the user (`--event-log <path>`); when the path lives
+/// inside the run directory we can find it. Searched names:
+///
+/// - `<run_dir>/event_log/session_NNN.jsonl`
+/// - `<run_dir>/event_log_NNN.jsonl`
+/// - `<run_dir>/events.jsonl` (single-file fallback for the most
+///   recent session)
+fn candidate_event_log(run_dir: &Path, session_index: u32) -> Option<PathBuf> {
+    let candidates = [
+        run_dir
+            .join("event_log")
+            .join(format!("session_{session_index:03}.jsonl")),
+        run_dir.join(format!("event_log_{session_index:03}.jsonl")),
+        run_dir.join("events.jsonl"),
+    ];
+    candidates.into_iter().find(|c| c.exists())
+}
+
+/// Minimal subset of [`tmg_core::EventLogWriter`]'s on-disk schema we
+/// need to consume here. Mirrors the `EventRecord<'a>` type — but
+/// stays decoupled so a future event-log evolution (e.g. new event
+/// kinds) can be added without forcing this crate to rebuild against
+/// `tmg-core`.
+#[derive(Debug, Deserialize)]
+struct EventEnvelope {
+    event: EventEnvelopeKind,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum EventEnvelopeKind {
+    #[serde(rename = "thinking")]
+    Thinking { token: String },
+    #[serde(rename = "token")]
+    Token { token: String },
+    #[serde(rename = "tool_call")]
+    ToolCall { name: String, arguments: String },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        name: String,
+        output: String,
+        is_error: bool,
+    },
+    #[serde(rename = "done")]
+    Done,
+    /// Catch-all so unknown event kinds (warnings, memory ops, pool
+    /// selection events) parse without erroring; we just drop them.
+    #[serde(other)]
+    Other,
+}
+
+fn replay_event_log(path: &Path, recorder: &Recorder) -> Result<(), TrajectoryError> {
+    let raw = std::fs::read_to_string(path).map_err(|e| TrajectoryError::io(path, e))?;
+    let mut current_thinking = String::new();
+    let mut current_text = String::new();
+    let mut current_calls: Vec<ToolCallRecord> = Vec::new();
+    // Keep a stable lookup of the most recent `tool_call` so the
+    // next `tool_result` can be matched up with the corresponding
+    // call_id. The event log does not carry call ids, so we
+    // synthesise sequential ones.
+    let mut next_call_id: u32 = 0;
+    let mut pending_calls: Vec<(String, String)> = Vec::new(); // (id, name)
+
+    for (line_no, line) in raw.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let env: EventEnvelope = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(line_no, error = %e, "skipping unparsable event_log line");
+                continue;
+            }
+        };
+        match env.event {
+            EventEnvelopeKind::Thinking { token } => current_thinking.push_str(&token),
+            EventEnvelopeKind::Token { token } => current_text.push_str(&token),
+            EventEnvelopeKind::ToolCall { name, arguments } => {
+                next_call_id = next_call_id.saturating_add(1);
+                let id = format!("export_call_{next_call_id}");
+                let args_val = serde_json::from_str::<serde_json::Value>(&arguments)
+                    .unwrap_or_else(|_| serde_json::Value::String(arguments.clone()));
+                current_calls.push(ToolCallRecord {
+                    id: id.clone(),
+                    name: name.clone(),
+                    arguments: args_val,
+                });
+                pending_calls.push((id, name));
+            }
+            EventEnvelopeKind::ToolResult {
+                name,
+                output,
+                is_error,
+            } => {
+                // Match against the oldest pending call by name. This
+                // is a heuristic — concurrent calls of the same name
+                // are still paired in FIFO order which is good enough
+                // for an offline reconstruction.
+                let id = pending_calls
+                    .iter()
+                    .position(|(_, n)| n == &name)
+                    .map_or_else(
+                        || {
+                            next_call_id = next_call_id.saturating_add(1);
+                            format!("export_call_{next_call_id}")
+                        },
+                        |i| pending_calls.remove(i).0,
+                    );
+                recorder.record_tool_result(&id, &name, &output, is_error)?;
+            }
+            EventEnvelopeKind::Done => {
+                // Flush the round.
+                let thinking = if current_thinking.is_empty() {
+                    None
+                } else {
+                    Some(current_thinking.as_str())
+                };
+                if !current_text.is_empty() || thinking.is_some() || !current_calls.is_empty() {
+                    recorder.record_assistant(&current_text, thinking, &current_calls)?;
+                }
+                current_text.clear();
+                current_thinking.clear();
+                current_calls.clear();
+            }
+            EventEnvelopeKind::Other => {}
+        }
+    }
+    // Flush any tail-end content that did not see a `done` event
+    // (e.g. truncated event log).
+    if !current_text.is_empty() || !current_thinking.is_empty() || !current_calls.is_empty() {
+        let thinking = if current_thinking.is_empty() {
+            None
+        } else {
+            Some(current_thinking.as_str())
+        };
+        recorder.record_assistant(&current_text, thinking, &current_calls)?;
+    }
+    Ok(())
+}
+
+/// Inventory entry returned by [`list_trajectories`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrajectoryEntry {
+    /// Owning run id.
+    pub run_id: String,
+    /// 1-indexed session number.
+    pub session_num: u32,
+    /// Path to the JSONL file on disk.
+    pub path: PathBuf,
+    /// File size in bytes.
+    pub size_bytes: u64,
+}
+
+/// Walk every run dir under `runs_dir`, listing trajectory files
+/// already on disk (under each run's `<output_dir>`). Used by
+/// `tmg trajectory list`.
+///
+/// # Errors
+/// Returns [`TrajectoryError::Io`] when a directory cannot be read.
+pub fn list_trajectories(
+    runs_dir: &Path,
+    config: &TrajectoryConfig,
+) -> Result<Vec<TrajectoryEntry>, TrajectoryError> {
+    let mut out = Vec::new();
+    if !runs_dir.exists() {
+        return Ok(out);
+    }
+    let read_dir = std::fs::read_dir(runs_dir).map_err(|e| TrajectoryError::io(runs_dir, e))?;
+    for run_ent in read_dir {
+        let run_ent = run_ent.map_err(|e| TrajectoryError::io(runs_dir, e))?;
+        let run_path = run_ent.path();
+        if !run_path.is_dir() {
+            continue;
+        }
+        let run_id = match run_path.file_name().and_then(|n| n.to_str()) {
+            Some(s) => s.to_owned(),
+            None => continue,
+        };
+        let traj_dir = config.resolve_output_dir(&run_path);
+        if !traj_dir.exists() {
+            continue;
+        }
+        let session_files =
+            std::fs::read_dir(&traj_dir).map_err(|e| TrajectoryError::io(&traj_dir, e))?;
+        for sess_ent in session_files {
+            let sess_ent = sess_ent.map_err(|e| TrajectoryError::io(&traj_dir, e))?;
+            let path = sess_ent.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let Some(idx) = parse_session_jsonl(name) else {
+                continue;
+            };
+            let metadata = std::fs::metadata(&path).map_err(|e| TrajectoryError::io(&path, e))?;
+            out.push(TrajectoryEntry {
+                run_id: run_id.clone(),
+                session_num: idx,
+                path,
+                size_bytes: metadata.len(),
+            });
+        }
+    }
+    out.sort_by(|a, b| {
+        a.run_id
+            .cmp(&b.run_id)
+            .then_with(|| a.session_num.cmp(&b.session_num))
+    });
+    Ok(out)
+}
+
+fn parse_session_jsonl(name: &str) -> Option<u32> {
+    let stripped = name.strip_prefix("session_")?.strip_suffix(".jsonl")?;
+    stripped.parse::<u32>().ok()
+}
+
+/// Convenience constructor used by the CLI to write a freshly-minted
+/// trajectory record without going through the streaming sink path.
+/// Callers that already hold a [`Recorder`] can skip this helper.
+///
+/// # Errors
+/// Returns [`TrajectoryError`] when the recorder cannot be constructed.
+pub fn open_recorder_for_session(
+    run_dir: &Path,
+    session_index: u32,
+    config: TrajectoryConfig,
+) -> Result<Recorder, TrajectoryError> {
+    let path = trajectory_path(run_dir, &config.output_dir, session_index);
+    Recorder::create(path, config)
+}
+
+/// Render a trivially-formatted `Verdict` outcome string from a
+/// session-end trigger. Public so callers (e.g. the CLI session-end
+/// path) emit identical labels.
+#[must_use]
+pub fn record_outcome_label_pub(trigger: &tmg_harness::SessionEndTrigger) -> String {
+    super::record_outcome_label(trigger)
+}
+
+/// Push a [`TrajectoryRecord`] into a recorder by variant. Lets
+/// callers write code in terms of the `TrajectoryRecord` enum without
+/// caring which `record_*` helper to call.
+///
+/// # Errors
+/// Returns [`TrajectoryError`] on serialisation or I/O failure.
+pub fn record(recorder: &Recorder, record: TrajectoryRecord) -> Result<(), TrajectoryError> {
+    match record {
+        TrajectoryRecord::Meta(m) => recorder.record_meta(m),
+        TrajectoryRecord::System(SystemRecord { content }) => recorder.record_system(&content),
+        TrajectoryRecord::User(UserRecord { content }) => recorder.record_user(&content),
+        TrajectoryRecord::Assistant(a) => {
+            recorder.record_assistant(&a.content, a.thinking.as_deref(), &a.tool_calls)
+        }
+        TrajectoryRecord::ToolResult(ToolResultRecord {
+            tool_call_id,
+            tool_name,
+            output,
+            is_error,
+        }) => recorder.record_tool_result(&tool_call_id, &tool_name, &output, is_error),
+        TrajectoryRecord::Feedback(f) => recorder.record_feedback(&f.source, &f.content),
+        TrajectoryRecord::Verdict(VerdictRecord {
+            outcome,
+            feature_marked_passing,
+        }) => recorder.record_verdict(&outcome, feature_marked_passing),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use tmg_harness::{Session, SessionEndTrigger};
+
+    /// Round-trip a minimal session through the export path: write a
+    /// `session_NNN.json`, run `export`, verify the produced JSONL
+    /// has meta + system + user + verdict.
+    #[test]
+    fn export_summary_only_fallback() {
+        let tmp = tempfile::TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let runs_dir = tmp.path().join("runs");
+        std::fs::create_dir_all(&runs_dir).unwrap_or_else(|e| panic!("{e}"));
+        let store = RunStore::new(&runs_dir);
+        let run = store
+            .create_ad_hoc(tmp.path().to_path_buf(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let log = SessionLog::new(store.session_log_dir(&run.id));
+        let mut session = Session::begin(1);
+        session.summary =
+            "implemented foo and ran the API key sk-abcdefghijklmnopqrstuvwxyz1234567890ABCD"
+                .into();
+        session.end(SessionEndTrigger::Completed);
+        log.save(&session).unwrap_or_else(|e| panic!("{e}"));
+
+        let out_dir = tmp.path().join("out");
+        let summaries = export(
+            &store,
+            &ExportFilter {
+                run_id: Some(run.id.as_str().to_owned()),
+                ..ExportFilter::default()
+            },
+            Some(&out_dir),
+            &TrajectoryConfig::default(),
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].sessions_exported, 1);
+        assert!(summaries[0].had_summary_only_fallback);
+
+        let traj = std::fs::read_to_string(out_dir.join(run.id.as_str()).join("session_001.jsonl"))
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(traj.contains(r#""type":"meta""#), "{traj}");
+        assert!(traj.contains(r#""type":"system""#), "{traj}");
+        assert!(traj.contains(r#""type":"user""#), "{traj}");
+        assert!(traj.contains(r#""type":"verdict""#), "{traj}");
+        // Redaction must apply on the `user` record minted from the summary.
+        assert!(!traj.contains("sk-abcdefghijkl"), "{traj}");
+    }
+
+    /// When an `event_log/session_NNN.jsonl` neighbour is present, the
+    /// export replays it into per-round assistant records.
+    #[test]
+    fn export_replays_event_log() {
+        let tmp = tempfile::TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let runs_dir = tmp.path().join("runs");
+        std::fs::create_dir_all(&runs_dir).unwrap_or_else(|e| panic!("{e}"));
+        let store = RunStore::new(&runs_dir);
+        let run = store
+            .create_ad_hoc(tmp.path().to_path_buf(), None)
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let log = SessionLog::new(store.session_log_dir(&run.id));
+        let mut session = Session::begin(1);
+        session.summary = "Read Cargo.toml".into();
+        session.end(SessionEndTrigger::Completed);
+        log.save(&session).unwrap_or_else(|e| panic!("{e}"));
+
+        let event_log_dir = store.run_dir(&run.id).join("event_log");
+        std::fs::create_dir_all(&event_log_dir).unwrap_or_else(|e| panic!("{e}"));
+        let event_log_path = event_log_dir.join("session_001.jsonl");
+        // Synthesised event log mimicking `EventLogWriter`'s schema.
+        let event_log_body = r#"{"elapsed_ms":0,"event":{"type":"token","token":"Reading "}}
+{"elapsed_ms":1,"event":{"type":"token","token":"Cargo.toml"}}
+{"elapsed_ms":2,"event":{"type":"tool_call","name":"file_read","arguments":"{\"path\":\"Cargo.toml\"}"}}
+{"elapsed_ms":3,"event":{"type":"done"}}
+{"elapsed_ms":4,"event":{"type":"tool_result","name":"file_read","output":"[workspace]","is_error":false}}
+{"elapsed_ms":5,"event":{"type":"token","token":"done"}}
+{"elapsed_ms":6,"event":{"type":"done"}}
+"#;
+        std::fs::write(&event_log_path, event_log_body).unwrap_or_else(|e| panic!("{e}"));
+
+        let out_dir = tmp.path().join("out");
+        let _ = export(
+            &store,
+            &ExportFilter {
+                run_id: Some(run.id.as_str().to_owned()),
+                ..ExportFilter::default()
+            },
+            Some(&out_dir),
+            &TrajectoryConfig::default(),
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let traj = std::fs::read_to_string(out_dir.join(run.id.as_str()).join("session_001.jsonl"))
+            .unwrap_or_else(|e| panic!("{e}"));
+        // Two assistant rounds, one tool_result.
+        let assistant_count = traj.matches(r#""type":"assistant""#).count();
+        let tool_result_count = traj.matches(r#""type":"tool_result""#).count();
+        assert_eq!(assistant_count, 2, "{traj}");
+        assert_eq!(tool_result_count, 1, "{traj}");
+    }
+}

--- a/crates/tmg-trajectory/src/lib.rs
+++ b/crates/tmg-trajectory/src/lib.rs
@@ -1,0 +1,92 @@
+//! tmg-trajectory: structured RL/SFT-grade conversation logs.
+//!
+//! Records every turn of an agent session (system prompt, user input,
+//! assistant response with optional reasoning + tool calls, tool
+//! results, user-intervention feedback, and an end-of-session
+//! verdict) as JSON Lines under
+//! `.tsumugi/runs/<run-id>/trajectories/session_NNN.jsonl`.
+//!
+//! # `OpenAI` compatibility
+//!
+//! The on-disk schema is a *superset* of the `OpenAI` chat-completion
+//! conversation format: each record's `type` field corresponds to a
+//! standard `role` (or to the auxiliary `tool_result` role) so a
+//! thin transform produces an `OpenAI`-compatible dataset without
+//! re-reading the source-of-truth log. The exact mapping is
+//! documented on [`record::TrajectoryRecord`].
+//!
+//! # Wiring into the agent loop
+//!
+//! The integrator (the CLI in this workspace) opens a [`Recorder`] at
+//! session start, wraps the existing [`tmg_core::StreamSink`] in a
+//! [`TrajectoryStreamSink`], and lets the tee chain do the rest. See
+//! [`sink`] for the wire-up details.
+//!
+//! # Default OFF
+//!
+//! Issue #55 mandates trajectory recording is **opt-in**. The CLI is
+//! responsible for honouring [`TrajectoryConfig::enabled`]; this
+//! crate refuses nothing, but the integrator must skip recorder
+//! construction when the config flag is `false`.
+//!
+//! # `.gitignore` recommendation
+//!
+//! Trajectory files are **not** intended for version control: they
+//! contain raw conversation text and code diffs. Add the following
+//! patterns to your project's `.gitignore`:
+//!
+//! ```text
+//! # tsumugi trajectories (issue #55) — full conversation logs
+//! .tsumugi/runs/*/trajectories/
+//! .tsumugi/trajectories/
+//! ```
+//!
+//! When `tmg init` adds a `.gitignore` template in a future revision
+//! it should include these entries.
+
+pub mod bundle;
+pub mod config;
+pub mod error;
+pub mod export;
+pub mod record;
+pub mod recorder;
+pub mod redact;
+pub mod sink;
+
+pub use config::{ToolResultMode, TrajectoryConfig};
+pub use error::TrajectoryError;
+pub use export::{
+    ExportFilter, ExportSummary, TrajectoryEntry, export, list_trajectories,
+    open_recorder_for_session,
+};
+pub use record::{
+    AssistantRecord, FeedbackRecord, MetaRecord, SystemRecord, ToolCallRecord, ToolResultRecord,
+    TrajectoryRecord, UserRecord, VerdictRecord,
+};
+pub use recorder::{Recorder, TRAJECTORIES_DIRNAME, now_utc, trajectory_path};
+pub use redact::{REDACTION_TOKEN, Redactor, redact_secrets};
+pub use sink::{NoOpSink, RecorderSink, TrajectorySink, TrajectoryStreamSink};
+
+/// Convert a [`tmg_harness::SessionEndTrigger`] into the short label
+/// used by the [`record::VerdictRecord::outcome`] / [`record::MetaRecord::outcome`]
+/// fields.
+///
+/// Centralised here so the live-recording path (CLI) and the export
+/// path (which has a `&Session` only) emit identical values.
+#[must_use]
+pub fn record_outcome_label(trigger: &tmg_harness::SessionEndTrigger) -> String {
+    match trigger {
+        tmg_harness::SessionEndTrigger::Completed => "completed".into(),
+        tmg_harness::SessionEndTrigger::UserCancelled => "user_cancelled".into(),
+        tmg_harness::SessionEndTrigger::Rotated { reason } => {
+            format!("rotated: {reason}")
+        }
+        tmg_harness::SessionEndTrigger::Errored { message } => {
+            format!("errored: {message}")
+        }
+        tmg_harness::SessionEndTrigger::UserExit => "user_exit".into(),
+        tmg_harness::SessionEndTrigger::ContextRotation => "context_rotation".into(),
+        tmg_harness::SessionEndTrigger::Timeout => "timeout".into(),
+        tmg_harness::SessionEndTrigger::UserNewSession => "user_new_session".into(),
+    }
+}

--- a/crates/tmg-trajectory/src/record.rs
+++ b/crates/tmg-trajectory/src/record.rs
@@ -1,0 +1,268 @@
+//! Serialisable trajectory record types.
+//!
+//! The on-disk format is JSONL (one record per line), and records are
+//! tagged by a `type` field so external converters can stream them with
+//! a single decode pass. The shape is deliberately a *superset* of the
+//! `OpenAI` chat-completion conversation format: every record's
+//! `type` field corresponds to a `role` (or to the auxiliary
+//! `tool_result` shape), so a thin transform can produce
+//! [Atropos](https://github.com/NousResearch/atropos) /
+//! [TRL](https://github.com/huggingface/trl) compatible training
+//! datasets without re-reading the source-of-truth log.
+//!
+//! # Type / role mapping
+//!
+//! | trajectory `type` | `OpenAI` chat `role` | Notes                                  |
+//! |-------------------|----------------------|----------------------------------------|
+//! | `system`          | `system`             | 1:1                                    |
+//! | `user`            | `user`               | 1:1                                    |
+//! | `assistant`       | `assistant`          | 1:1; carries optional `tool_calls`     |
+//! | `tool_result`     | `tool`               | `OpenAI` uses the `tool` role here     |
+//! | `meta`            | n/a                  | dataset metadata; outside the chat log |
+//! | `feedback`        | n/a                  | RL signal; outside the chat log        |
+//! | `verdict`         | n/a                  | session outcome; outside the chat log  |
+//!
+//! Converters that target `OpenAI` exactly should drop `meta`,
+//! `feedback`, and `verdict` (or fold `feedback` into a separate
+//! reward channel).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// One record line in a trajectory JSONL file.
+///
+/// `#[serde(tag = "type")]` writes a `type` field on the wire so the
+/// JSONL is self-describing. `#[serde(rename_all = "snake_case")]`
+/// keeps the discriminator values lower-case (`"meta"`, `"system"`,
+/// ...) per the issue spec.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TrajectoryRecord {
+    /// Dataset metadata. Always the first record in a session file.
+    Meta(MetaRecord),
+    /// System prompt at the start of the conversation.
+    System(SystemRecord),
+    /// User-authored turn input.
+    User(UserRecord),
+    /// Assistant response (free text + optional reasoning + optional
+    /// `tool_calls`).
+    Assistant(AssistantRecord),
+    /// Result of a single tool invocation, paired with the
+    /// `tool_call_id` from the matching [`AssistantRecord`].
+    ToolResult(ToolResultRecord),
+    /// User intervention or correction signal (RL / SFT).
+    Feedback(FeedbackRecord),
+    /// Final session outcome label.
+    Verdict(VerdictRecord),
+}
+
+/// Dataset metadata record (one per file, written first).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetaRecord {
+    /// Run id (8-char short form).
+    pub run_id: String,
+    /// 1-indexed session number within the run.
+    pub session_num: u32,
+    /// LLM model name as recorded in `tsumugi.toml`.
+    pub model: String,
+    /// Run scope label (`"ad-hoc"` or `"harnessed"`).
+    pub scope: String,
+    /// Session start timestamp (UTC).
+    pub started_at: DateTime<Utc>,
+    /// Session end timestamp; `None` while the session is still live.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<DateTime<Utc>>,
+    /// Outcome label written when the session ends. Free-form short
+    /// string (`"completed"`, `"errored"`, `"cancelled"`, ...).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+}
+
+/// System-prompt record.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SystemRecord {
+    /// System prompt text. Redaction is applied before write.
+    pub content: String,
+}
+
+/// User-turn record.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserRecord {
+    /// User message text. Redaction is applied before write.
+    pub content: String,
+}
+
+/// Assistant-turn record.
+///
+/// `thinking` is gated by `[trajectory] include_thinking` (off by
+/// default to keep file size manageable). `tool_calls` is the same
+/// shape as the `OpenAI` tool-calling response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssistantRecord {
+    /// Final visible assistant text (post tool-call extraction).
+    pub content: String,
+    /// Optional reasoning / chain-of-thought block, when
+    /// `include_thinking = true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
+    /// Tool calls the assistant emitted in this turn (empty when none
+    /// were issued).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ToolCallRecord>,
+}
+
+/// One tool call inside an [`AssistantRecord`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolCallRecord {
+    /// Unique LLM-issued call identifier; pairs with the
+    /// [`ToolResultRecord::tool_call_id`].
+    pub id: String,
+    /// Function/tool name.
+    pub name: String,
+    /// Arguments JSON object (already parsed when possible, otherwise
+    /// the raw string verbatim — preserves out-of-spec emissions for
+    /// later inspection).
+    pub arguments: serde_json::Value,
+}
+
+/// Tool result record. Pairs with the matching
+/// [`ToolCallRecord::id`] via `tool_call_id`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolResultRecord {
+    /// LLM-issued call id; matches the corresponding
+    /// [`ToolCallRecord::id`].
+    pub tool_call_id: String,
+    /// Tool name (duplicated for ergonomics; some external converters
+    /// look here rather than chasing the `tool_call_id` back to the
+    /// assistant record).
+    pub tool_name: String,
+    /// Result body. Truncated, redacted, or summarised based on
+    /// `[trajectory] include_tool_results`.
+    pub output: String,
+    /// Whether the tool reported an error.
+    pub is_error: bool,
+}
+
+/// User-intervention record (`/run abort`, "違う", "yes 続けて", ...).
+///
+/// These records are the analogue of the RL reward signal Hermes
+/// carries to Atropos; tsumugi only tags them, the actual reward
+/// shaping lives in the consumer pipeline.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeedbackRecord {
+    /// Free-form short label identifying the source of the feedback.
+    /// Issue #55 recommends `"user_correction"`, `"abort"`,
+    /// `"approval"`. The string is stored verbatim so callers can
+    /// extend the vocabulary without a schema change.
+    pub source: String,
+    /// Free-form payload. Redaction is applied before write.
+    pub content: String,
+}
+
+/// Final session outcome record.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VerdictRecord {
+    /// Session-end outcome label. Mirrors the
+    /// [`tmg_harness::SessionEndTrigger`] discriminator (e.g.
+    /// `"completed"`, `"user_cancelled"`, `"timeout"`, `"errored"`).
+    pub outcome: String,
+    /// Feature ids the session marked as passing, when applicable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub feature_marked_passing: Vec<String>,
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+
+    /// Round-trip every record variant through `serde_json` to guard
+    /// the on-disk schema. A failure here is a breaking change to the
+    /// trajectory format.
+    #[test]
+    fn round_trip_meta() {
+        let rec = TrajectoryRecord::Meta(MetaRecord {
+            run_id: "abc12345".into(),
+            session_num: 7,
+            model: "qwen3.5-4b".into(),
+            scope: "harnessed".into(),
+            started_at: DateTime::parse_from_rfc3339("2026-04-28T00:00:00Z")
+                .unwrap_or_else(|e| panic!("{e}"))
+                .with_timezone(&Utc),
+            ended_at: None,
+            outcome: None,
+        });
+        let s = serde_json::to_string(&rec).unwrap_or_else(|e| panic!("{e}"));
+        assert!(s.contains(r#""type":"meta""#), "tag missing: {s}");
+        let back: TrajectoryRecord = serde_json::from_str(&s).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn round_trip_assistant_with_tool_calls() {
+        let rec = TrajectoryRecord::Assistant(AssistantRecord {
+            content: "calling file_read".into(),
+            thinking: Some("I should read the file".into()),
+            tool_calls: vec![ToolCallRecord {
+                id: "call_1".into(),
+                name: "file_read".into(),
+                arguments: serde_json::json!({"path": "Cargo.toml"}),
+            }],
+        });
+        let s = serde_json::to_string(&rec).unwrap_or_else(|e| panic!("{e}"));
+        assert!(s.contains(r#""type":"assistant""#), "{s}");
+        assert!(s.contains(r#""thinking""#), "{s}");
+        let back: TrajectoryRecord = serde_json::from_str(&s).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn round_trip_tool_result() {
+        let rec = TrajectoryRecord::ToolResult(ToolResultRecord {
+            tool_call_id: "call_1".into(),
+            tool_name: "file_read".into(),
+            output: "[workspace]\nresolver = \"3\"".into(),
+            is_error: false,
+        });
+        let s = serde_json::to_string(&rec).unwrap_or_else(|e| panic!("{e}"));
+        assert!(s.contains(r#""type":"tool_result""#), "{s}");
+        let back: TrajectoryRecord = serde_json::from_str(&s).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn round_trip_feedback() {
+        let rec = TrajectoryRecord::Feedback(FeedbackRecord {
+            source: "user_correction".into(),
+            content: "use approach X instead".into(),
+        });
+        let s = serde_json::to_string(&rec).unwrap_or_else(|e| panic!("{e}"));
+        let back: TrajectoryRecord = serde_json::from_str(&s).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(rec, back);
+    }
+
+    #[test]
+    fn round_trip_verdict() {
+        let rec = TrajectoryRecord::Verdict(VerdictRecord {
+            outcome: "completed".into(),
+            feature_marked_passing: vec!["feat-014".into(), "feat-015".into()],
+        });
+        let s = serde_json::to_string(&rec).unwrap_or_else(|e| panic!("{e}"));
+        let back: TrajectoryRecord = serde_json::from_str(&s).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(rec, back);
+    }
+
+    /// `thinking = None` and empty `tool_calls` must serialize to a
+    /// compact form (no `null` / no `[]`).
+    #[test]
+    fn assistant_compact_when_optional_fields_absent() {
+        let rec = TrajectoryRecord::Assistant(AssistantRecord {
+            content: "hi".into(),
+            thinking: None,
+            tool_calls: Vec::new(),
+        });
+        let s = serde_json::to_string(&rec).unwrap_or_else(|e| panic!("{e}"));
+        assert!(!s.contains("thinking"), "{s}");
+        assert!(!s.contains("tool_calls"), "{s}");
+    }
+}

--- a/crates/tmg-trajectory/src/recorder.rs
+++ b/crates/tmg-trajectory/src/recorder.rs
@@ -32,7 +32,7 @@
 //! recorder is `None`.
 
 use std::fs::{File, OpenOptions};
-use std::io::{BufWriter, Write as _};
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -64,7 +64,11 @@ pub fn trajectory_path(run_dir: &Path, output_dir: &str, session_index: u32) -> 
 ///
 /// Construction opens the file in append mode; the directory is
 /// created on demand. Appending a record acquires the internal
-/// mutex, serialises the record, writes it as one line, and flushes.
+/// mutex, serialises the record, writes it as one line, and flushes
+/// the file directly — every record is followed by a `flush()` call
+/// so a process kill does not lose the tail. We deliberately use the
+/// bare [`File`] (no [`std::io::BufWriter`]): per-line flushing makes
+/// any buffer pointless and keeps the writer one syscall per record.
 /// Errors are surfaced via the public methods so callers can decide
 /// whether to abort or warn-and-continue (the typical agent-loop
 /// path warns).
@@ -75,7 +79,11 @@ pub struct Recorder {
 }
 
 struct RecorderState {
-    writer: BufWriter<File>,
+    /// Raw file handle. We do not wrap in [`std::io::BufWriter`]
+    /// because [`Recorder::write_line`] flushes after every record
+    /// (durability matters more than throughput for trajectory
+    /// recording), so a buffer would never amortise.
+    writer: File,
     path: PathBuf,
 }
 
@@ -119,7 +127,7 @@ impl Recorder {
             .map_err(|e| TrajectoryError::io(path_ref, e))?;
         Ok(Self {
             inner: Mutex::new(RecorderState {
-                writer: BufWriter::new(file),
+                writer: file,
                 path: path_ref.to_path_buf(),
             }),
             config,
@@ -286,9 +294,10 @@ impl Recorder {
         }))
     }
 
-    /// Flush the buffered writer. Useful for tests; production
-    /// integrators don't need to call this — the buffered writer
-    /// flushes after every line, and the file is closed on drop.
+    /// Flush the underlying file. Useful for tests; production
+    /// integrators don't need to call this — [`Self::write_line`]
+    /// already flushes after every record, and the file is closed on
+    /// drop.
     ///
     /// # Errors
     /// Returns [`TrajectoryError::Io`] on flush failure.

--- a/crates/tmg-trajectory/src/recorder.rs
+++ b/crates/tmg-trajectory/src/recorder.rs
@@ -1,0 +1,595 @@
+//! [`Recorder`]: JSONL trajectory writer.
+//!
+//! A [`Recorder`] owns one open file under
+//! `.tsumugi/runs/<run-id>/trajectories/session_NNN.jsonl` and exposes
+//! an `append`-style API. The implementation is deliberately
+//! synchronous: writing one JSON line at a time is comparable in cost
+//! to a single `tracing::warn!`, so spawning a background task adds
+//! plumbing overhead without measurable benefit. When integrators
+//! want fire-and-forget semantics they wrap the recorder in an
+//! [`std::sync::Arc`] and drive it from inside the agent loop's
+//! existing tokio task — the recorder takes `&self` everywhere via an
+//! internal mutex, so the wrapper is shareable across sinks.
+//!
+//! # Trajectory tee pattern
+//!
+//! Issue #55 specifies the recorder must integrate alongside the
+//! existing `--event-log` `TeeStreamSink` rather than spawn its own
+//! second tee. The CLI wires this by using
+//! [`TrajectoryStreamSink`](crate::sink::TrajectoryStreamSink), which
+//! wraps an inner sink and also forwards to a `Recorder`. The same
+//! sink composes with the event log: `TeeStreamSink<TrajectorySink<Inner>>`
+//! gives one tee chain, three observers.
+//!
+//! # Disabled vs. enabled
+//!
+//! When `[trajectory] enabled = false`, the CLI must skip
+//! [`Recorder::create`] altogether so no file is opened and no
+//! records are written. The recorder itself does not consult the
+//! enable flag — it is the integrator's responsibility to gate
+//! construction. See [`crate::sink::TrajectoryStreamSink`] for the
+//! optional-recorder convenience wrapper that no-ops when the
+//! recorder is `None`.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write as _};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tracing::warn;
+
+use crate::config::{ToolResultMode, TrajectoryConfig};
+use crate::error::TrajectoryError;
+use crate::record::{
+    AssistantRecord, FeedbackRecord, MetaRecord, SystemRecord, ToolCallRecord, ToolResultRecord,
+    TrajectoryRecord, UserRecord, VerdictRecord,
+};
+use crate::redact::Redactor;
+
+/// Directory name (under each run dir) where trajectories live.
+pub const TRAJECTORIES_DIRNAME: &str = "trajectories";
+
+/// Construct the path of a session trajectory file under
+/// `<run_dir>/<output_dir>/session_NNN.jsonl`.
+#[must_use]
+pub fn trajectory_path(run_dir: &Path, output_dir: &str, session_index: u32) -> PathBuf {
+    run_dir
+        .join(output_dir)
+        .join(format!("session_{session_index:03}.jsonl"))
+}
+
+/// JSONL recorder for one session.
+///
+/// Construction opens the file in append mode; the directory is
+/// created on demand. Appending a record acquires the internal
+/// mutex, serialises the record, writes it as one line, and flushes.
+/// Errors are surfaced via the public methods so callers can decide
+/// whether to abort or warn-and-continue (the typical agent-loop
+/// path warns).
+pub struct Recorder {
+    inner: Mutex<RecorderState>,
+    config: TrajectoryConfig,
+    redactor: Redactor,
+}
+
+struct RecorderState {
+    writer: BufWriter<File>,
+    path: PathBuf,
+}
+
+impl Recorder {
+    /// Open or create the trajectory file at `path` in append mode.
+    ///
+    /// `config` controls runtime knobs (whether to emit `thinking`,
+    /// how to render tool results); `extra_patterns` is the
+    /// pre-compiled extras for the redactor — passing them at
+    /// construction time means we surface a regex-compile failure at
+    /// recorder creation rather than first-write.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TrajectoryError::Io`] when the parent directory cannot
+    /// be created or the file cannot be opened.
+    pub fn create(
+        path: impl AsRef<Path>,
+        config: TrajectoryConfig,
+    ) -> Result<Self, TrajectoryError> {
+        let redactor = Redactor::with_extras(config.redact_extra_patterns.iter())?;
+        Self::with_redactor(path, config, redactor)
+    }
+
+    /// Like [`Self::create`] but reuses an already-built [`Redactor`].
+    /// Used by the export path so a single redactor is reused across
+    /// all reconstructed sessions.
+    pub fn with_redactor(
+        path: impl AsRef<Path>,
+        config: TrajectoryConfig,
+        redactor: Redactor,
+    ) -> Result<Self, TrajectoryError> {
+        let path_ref = path.as_ref();
+        if let Some(parent) = path_ref.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| TrajectoryError::io(parent, e))?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path_ref)
+            .map_err(|e| TrajectoryError::io(path_ref, e))?;
+        Ok(Self {
+            inner: Mutex::new(RecorderState {
+                writer: BufWriter::new(file),
+                path: path_ref.to_path_buf(),
+            }),
+            config,
+            redactor,
+        })
+    }
+
+    /// Borrow the path of the trajectory file. Useful for logging /
+    /// diagnostics.
+    #[must_use]
+    pub fn path(&self) -> PathBuf {
+        // Take a short lock and clone — the path never mutates after
+        // construction so this is wait-free in the common case.
+        match self.inner.lock() {
+            Ok(g) => g.path.clone(),
+            Err(p) => p.into_inner().path.clone(),
+        }
+    }
+
+    /// Borrow the active configuration.
+    #[must_use]
+    pub fn config(&self) -> &TrajectoryConfig {
+        &self.config
+    }
+
+    /// Append a fully-formed [`TrajectoryRecord`] verbatim. Callers
+    /// that go through this method are responsible for redaction; the
+    /// dedicated `record_*` helpers below redact transparently.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TrajectoryError`] on serialisation or I/O failure.
+    pub fn append_raw(&self, record: &TrajectoryRecord) -> Result<(), TrajectoryError> {
+        self.write_line(record)
+    }
+
+    /// Append a [`MetaRecord`] (no redaction needed — `MetaRecord`
+    /// fields are all integer / enum / timestamp).
+    ///
+    /// # Errors
+    /// Returns [`TrajectoryError`] on serialisation or I/O failure.
+    pub fn record_meta(&self, meta: MetaRecord) -> Result<(), TrajectoryError> {
+        self.write_line(&TrajectoryRecord::Meta(meta))
+    }
+
+    /// Append a [`SystemRecord`] with redaction applied.
+    ///
+    /// # Errors
+    /// Returns [`TrajectoryError`] on serialisation or I/O failure.
+    pub fn record_system(&self, content: &str) -> Result<(), TrajectoryError> {
+        self.write_line(&TrajectoryRecord::System(SystemRecord {
+            content: self.redactor.apply(content),
+        }))
+    }
+
+    /// Append a [`UserRecord`] with redaction applied.
+    ///
+    /// # Errors
+    /// Returns [`TrajectoryError`] on serialisation or I/O failure.
+    pub fn record_user(&self, content: &str) -> Result<(), TrajectoryError> {
+        self.write_line(&TrajectoryRecord::User(UserRecord {
+            content: self.redactor.apply(content),
+        }))
+    }
+
+    /// Append an [`AssistantRecord`].
+    ///
+    /// `thinking` is dropped when [`TrajectoryConfig::include_thinking`]
+    /// is `false`. `content` and `thinking` are redacted; tool-call
+    /// argument values are redacted by serialising the arguments
+    /// `serde_json::Value` and re-parsing — strings inside the JSON
+    /// tree get the same redactor pass.
+    ///
+    /// # Errors
+    /// Returns [`TrajectoryError`] on serialisation or I/O failure.
+    pub fn record_assistant(
+        &self,
+        content: &str,
+        thinking: Option<&str>,
+        tool_calls: &[ToolCallRecord],
+    ) -> Result<(), TrajectoryError> {
+        let thinking = if self.config.include_thinking {
+            thinking.map(|t| self.redactor.apply(t))
+        } else {
+            None
+        };
+        let redacted_calls: Vec<ToolCallRecord> = tool_calls
+            .iter()
+            .map(|tc| ToolCallRecord {
+                id: tc.id.clone(),
+                name: tc.name.clone(),
+                arguments: redact_value(&tc.arguments, &self.redactor),
+            })
+            .collect();
+        self.write_line(&TrajectoryRecord::Assistant(AssistantRecord {
+            content: self.redactor.apply(content),
+            thinking,
+            tool_calls: redacted_calls,
+        }))
+    }
+
+    /// Append a [`ToolResultRecord`].
+    ///
+    /// The `output` payload is rendered according to
+    /// [`TrajectoryConfig::include_tool_results`]:
+    ///
+    /// - [`ToolResultMode::Full`] — verbatim, no redaction. Use only
+    ///   when the operator has accepted the full disclosure trade-off.
+    /// - [`ToolResultMode::Redacted`] — pass through the redactor (the
+    ///   default).
+    /// - [`ToolResultMode::SummaryOnly`] — replaced by a one-line
+    ///   `"<N chars, ok|err>"` placeholder. Useful for shipping
+    ///   trajectories where the conversation flow matters but the
+    ///   actual tool payloads are sensitive.
+    ///
+    /// # Errors
+    /// Returns [`TrajectoryError`] on serialisation or I/O failure.
+    pub fn record_tool_result(
+        &self,
+        tool_call_id: &str,
+        tool_name: &str,
+        output: &str,
+        is_error: bool,
+    ) -> Result<(), TrajectoryError> {
+        let rendered = match self.config.include_tool_results {
+            ToolResultMode::Full => output.to_owned(),
+            ToolResultMode::Redacted => self.redactor.apply(output),
+            ToolResultMode::SummaryOnly => {
+                let tag = if is_error { "err" } else { "ok" };
+                format!("<{} chars, {}>", output.chars().count(), tag)
+            }
+        };
+        self.write_line(&TrajectoryRecord::ToolResult(ToolResultRecord {
+            tool_call_id: tool_call_id.to_owned(),
+            tool_name: tool_name.to_owned(),
+            output: rendered,
+            is_error,
+        }))
+    }
+
+    /// Append a [`FeedbackRecord`] with redaction applied to `content`.
+    ///
+    /// # Errors
+    /// Returns [`TrajectoryError`] on serialisation or I/O failure.
+    pub fn record_feedback(&self, source: &str, content: &str) -> Result<(), TrajectoryError> {
+        self.write_line(&TrajectoryRecord::Feedback(FeedbackRecord {
+            source: source.to_owned(),
+            content: self.redactor.apply(content),
+        }))
+    }
+
+    /// Append a [`VerdictRecord`].
+    ///
+    /// # Errors
+    /// Returns [`TrajectoryError`] on serialisation or I/O failure.
+    pub fn record_verdict(
+        &self,
+        outcome: &str,
+        feature_marked_passing: Vec<String>,
+    ) -> Result<(), TrajectoryError> {
+        self.write_line(&TrajectoryRecord::Verdict(VerdictRecord {
+            outcome: outcome.to_owned(),
+            feature_marked_passing,
+        }))
+    }
+
+    /// Flush the buffered writer. Useful for tests; production
+    /// integrators don't need to call this — the buffered writer
+    /// flushes after every line, and the file is closed on drop.
+    ///
+    /// # Errors
+    /// Returns [`TrajectoryError::Io`] on flush failure.
+    pub fn flush(&self) -> Result<(), TrajectoryError> {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let path = guard.path.clone();
+        guard
+            .writer
+            .flush()
+            .map_err(|e| TrajectoryError::io(path, e))
+    }
+
+    fn write_line<T: Serialize>(&self, value: &T) -> Result<(), TrajectoryError> {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => {
+                // Mutex poisoning means a previous writer panicked;
+                // the file handle is still valid, so we recover the
+                // inner state and continue. Surface a warning so the
+                // operator can investigate the original panic.
+                warn!("trajectory recorder mutex poisoned; recovering");
+                p.into_inner()
+            }
+        };
+        let path = guard.path.clone();
+        let line = serde_json::to_string(value).map_err(TrajectoryError::Json)?;
+        guard
+            .writer
+            .write_all(line.as_bytes())
+            .map_err(|e| TrajectoryError::io(&path, e))?;
+        guard
+            .writer
+            .write_all(b"\n")
+            .map_err(|e| TrajectoryError::io(&path, e))?;
+        // Flush per record so a process kill does not lose the tail.
+        // This matches `EventLogWriter::write_event`.
+        guard
+            .writer
+            .flush()
+            .map_err(|e| TrajectoryError::io(&path, e))?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for Recorder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Recorder")
+            .field("path", &self.path())
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Recursively redact every string node inside a JSON value. Numbers /
+/// booleans / nulls pass through unchanged. Maps and arrays preserve
+/// key order so trajectory diffs stay stable.
+fn redact_value(value: &serde_json::Value, redactor: &Redactor) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(s) => serde_json::Value::String(redactor.apply(s)),
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(|v| redact_value(v, redactor)).collect())
+        }
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                out.insert(k.clone(), redact_value(v, redactor));
+            }
+            serde_json::Value::Object(out)
+        }
+        // Numbers / booleans / nulls have no redactable content.
+        other => other.clone(),
+    }
+}
+
+/// Best-effort timestamp helper used by the recorder's `MetaRecord`
+/// builders so the integrator does not need to import chrono on every
+/// call site.
+#[must_use]
+pub fn now_utc() -> DateTime<Utc> {
+    Utc::now()
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use crate::record::{MetaRecord, ToolCallRecord};
+    use tempfile::TempDir;
+
+    fn read_lines(path: &Path) -> Vec<String> {
+        let body = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("{e}"));
+        body.lines().map(str::to_owned).collect()
+    }
+
+    #[test]
+    fn appends_jsonl_when_enabled() {
+        let dir = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let path = dir.path().join("session_001.jsonl");
+        let rec =
+            Recorder::create(&path, TrajectoryConfig::default()).unwrap_or_else(|e| panic!("{e}"));
+        rec.record_meta(MetaRecord {
+            run_id: "abc12345".into(),
+            session_num: 1,
+            model: "qwen3.5-4b".into(),
+            scope: "ad-hoc".into(),
+            started_at: Utc::now(),
+            ended_at: None,
+            outcome: None,
+        })
+        .unwrap_or_else(|e| panic!("{e}"));
+        rec.record_system("you are tsumugi")
+            .unwrap_or_else(|e| panic!("{e}"));
+        rec.record_user("read Cargo.toml")
+            .unwrap_or_else(|e| panic!("{e}"));
+        rec.flush().unwrap_or_else(|e| panic!("{e}"));
+        drop(rec);
+
+        let lines = read_lines(&path);
+        assert_eq!(lines.len(), 3, "{lines:?}");
+        assert!(lines[0].contains(r#""type":"meta""#));
+        assert!(lines[1].contains(r#""type":"system""#));
+        assert!(lines[2].contains(r#""type":"user""#));
+    }
+
+    /// Redaction fires on user / assistant / `tool_result` content.
+    #[test]
+    fn redacts_secrets_across_record_types() {
+        let dir = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let path = dir.path().join("s.jsonl");
+        let rec =
+            Recorder::create(&path, TrajectoryConfig::default()).unwrap_or_else(|e| panic!("{e}"));
+        rec.record_user("API key sk-abcdefghijklmnopqrstuvwxyz1234567890ABCD")
+            .unwrap_or_else(|e| panic!("{e}"));
+        rec.record_assistant("ghp_abcdefghijklmnopqrstuvwxyz0123456789AB", None, &[])
+            .unwrap_or_else(|e| panic!("{e}"));
+        rec.record_tool_result("call_1", "file_read", "AKIAIOSFODNN7EXAMPLE in env", false)
+            .unwrap_or_else(|e| panic!("{e}"));
+        rec.flush().unwrap_or_else(|e| panic!("{e}"));
+        drop(rec);
+
+        let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{e}"));
+        for needle in [
+            "sk-abcdefghijkl",
+            "ghp_abcdefghijkl",
+            "AKIAIOSFODNN7EXAMPLE",
+        ] {
+            assert!(!body.contains(needle), "leaked {needle}: {body}");
+        }
+        assert!(body.contains("[REDACTED]"), "{body}");
+    }
+
+    /// `include_thinking = false` strips `thinking` from the assistant
+    /// record entirely (no `null`, no `""`).
+    #[test]
+    fn include_thinking_false_strips_block() {
+        let dir = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let path = dir.path().join("s.jsonl");
+        let cfg = TrajectoryConfig {
+            include_thinking: false,
+            ..TrajectoryConfig::default()
+        };
+        let rec = Recorder::create(&path, cfg).unwrap_or_else(|e| panic!("{e}"));
+        rec.record_assistant("hello", Some("internal reasoning"), &[])
+            .unwrap_or_else(|e| panic!("{e}"));
+        rec.flush().unwrap_or_else(|e| panic!("{e}"));
+        drop(rec);
+
+        let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{e}"));
+        assert!(!body.contains("internal reasoning"), "{body}");
+        assert!(!body.contains("\"thinking\""), "{body}");
+    }
+
+    /// `include_thinking = true` keeps the block AND redacts secrets
+    /// inside it.
+    #[test]
+    fn include_thinking_true_redacts_block() {
+        let dir = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let path = dir.path().join("s.jsonl");
+        let cfg = TrajectoryConfig {
+            include_thinking: true,
+            ..TrajectoryConfig::default()
+        };
+        let rec = Recorder::create(&path, cfg).unwrap_or_else(|e| panic!("{e}"));
+        rec.record_assistant(
+            "hello",
+            Some("plan: use sk-abcdefghijklmnopqrstuvwxyz1234567890ABCD"),
+            &[],
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+        rec.flush().unwrap_or_else(|e| panic!("{e}"));
+        drop(rec);
+
+        let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{e}"));
+        assert!(body.contains("\"thinking\""), "{body}");
+        assert!(!body.contains("sk-abcdefghijkl"), "{body}");
+    }
+
+    /// `include_tool_results = "summary_only"` produces a compact
+    /// `"<N chars, ok>"` placeholder.
+    #[test]
+    fn summary_only_produces_compact_form() {
+        let dir = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let path = dir.path().join("s.jsonl");
+        let cfg = TrajectoryConfig {
+            include_tool_results: ToolResultMode::SummaryOnly,
+            ..TrajectoryConfig::default()
+        };
+        let rec = Recorder::create(&path, cfg).unwrap_or_else(|e| panic!("{e}"));
+        let big = "x".repeat(5_000);
+        rec.record_tool_result("c1", "file_read", &big, false)
+            .unwrap_or_else(|e| panic!("{e}"));
+        rec.flush().unwrap_or_else(|e| panic!("{e}"));
+        drop(rec);
+
+        let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{e}"));
+        // Body must NOT contain the full payload.
+        assert!(!body.contains(&"x".repeat(100)), "{body}");
+        // Must contain the placeholder.
+        assert!(body.contains("<5000 chars, ok>"), "{body}");
+    }
+
+    /// `include_tool_results = "full"` keeps the payload verbatim
+    /// (intentionally bypasses redaction).
+    #[test]
+    fn full_mode_keeps_payload_verbatim() {
+        let dir = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let path = dir.path().join("s.jsonl");
+        let cfg = TrajectoryConfig {
+            include_tool_results: ToolResultMode::Full,
+            ..TrajectoryConfig::default()
+        };
+        let rec = Recorder::create(&path, cfg).unwrap_or_else(|e| panic!("{e}"));
+        rec.record_tool_result(
+            "c1",
+            "file_read",
+            "secret token=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab",
+            false,
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+        rec.flush().unwrap_or_else(|e| panic!("{e}"));
+        drop(rec);
+
+        let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{e}"));
+        // Full mode does NOT redact.
+        assert!(body.contains("token=ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "{body}");
+    }
+
+    /// Tool-call argument values get the redactor pass, but field
+    /// keys are preserved.
+    #[test]
+    fn tool_call_arguments_are_redacted() {
+        let dir = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let path = dir.path().join("s.jsonl");
+        let rec =
+            Recorder::create(&path, TrajectoryConfig::default()).unwrap_or_else(|e| panic!("{e}"));
+        let args = serde_json::json!({
+            "path": "/etc/secrets",
+            "auth": "token=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789xx",
+        });
+        let calls = vec![ToolCallRecord {
+            id: "c1".into(),
+            name: "file_read".into(),
+            arguments: args,
+        }];
+        rec.record_assistant("", None, &calls)
+            .unwrap_or_else(|e| panic!("{e}"));
+        rec.flush().unwrap_or_else(|e| panic!("{e}"));
+        drop(rec);
+
+        let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{e}"));
+        assert!(!body.contains("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "{body}");
+        assert!(body.contains("/etc/secrets"), "{body}");
+    }
+
+    /// `extras` configured via `redact_extra_patterns` apply on top of
+    /// the shared base set.
+    #[test]
+    fn extra_patterns_applied() {
+        let dir = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let path = dir.path().join("s.jsonl");
+        let cfg = TrajectoryConfig {
+            redact_extra_patterns: vec!["INTERNAL-[A-Z]{4}-[0-9]{4}".into()],
+            ..TrajectoryConfig::default()
+        };
+        let rec = Recorder::create(&path, cfg).unwrap_or_else(|e| panic!("{e}"));
+        rec.record_user("see ticket INTERNAL-ABCD-1234 today")
+            .unwrap_or_else(|e| panic!("{e}"));
+        rec.flush().unwrap_or_else(|e| panic!("{e}"));
+        drop(rec);
+
+        let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{e}"));
+        assert!(!body.contains("INTERNAL-ABCD-1234"), "{body}");
+        assert!(body.contains("[REDACTED]"), "{body}");
+    }
+
+    #[test]
+    fn trajectory_path_format() {
+        let p = trajectory_path(Path::new("/runs/abc"), "trajectories", 42);
+        assert_eq!(p, PathBuf::from("/runs/abc/trajectories/session_042.jsonl"));
+    }
+}

--- a/crates/tmg-trajectory/src/redact.rs
+++ b/crates/tmg-trajectory/src/redact.rs
@@ -1,0 +1,151 @@
+//! Trajectory-side redaction.
+//!
+//! The credential patterns themselves live in [`tmg_search::redact`]
+//! (issue #53); this module re-exports them so we never duplicate the
+//! regex set. The trajectory layer adds two pieces of behaviour on
+//! top:
+//!
+//! 1. A [`Redactor`] type that combines the shared base patterns with
+//!    *extra* patterns supplied by the operator via
+//!    `[trajectory] redact_extra_patterns`.
+//! 2. A short module re-export so call sites can write
+//!    `tmg_trajectory::redact::redact_secrets` and stay symmetric with
+//!    `tmg_search`.
+//!
+//! ## Why not move the regex set into a third crate?
+//!
+//! The base patterns are tightly coupled to the search-index ingestion
+//! tests in `tmg-search` (the false-positive suite for git SHAs, etc.).
+//! Carving them into a fourth crate just for sharing would force a
+//! leaf crate that owns nothing but `regex`-compile cost; re-exporting
+//! the existing helper from `tmg-search` is the minimal change. If a
+//! third consumer ever appears we can promote the patterns then.
+//!
+//! Both crates compile the regex set lazily inside their respective
+//! `OnceLock` cells, so loading both crates only pays the compile cost
+//! once for the base set (the `tmg-search` static is shared) and once
+//! for any extra patterns the trajectory operator added.
+
+use regex::Regex;
+
+pub use tmg_search::redact::{REDACTION_TOKEN, redact_secrets};
+
+use crate::error::TrajectoryError;
+
+/// A composed redactor that applies the shared `tmg-search` regex set
+/// plus any operator-supplied extras.
+///
+/// Construction validates every extra pattern; an invalid regex is
+/// surfaced as [`TrajectoryError::InvalidRedactionPattern`] so the
+/// recorder never has to silently drop a misconfigured rule.
+#[derive(Debug, Clone)]
+pub struct Redactor {
+    extras: Vec<Regex>,
+}
+
+impl Redactor {
+    /// Build a redactor with no operator-supplied extras. Equivalent to
+    /// calling [`redact_secrets`] directly, but cheap to clone and
+    /// pass around.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { extras: Vec::new() }
+    }
+
+    /// Build a redactor with operator-supplied extra patterns.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TrajectoryError::InvalidRedactionPattern`] when any
+    /// pattern fails to compile.
+    pub fn with_extras<I, S>(extras: I) -> Result<Self, TrajectoryError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut compiled = Vec::new();
+        for pat in extras {
+            let raw = pat.as_ref();
+            let re =
+                Regex::new(raw).map_err(|source| TrajectoryError::InvalidRedactionPattern {
+                    pattern: raw.to_owned(),
+                    source,
+                })?;
+            compiled.push(re);
+        }
+        Ok(Self { extras: compiled })
+    }
+
+    /// Redact `text` by applying the shared base patterns first, then
+    /// each extra pattern in order.
+    #[must_use]
+    pub fn apply(&self, text: &str) -> String {
+        let mut current = redact_secrets(text);
+        for re in &self.extras {
+            current = re.replace_all(&current, REDACTION_TOKEN).into_owned();
+        }
+        current
+    }
+}
+
+impl Default for Redactor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_redactor_runs_shared_patterns() {
+        let r = Redactor::new();
+        let out = r.apply("token=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijxxxx tail");
+        assert!(out.contains(REDACTION_TOKEN), "{out}");
+        assert!(out.contains("tail"), "{out}");
+    }
+
+    #[test]
+    fn extra_patterns_apply() {
+        let r = Redactor::with_extras(["INTERNAL-[A-Z0-9]{8}"]).unwrap_or_else(|e| panic!("{e}"));
+        let out = r.apply("see INTERNAL-ABCD1234 for details");
+        assert!(!out.contains("INTERNAL-ABCD1234"), "{out}");
+        assert!(out.contains(REDACTION_TOKEN), "{out}");
+        assert!(out.contains("for details"), "{out}");
+    }
+
+    #[test]
+    fn invalid_pattern_surfaced() {
+        let r = Redactor::with_extras(["[unterminated"]);
+        match r {
+            Err(TrajectoryError::InvalidRedactionPattern { pattern, .. }) => {
+                assert_eq!(pattern, "[unterminated");
+            }
+            other => panic!("expected InvalidRedactionPattern, got {other:?}"),
+        }
+    }
+
+    /// Five-pattern smoke test mirroring `tmg-search`'s acceptance
+    /// suite: every shared redactor must fire on the trajectory side.
+    #[test]
+    fn five_pattern_acceptance_via_trajectory() {
+        let r = Redactor::new();
+        let input = "AKIAIOSFODNN7EXAMPLE \
+                     sk-abcdefghijklmnopqrstuvwxyz1234567890ABCD \
+                     ghp_abcdefghijklmnopqrstuvwxyz0123456789AB \
+                     Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 \
+                     token=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijxxxx";
+        let out = r.apply(input);
+        for needle in [
+            "AKIAIOSFODNN7EXAMPLE",
+            "sk-abcdefghijkl",
+            "ghp_abcdefghijkl",
+            "eyJhbGciOiJ",
+            "token=ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        ] {
+            assert!(!out.contains(needle), "leaked {needle}: {out}");
+        }
+    }
+}

--- a/crates/tmg-trajectory/src/sink.rs
+++ b/crates/tmg-trajectory/src/sink.rs
@@ -1,0 +1,373 @@
+//! [`TrajectorySink`] trait and the [`TrajectoryStreamSink`] adapter
+//! that wires a [`Recorder`] into the agent loop's
+//! [`tmg_core::StreamSink`] tee chain.
+//!
+//! ## Why two abstractions?
+//!
+//! - [`TrajectorySink`] is the **public interface** integrators code
+//!   against. It accepts a [`crate::record::TrajectoryRecord`] and
+//!   nothing else: useful for unit-testing recorder consumers, for
+//!   the export path (which mints records out of `session_log/*.json`
+//!   rather than from a live LLM stream), and for any future consumer
+//!   that wants to plug in alongside or instead of a recorder.
+//!
+//! - [`TrajectoryStreamSink`] is the **agent-loop wire-up**. It
+//!   implements [`tmg_core::StreamSink`] so the existing tee chain
+//!   (`TeeStreamSink<TrajectoryStreamSink<Inner>>`) works without
+//!   changes to `tmg-core`. The wire-up translates `on_token` /
+//!   `on_tool_call` / `on_tool_result` callbacks into the right
+//!   [`crate::record::TrajectoryRecord`] variants.
+//!
+//! Both abstractions accept an optional recorder so callers can use
+//! the same wiring whether or not `[trajectory] enabled` is set —
+//! the disabled case is a no-op.
+
+use std::sync::{Arc, Mutex};
+
+use tmg_core::{CoreError, StreamSink};
+
+use crate::error::TrajectoryError;
+use crate::record::{ToolCallRecord, TrajectoryRecord};
+use crate::recorder::Recorder;
+
+/// Public interface for trajectory consumers.
+///
+/// Each `append` must be cheap: implementations are called from
+/// inside the agent loop's hot path, and a slow / blocking sink
+/// would back-pressure the LLM stream.
+pub trait TrajectorySink: Send + Sync {
+    /// Append a fully-formed record. Implementations decide whether
+    /// to redact, drop, or persist; the caller treats the call as
+    /// fire-and-forget.
+    fn append(&self, record: TrajectoryRecord);
+}
+
+/// [`TrajectorySink`] backed by a [`Recorder`].
+///
+/// Errors from the recorder are logged via `tracing::warn!` and
+/// swallowed: a transient I/O failure on the trajectory path must
+/// not abort the live conversation.
+#[derive(Debug, Clone)]
+pub struct RecorderSink {
+    recorder: Arc<Recorder>,
+}
+
+impl RecorderSink {
+    /// Wrap a [`Recorder`] in a [`TrajectorySink`].
+    #[must_use]
+    pub fn new(recorder: Arc<Recorder>) -> Self {
+        Self { recorder }
+    }
+
+    /// Borrow the wrapped recorder so callers can drive it directly
+    /// (e.g. for a `record_meta` call at session start, before any
+    /// stream events have fired).
+    #[must_use]
+    pub fn recorder(&self) -> Arc<Recorder> {
+        Arc::clone(&self.recorder)
+    }
+}
+
+impl TrajectorySink for RecorderSink {
+    fn append(&self, record: TrajectoryRecord) {
+        if let Err(e) = self.recorder.append_raw(&record) {
+            tracing::warn!(error = %e, "trajectory append failed");
+        }
+    }
+}
+
+/// Wraps an inner [`StreamSink`] and forwards every event into a
+/// [`Recorder`] (when present), buffering per-turn assistant state so
+/// the trajectory captures the canonical
+/// `(content, thinking, tool_calls)` triple as one record per round.
+///
+/// # Buffering rationale
+///
+/// The agent loop streams text/thinking incrementally and only knows
+/// the full assistant text + tool calls at `on_done`. We buffer the
+/// streaming deltas inside a [`Mutex`] until the round closes, then
+/// emit one [`crate::record::AssistantRecord`] per round and
+/// [`crate::record::ToolResultRecord`] per `on_tool_result` callback.
+/// This mirrors the on-disk format requested in issue #55:
+/// the JSONL has one assistant record per LLM round, not one per
+/// token.
+///
+/// # Tool-call lookup
+///
+/// `on_tool_call` fires once per call before dispatch. We park the
+/// `(id, name, arguments)` triple in an internal map keyed by
+/// `call_id` so the matching `on_tool_result` can recover the tool
+/// name even when a sink is given the result first (rare, but
+/// possible if the inner sink reorders).
+pub struct TrajectoryStreamSink<S> {
+    inner: S,
+    recorder: Option<Arc<Recorder>>,
+    buf: Mutex<TurnBuffer>,
+}
+
+#[derive(Default)]
+struct TurnBuffer {
+    /// Accumulated reasoning tokens for the current round.
+    thinking: String,
+    /// Accumulated text content tokens for the current round.
+    content: String,
+    /// Tool calls emitted this round (`on_tool_call` events).
+    tool_calls: Vec<ToolCallRecord>,
+}
+
+impl TurnBuffer {
+    fn take(&mut self) -> Self {
+        Self {
+            thinking: std::mem::take(&mut self.thinking),
+            content: std::mem::take(&mut self.content),
+            tool_calls: std::mem::take(&mut self.tool_calls),
+        }
+    }
+}
+
+impl<S> TrajectoryStreamSink<S> {
+    /// Create a tee that forwards every event to `inner` and (when
+    /// `recorder` is `Some`) writes a corresponding trajectory record.
+    pub fn new(inner: S, recorder: Option<Arc<Recorder>>) -> Self {
+        Self {
+            inner,
+            recorder,
+            buf: Mutex::new(TurnBuffer::default()),
+        }
+    }
+
+    /// Borrow the inner sink. Useful for tests that want to inspect
+    /// the wrapped sink's state.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    /// Drop the wrapper and return the inner sink.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+
+    /// Borrow the optional recorder so callers can drive it directly
+    /// (e.g. to write a `MetaRecord` at session start or a
+    /// `FeedbackRecord` from a slash-command path that does not flow
+    /// through `StreamSink`).
+    #[must_use]
+    pub fn recorder(&self) -> Option<Arc<Recorder>> {
+        self.recorder.as_ref().map(Arc::clone)
+    }
+
+    fn record_assistant(&self, buf: &TurnBuffer) {
+        let Some(recorder) = self.recorder.as_ref() else {
+            return;
+        };
+        // Skip empty assistant rounds (e.g. tool-only rounds with no
+        // text and no thinking carry no information beyond the
+        // tool_calls themselves; we keep them so the assistant ->
+        // tool_result -> assistant flow is preserved in trajectory
+        // form even when the model only emits tool calls).
+        if buf.content.is_empty() && buf.thinking.is_empty() && buf.tool_calls.is_empty() {
+            return;
+        }
+        let thinking = if buf.thinking.is_empty() {
+            None
+        } else {
+            Some(buf.thinking.as_str())
+        };
+        if let Err(e) = recorder.record_assistant(&buf.content, thinking, &buf.tool_calls) {
+            tracing::warn!(error = %e, "trajectory assistant record failed");
+        }
+    }
+}
+
+impl<S: StreamSink> StreamSink for TrajectoryStreamSink<S> {
+    fn on_thinking(&mut self, token: &str) -> Result<(), CoreError> {
+        if self.recorder.is_some()
+            && let Ok(mut g) = self.buf.lock()
+        {
+            g.thinking.push_str(token);
+        }
+        self.inner.on_thinking(token)
+    }
+
+    fn on_token(&mut self, token: &str) -> Result<(), CoreError> {
+        if self.recorder.is_some()
+            && let Ok(mut g) = self.buf.lock()
+        {
+            g.content.push_str(token);
+        }
+        self.inner.on_token(token)
+    }
+
+    fn on_done(&mut self) -> Result<(), CoreError> {
+        // Take the buffer first, write the assistant record, then
+        // forward `on_done` so any state the inner sink mutates does
+        // not race with our recorder.
+        if self.recorder.is_some() {
+            let taken = match self.buf.lock() {
+                Ok(mut g) => g.take(),
+                Err(p) => p.into_inner().take(),
+            };
+            self.record_assistant(&taken);
+        }
+        self.inner.on_done()
+    }
+
+    fn on_tool_call(
+        &mut self,
+        call_id: &str,
+        name: &str,
+        arguments: &str,
+    ) -> Result<(), CoreError> {
+        if self.recorder.is_some()
+            && let Ok(mut g) = self.buf.lock()
+        {
+            // Try to parse the arguments as JSON; if the model emitted
+            // something malformed, keep the raw string so the record
+            // still carries the literal payload for offline triage.
+            let args_val = serde_json::from_str::<serde_json::Value>(arguments)
+                .unwrap_or_else(|_| serde_json::Value::String(arguments.to_owned()));
+            g.tool_calls.push(ToolCallRecord {
+                id: call_id.to_owned(),
+                name: name.to_owned(),
+                arguments: args_val,
+            });
+        }
+        self.inner.on_tool_call(call_id, name, arguments)
+    }
+
+    fn on_tool_result(
+        &mut self,
+        call_id: &str,
+        name: &str,
+        output: &str,
+        is_error: bool,
+    ) -> Result<(), CoreError> {
+        if let Some(recorder) = self.recorder.as_ref()
+            && let Err(e) = recorder.record_tool_result(call_id, name, output, is_error)
+        {
+            tracing::warn!(error = %e, "trajectory tool_result record failed");
+        }
+        self.inner.on_tool_result(call_id, name, output, is_error)
+    }
+
+    fn on_tool_result_compressed(
+        &mut self,
+        call_id: &str,
+        name: &str,
+        symbol_count: usize,
+    ) -> Result<(), CoreError> {
+        // Compression metadata is informational only; we do not emit
+        // a trajectory record for it because the post-compression
+        // payload was already captured in `on_tool_result`.
+        self.inner
+            .on_tool_result_compressed(call_id, name, symbol_count)
+    }
+
+    fn on_warning(&mut self, message: &str) -> Result<(), CoreError> {
+        // Surfaces (memory swap, auto-compression failure) are not
+        // training signal; forward to the inner sink only.
+        self.inner.on_warning(message)
+    }
+}
+
+/// Convenience: a no-op [`TrajectorySink`] used in tests and in CLI
+/// branches where the recorder is disabled but a sink type is still
+/// required.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoOpSink;
+
+impl TrajectorySink for NoOpSink {
+    fn append(&self, _record: TrajectoryRecord) {}
+}
+
+/// Drive a [`TrajectorySink`] to flush any internal buffers.
+///
+/// Implementors that batch writes can override this; the default is
+/// a no-op so tests can call `flush` unconditionally.
+///
+/// # Errors
+///
+/// Returns [`TrajectoryError`] when the recorder fails to flush.
+pub fn flush_sink(sink: &dyn AnyRecorder) -> Result<(), TrajectoryError> {
+    sink.flush()
+}
+
+/// Internal trait used by [`flush_sink`]; lets the CLI poke at the
+/// recorder without leaking the concrete type.
+pub trait AnyRecorder {
+    /// Flush the underlying writer.
+    ///
+    /// # Errors
+    /// Returns [`TrajectoryError`] when the writer fails to flush.
+    fn flush(&self) -> Result<(), TrajectoryError>;
+}
+
+impl AnyRecorder for Recorder {
+    fn flush(&self) -> Result<(), TrajectoryError> {
+        Recorder::flush(self)
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use crate::config::TrajectoryConfig;
+    use tempfile::TempDir;
+
+    /// A no-op inner sink for the `TrajectoryStreamSink` tests.
+    struct InnerSink;
+    impl StreamSink for InnerSink {
+        fn on_token(&mut self, _t: &str) -> Result<(), CoreError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn stream_sink_emits_one_assistant_record_per_round() {
+        let dir = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let path = dir.path().join("s.jsonl");
+        let rec = Arc::new(
+            Recorder::create(&path, TrajectoryConfig::default()).unwrap_or_else(|e| panic!("{e}")),
+        );
+        let mut sink = TrajectoryStreamSink::new(InnerSink, Some(Arc::clone(&rec)));
+        sink.on_thinking("plan: ").unwrap_or_else(|e| panic!("{e}"));
+        sink.on_thinking("read file")
+            .unwrap_or_else(|e| panic!("{e}"));
+        sink.on_token("Reading ").unwrap_or_else(|e| panic!("{e}"));
+        sink.on_token("Cargo.toml")
+            .unwrap_or_else(|e| panic!("{e}"));
+        sink.on_tool_call("call_1", "file_read", r#"{"path":"Cargo.toml"}"#)
+            .unwrap_or_else(|e| panic!("{e}"));
+        sink.on_done().unwrap_or_else(|e| panic!("{e}"));
+        sink.on_tool_result("call_1", "file_read", "[workspace]", false)
+            .unwrap_or_else(|e| panic!("{e}"));
+        // Second round (post tool result).
+        sink.on_token("done").unwrap_or_else(|e| panic!("{e}"));
+        sink.on_done().unwrap_or_else(|e| panic!("{e}"));
+        rec.flush().unwrap_or_else(|e| panic!("{e}"));
+
+        let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{e}"));
+        let lines: Vec<&str> = body.lines().collect();
+        // 1 assistant (with tool_call) + 1 tool_result + 1 assistant.
+        assert_eq!(lines.len(), 3, "{lines:?}");
+        assert!(lines[0].contains(r#""type":"assistant""#), "{}", lines[0]);
+        assert!(lines[0].contains("Reading Cargo.toml"), "{}", lines[0]);
+        // include_thinking=false by default -> thinking stripped.
+        assert!(!lines[0].contains("plan: read file"), "{}", lines[0]);
+        assert!(lines[0].contains("file_read"), "{}", lines[0]);
+        assert!(lines[1].contains(r#""type":"tool_result""#), "{}", lines[1]);
+        assert!(lines[2].contains(r#""type":"assistant""#), "{}", lines[2]);
+        assert!(lines[2].contains("done"), "{}", lines[2]);
+    }
+
+    /// When the recorder is `None`, the sink writes nothing.
+    #[test]
+    fn disabled_sink_writes_nothing() {
+        let mut sink: TrajectoryStreamSink<InnerSink> = TrajectoryStreamSink::new(InnerSink, None);
+        sink.on_token("ignored").unwrap_or_else(|e| panic!("{e}"));
+        sink.on_done().unwrap_or_else(|e| panic!("{e}"));
+        // Nothing to assert beyond "no panic, no I/O" — the empty
+        // recorder slot guarantees no file is touched.
+    }
+}

--- a/crates/tmg-trajectory/src/sink.rs
+++ b/crates/tmg-trajectory/src/sink.rs
@@ -125,6 +125,22 @@ impl TurnBuffer {
     }
 }
 
+/// Lock the per-turn buffer, recovering from poison.
+///
+/// A poisoned mutex means a previous holder panicked while owning the
+/// buffer. The buffer itself is plain [`String`] / [`Vec`] state with
+/// no broken invariants we know about, so dropping events on the
+/// floor is the wrong default — that would cause the trajectory to
+/// silently miss tokens / tool calls. Instead we surface a warning
+/// and recover the inner state with [`std::sync::PoisonError::into_inner`]
+/// so the sink keeps observing the conversation.
+fn lock_turn_buffer(m: &Mutex<TurnBuffer>) -> std::sync::MutexGuard<'_, TurnBuffer> {
+    m.lock().unwrap_or_else(|poison| {
+        tracing::warn!("trajectory turn buffer mutex poisoned; recovering");
+        poison.into_inner()
+    })
+}
+
 impl<S> TrajectoryStreamSink<S> {
     /// Create a tee that forwards every event to `inner` and (when
     /// `recorder` is `Some`) writes a corresponding trajectory record.
@@ -179,20 +195,25 @@ impl<S> TrajectoryStreamSink<S> {
     }
 }
 
+// NOTE: any new method added to `tmg_core::StreamSink` MUST be
+// implemented (and forwarded) here as well — otherwise the trajectory
+// recorder will silently miss the new event kind and the on-disk
+// JSONL becomes incomplete relative to the live conversation. The
+// `on_*` methods below cover every event the agent loop currently
+// emits; adding a new kind is a deliberate change to both `tmg-core`
+// and this impl.
 impl<S: StreamSink> StreamSink for TrajectoryStreamSink<S> {
     fn on_thinking(&mut self, token: &str) -> Result<(), CoreError> {
-        if self.recorder.is_some()
-            && let Ok(mut g) = self.buf.lock()
-        {
+        if self.recorder.is_some() {
+            let mut g = lock_turn_buffer(&self.buf);
             g.thinking.push_str(token);
         }
         self.inner.on_thinking(token)
     }
 
     fn on_token(&mut self, token: &str) -> Result<(), CoreError> {
-        if self.recorder.is_some()
-            && let Ok(mut g) = self.buf.lock()
-        {
+        if self.recorder.is_some() {
+            let mut g = lock_turn_buffer(&self.buf);
             g.content.push_str(token);
         }
         self.inner.on_token(token)
@@ -203,10 +224,7 @@ impl<S: StreamSink> StreamSink for TrajectoryStreamSink<S> {
         // forward `on_done` so any state the inner sink mutates does
         // not race with our recorder.
         if self.recorder.is_some() {
-            let taken = match self.buf.lock() {
-                Ok(mut g) => g.take(),
-                Err(p) => p.into_inner().take(),
-            };
+            let taken = lock_turn_buffer(&self.buf).take();
             self.record_assistant(&taken);
         }
         self.inner.on_done()
@@ -218,9 +236,8 @@ impl<S: StreamSink> StreamSink for TrajectoryStreamSink<S> {
         name: &str,
         arguments: &str,
     ) -> Result<(), CoreError> {
-        if self.recorder.is_some()
-            && let Ok(mut g) = self.buf.lock()
-        {
+        if self.recorder.is_some() {
+            let mut g = lock_turn_buffer(&self.buf);
             // Try to parse the arguments as JSON; if the model emitted
             // something malformed, keep the raw string so the record
             // still carries the literal payload for offline triage.

--- a/crates/tmg-tui/Cargo.toml
+++ b/crates/tmg-tui/Cargo.toml
@@ -13,6 +13,7 @@ tmg-harness = { workspace = true }
 tmg-memory = { workspace = true }
 tmg-search = { workspace = true }
 tmg-skills = { workspace = true }
+tmg-trajectory = { workspace = true }
 tmg-workflow = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }

--- a/crates/tmg-tui/src/app.rs
+++ b/crates/tmg-tui/src/app.rs
@@ -11,6 +11,7 @@ use tmg_llm::Role;
 use tmg_memory::MemoryStore;
 use tmg_search::SearchIndex;
 use tmg_skills::{SkillMeta, SkillsRuntime, SlashCommand, TurnOutcomeRecorder};
+use tmg_trajectory::Recorder as TrajectoryRecorder;
 use tmg_workflow::{WorkflowMeta, WorkflowProgress};
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -333,6 +334,12 @@ pub struct App {
     /// drive the autonomous skill pipeline. Carries the user message
     /// associated with the turn for downstream consumers.
     turn_finished_signal: Option<TurnFinishedSignal>,
+
+    /// Optional trajectory recorder (issue #55). When set, the per-turn
+    /// background task wraps its sink in a
+    /// [`tmg_trajectory::TrajectoryStreamSink`] so every assistant
+    /// turn is appended to the active session's JSONL file.
+    trajectory_recorder: Option<Arc<TrajectoryRecorder>>,
 }
 
 /// Signal emitted on the App once per completed turn — drives the
@@ -403,7 +410,22 @@ impl App {
             skill_outcome_recorder: None,
             skill_turn_index: 0,
             turn_finished_signal: None,
+            trajectory_recorder: None,
         }
+    }
+
+    /// Install a trajectory recorder (issue #55). The recorder is
+    /// shared with the per-turn background task via [`Arc`] so each
+    /// turn's sink chain can append assistant / `tool_result` records
+    /// without touching the TUI's main loop.
+    pub fn set_trajectory_recorder(&mut self, recorder: Arc<TrajectoryRecorder>) {
+        self.trajectory_recorder = Some(recorder);
+    }
+
+    /// Borrow the active trajectory recorder, if any.
+    #[must_use]
+    pub fn trajectory_recorder(&self) -> Option<&Arc<TrajectoryRecorder>> {
+        self.trajectory_recorder.as_ref()
     }
 
     /// Drain any pending turn-finished signal (issue #54). Returns
@@ -1321,6 +1343,10 @@ impl App {
     /// Panics if called while the agent is `None` (i.e., another turn
     /// is already running). This is guarded by `is_streaming()` checks
     /// in the event loop.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "linear sink-chain construction with branching for (event_log, runner, trajectory) presence; splitting fragments the spawn closure that needs to own all the state"
+    )]
     pub fn start_turn(&mut self, user_input: String, parent_cancel: &CancellationToken) {
         let Some(mut agent) = self.agent.take() else {
             // Should not happen: the event loop checks `is_streaming()`
@@ -1357,6 +1383,16 @@ impl App {
 
         let runner = self.runner.clone();
         let outcome_recorder = self.skill_outcome_recorder.clone();
+        let trajectory_recorder = self.trajectory_recorder.clone();
+        // Mint a `User` record for the trajectory before the turn fires
+        // so the JSONL captures the user input even though the
+        // `StreamSink` API only sees the assistant side. Best-effort:
+        // a failure here only loses the `user` line for this turn.
+        if let Some(rec) = trajectory_recorder.as_ref()
+            && let Err(e) = rec.record_user(&user_input)
+        {
+            tracing::warn!(error = %e, "trajectory user record failed");
+        }
 
         let join = tokio::spawn(async move {
             let channel_sink = ChannelStreamSink { tx: tx.clone() };
@@ -1364,15 +1400,9 @@ impl App {
             // sink (and optional event log) sit at the bottom, and
             // `HarnessStreamSink` wraps them so harness session-stat
             // updates fire on every event without changing the in-flight
-            // forwarding to the TUI.
-            //
-            // When the autonomous skill pipeline is active
-            // (`outcome_recorder` is `Some`), the harness sink also
-            // records per-call outcomes so the per-turn observer
-            // (driven by the run-finished branch in
-            // `App::drain_turn_messages`) can build a
-            // [`tmg_skills::TurnSummary`] with proper outcomes — issue
-            // #54.
+            // forwarding to the TUI. The trajectory recorder (issue
+            // #55) is the outermost layer so it sees every event in
+            // its post-tee form.
             let result = match (event_log_writer, runner) {
                 (Some(log), Some(runner)) => {
                     let tee = tmg_core::TeeStreamSink::new(channel_sink, log);
@@ -1380,22 +1410,35 @@ impl App {
                     if let Some(rec) = outcome_recorder.as_ref() {
                         wrapped = wrapped.with_skill_outcome_recorder(Arc::clone(rec));
                     }
-                    agent.turn(&user_input, &mut wrapped).await
+                    let mut traj = tmg_trajectory::TrajectoryStreamSink::new(
+                        wrapped,
+                        trajectory_recorder.clone(),
+                    );
+                    agent.turn(&user_input, &mut traj).await
                 }
                 (Some(log), None) => {
-                    let mut tee = tmg_core::TeeStreamSink::new(channel_sink, log);
-                    agent.turn(&user_input, &mut tee).await
+                    let tee = tmg_core::TeeStreamSink::new(channel_sink, log);
+                    let mut traj =
+                        tmg_trajectory::TrajectoryStreamSink::new(tee, trajectory_recorder.clone());
+                    agent.turn(&user_input, &mut traj).await
                 }
                 (None, Some(runner)) => {
                     let mut wrapped = HarnessStreamSink::new(channel_sink, runner);
                     if let Some(rec) = outcome_recorder.as_ref() {
                         wrapped = wrapped.with_skill_outcome_recorder(Arc::clone(rec));
                     }
-                    agent.turn(&user_input, &mut wrapped).await
+                    let mut traj = tmg_trajectory::TrajectoryStreamSink::new(
+                        wrapped,
+                        trajectory_recorder.clone(),
+                    );
+                    agent.turn(&user_input, &mut traj).await
                 }
                 (None, None) => {
-                    let mut sink = channel_sink;
-                    agent.turn(&user_input, &mut sink).await
+                    let mut traj = tmg_trajectory::TrajectoryStreamSink::new(
+                        channel_sink,
+                        trajectory_recorder.clone(),
+                    );
+                    agent.turn(&user_input, &mut traj).await
                 }
             };
 

--- a/crates/tmg-tui/src/lib.rs
+++ b/crates/tmg-tui/src/lib.rs
@@ -100,6 +100,7 @@ pub async fn run(
     startup_banner: Option<String>,
     skills_runtime: Option<Arc<Mutex<SkillsRuntime>>>,
     skill_outcome_recorder: Option<Arc<TurnOutcomeRecorder>>,
+    trajectory_recorder: Option<Arc<tmg_trajectory::Recorder>>,
 ) -> Result<(), TuiError> {
     // Pre-warm the syntect bundle off the rendering thread. Loading
     // `SyntaxSet::load_defaults_newlines` + `ThemeSet::load_defaults`
@@ -190,6 +191,10 @@ pub async fn run(
 
     if let Some(recorder) = skill_outcome_recorder {
         app.set_skill_outcome_recorder(recorder);
+    }
+
+    if let Some(recorder) = trajectory_recorder {
+        app.set_trajectory_recorder(recorder);
     }
 
     // Issue #54: surface the auto-generated-skill banner at startup

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -34,6 +34,7 @@ tmg-sandbox = { workspace = true }
 tmg-search = { workspace = true }
 tmg-skills = { workspace = true }
 tmg-tools = { workspace = true }
+tmg-trajectory = { workspace = true }
 tmg-tui = { workspace = true }
 tmg-workflow = { workspace = true }
 

--- a/tmg-cli/Cargo.toml
+++ b/tmg-cli/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { workspace = true, features = ["signal", "sync"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tmg-agents = { workspace = true }

--- a/tmg-cli/src/config.rs
+++ b/tmg-cli/src/config.rs
@@ -658,6 +658,54 @@ impl PartialSearchConfig {
     }
 }
 
+/// Partial `[trajectory]` config — fields are `Option` so partial
+/// layers (global / project / env / CLI) compose without clobbering
+/// unset knobs. Issue #55.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PartialTrajectoryConfig {
+    pub enabled: Option<bool>,
+    pub output_dir: Option<String>,
+    pub include_thinking: Option<bool>,
+    pub include_tool_results: Option<tmg_trajectory::ToolResultMode>,
+    pub redact_extra_patterns: Option<Vec<String>>,
+}
+
+impl PartialTrajectoryConfig {
+    fn merge_from(&mut self, other: &Self) {
+        if other.enabled.is_some() {
+            self.enabled = other.enabled;
+        }
+        if other.output_dir.is_some() {
+            self.output_dir.clone_from(&other.output_dir);
+        }
+        if other.include_thinking.is_some() {
+            self.include_thinking = other.include_thinking;
+        }
+        if other.include_tool_results.is_some() {
+            self.include_tool_results = other.include_tool_results;
+        }
+        if other.redact_extra_patterns.is_some() {
+            self.redact_extra_patterns
+                .clone_from(&other.redact_extra_patterns);
+        }
+    }
+
+    fn into_final(self) -> tmg_trajectory::TrajectoryConfig {
+        let defaults = tmg_trajectory::TrajectoryConfig::default();
+        tmg_trajectory::TrajectoryConfig {
+            enabled: self.enabled.unwrap_or(defaults.enabled),
+            output_dir: self.output_dir.unwrap_or(defaults.output_dir),
+            include_thinking: self.include_thinking.unwrap_or(defaults.include_thinking),
+            include_tool_results: self
+                .include_tool_results
+                .unwrap_or(defaults.include_tool_results),
+            redact_extra_patterns: self
+                .redact_extra_patterns
+                .unwrap_or(defaults.redact_extra_patterns),
+        }
+    }
+}
+
 /// Partial top-level config used for deserialization and merging.
 ///
 /// Partial memory config used for deserialization / merging. Each
@@ -728,6 +776,8 @@ struct PartialTsumugiConfig {
     pub memory: PartialMemoryConfig,
     #[serde(default)]
     pub search: PartialSearchConfig,
+    #[serde(default)]
+    pub trajectory: PartialTrajectoryConfig,
 }
 
 impl PartialTsumugiConfig {
@@ -742,6 +792,7 @@ impl PartialTsumugiConfig {
         self.workflow.merge_from(&other.workflow);
         self.memory.merge_from(&other.memory);
         self.search.merge_from(&other.search);
+        self.trajectory.merge_from(&other.trajectory);
     }
 
     /// Apply environment variable overrides (`TMG_*` prefix).
@@ -1013,6 +1064,41 @@ impl PartialTsumugiConfig {
             }
             self.workflow.max_parallel_agents = Some(n);
         }
+        // [trajectory] env overrides (issue #55).
+        if let Some(v) = env_fn("TMG_TRAJECTORY_ENABLED") {
+            let parsed = parse_bool(&v).map_err(|()| ConfigError::InvalidValue {
+                field: "TMG_TRAJECTORY_ENABLED".to_owned(),
+                value: v,
+                reason: "must be one of: true, false, 1, 0".to_owned(),
+            })?;
+            self.trajectory.enabled = Some(parsed);
+        }
+        if let Some(v) = env_fn("TMG_TRAJECTORY_OUTPUT_DIR") {
+            self.trajectory.output_dir = Some(v);
+        }
+        if let Some(v) = env_fn("TMG_TRAJECTORY_INCLUDE_THINKING") {
+            let parsed = parse_bool(&v).map_err(|()| ConfigError::InvalidValue {
+                field: "TMG_TRAJECTORY_INCLUDE_THINKING".to_owned(),
+                value: v,
+                reason: "must be one of: true, false, 1, 0".to_owned(),
+            })?;
+            self.trajectory.include_thinking = Some(parsed);
+        }
+        if let Some(v) = env_fn("TMG_TRAJECTORY_INCLUDE_TOOL_RESULTS") {
+            let mode = match v.as_str() {
+                "full" => tmg_trajectory::ToolResultMode::Full,
+                "redacted" => tmg_trajectory::ToolResultMode::Redacted,
+                "summary_only" => tmg_trajectory::ToolResultMode::SummaryOnly,
+                _ => {
+                    return Err(ConfigError::InvalidValue {
+                        field: "TMG_TRAJECTORY_INCLUDE_TOOL_RESULTS".to_owned(),
+                        value: v,
+                        reason: "must be one of: full, redacted, summary_only".to_owned(),
+                    });
+                }
+            };
+            self.trajectory.include_tool_results = Some(mode);
+        }
         Ok(())
     }
 
@@ -1027,6 +1113,7 @@ impl PartialTsumugiConfig {
             workflow: self.workflow.into_final()?,
             memory: self.memory.into_final(),
             search: self.search.into_final(),
+            trajectory: self.trajectory.into_final(),
         })
     }
 }
@@ -1370,6 +1457,14 @@ pub struct TsumugiConfig {
     /// Cross-session search layer settings (issue #53).
     #[serde(default)]
     pub search: SearchConfig,
+
+    /// Trajectory recorder settings (issue #55).
+    ///
+    /// Defaults to `enabled = false` (opt-in). When the operator
+    /// flips the switch, the recorder writes per-session JSONL files
+    /// under each run dir.
+    #[serde(default)]
+    pub trajectory: tmg_trajectory::TrajectoryConfig,
 }
 
 /// `[memory]` section: project-scoped persistent memory configuration.

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -17,6 +17,7 @@ mod init_command;
 mod memory_commands;
 mod pool_setup;
 mod run_commands;
+mod trajectory_commands;
 mod workflow_commands;
 
 use config::{HarnessConfig, SandboxConfigSection, SearchConfig, SkillsSection, TsumugiConfig};
@@ -116,6 +117,63 @@ enum Command {
         /// Sub-operation on the search index.
         #[command(subcommand)]
         op: SearchCommand,
+    },
+    /// Trajectory recorder management (`tmg trajectory <op>`). Issue #55.
+    ///
+    /// Operations: enable / disable the master switch, list trajectory
+    /// files on disk, export from existing `session_log` artifacts, and
+    /// bundle every trajectory into a `tar.zst` archive.
+    Trajectory {
+        /// Sub-operation on the trajectory store.
+        #[command(subcommand)]
+        op: TrajectoryCommand,
+    },
+}
+
+/// Operations under `tmg trajectory`. Issue #55.
+#[derive(Subcommand, Debug)]
+enum TrajectoryCommand {
+    /// Enable the recorder by writing `[trajectory] enabled = true`
+    /// to the project `tsumugi.toml`. Prints a consent warning that
+    /// the operator must acknowledge with `--yes` before the file is
+    /// written.
+    Enable {
+        /// Skip the consent prompt and write the enable flag directly.
+        /// Required for non-interactive (CI) use.
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Disable the recorder by writing `[trajectory] enabled = false`
+    /// to the project `tsumugi.toml`. Existing trajectory files are
+    /// preserved.
+    Disable,
+    /// List trajectory files already on disk under each run dir.
+    List,
+    /// Reconstruct trajectories from existing `session_log/*.json`
+    /// (and, when present, the matching `event_log/*.jsonl`).
+    Export {
+        /// Specific run id to export. Mutually-suggestive with `--all`.
+        #[arg(long)]
+        run: Option<String>,
+        /// Override the output directory; otherwise the recorder's
+        /// configured `output_dir` under each run dir is used.
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Export every run.
+        #[arg(long)]
+        all: bool,
+        /// Lower bound on `Run::created_at` (ISO8601 / RFC3339).
+        #[arg(long)]
+        since: Option<String>,
+    },
+    /// Pack every trajectory into a `tar.zst` archive.
+    Bundle {
+        /// Destination archive path (e.g. `tsumugi-traj.tar.zst`).
+        #[arg(long)]
+        out: PathBuf,
+        /// zstd compression level (1..=22; default `3`).
+        #[arg(long, default_value_t = 3)]
+        compression: i32,
     },
 }
 
@@ -326,6 +384,9 @@ fn main() -> anyhow::Result<()> {
             dispatch_memory_command(op, &config, cli.event_log.as_deref())
         }
         Some(Command::Search { op }) => dispatch_search_command(op, &config),
+        Some(Command::Trajectory { op }) => {
+            dispatch_trajectory_command(op, &config, cli.config.as_deref())
+        }
         None => {
             if let Some(prompt) = cli.prompt {
                 run_prompt(
@@ -338,6 +399,7 @@ fn main() -> anyhow::Result<()> {
                     &config.sandbox,
                     context_config,
                     config.llm.tool_calling,
+                    &config.trajectory,
                 )
             } else {
                 run_tui(
@@ -352,6 +414,7 @@ fn main() -> anyhow::Result<()> {
                     &config.skills,
                     &config.memory,
                     &config.search,
+                    &config.trajectory,
                     config.llm.subagent_pool.as_ref(),
                     None,
                 )
@@ -406,6 +469,28 @@ fn dispatch_memory_command(
     event_log: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     memory_commands::dispatch(op, config, event_log)
+}
+
+/// Dispatch one `tmg trajectory <op>` invocation. Issue #55.
+fn dispatch_trajectory_command(
+    op: TrajectoryCommand,
+    config: &TsumugiConfig,
+    config_path: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    match op {
+        TrajectoryCommand::Enable { yes } => trajectory_commands::cmd_enable(config_path, yes),
+        TrajectoryCommand::Disable => trajectory_commands::cmd_disable(config_path),
+        TrajectoryCommand::List => trajectory_commands::cmd_list(config),
+        TrajectoryCommand::Export {
+            run,
+            out,
+            all,
+            since,
+        } => trajectory_commands::cmd_export(config, run, out.as_deref(), all, since),
+        TrajectoryCommand::Bundle { out, compression } => {
+            trajectory_commands::cmd_bundle(config, &out, compression)
+        }
+    }
 }
 
 /// Dispatch one `tmg search <op>` invocation. Issue #53.
@@ -582,6 +667,7 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
                 &config.skills,
                 &config.memory,
                 &config.search,
+                &config.trajectory,
                 config.llm.subagent_pool.as_ref(),
                 resolved.as_ref(),
             )
@@ -637,6 +723,10 @@ fn dispatch_run_command(op: RunCommand, config: &TsumugiConfig) -> anyhow::Resul
     clippy::too_many_arguments,
     reason = "linear setup helper takes the merged config sections as discrete refs"
 )]
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear startup wiring (config -> client -> stores -> agent loop -> sink); splitting obscures the launch sequence"
+)]
 fn run_prompt(
     endpoint: &str,
     model: &str,
@@ -647,6 +737,7 @@ fn run_prompt(
     sandbox_config: &SandboxConfigSection,
     context_config: tmg_core::ContextConfig,
     tool_calling_mode: tmg_llm::ToolCallingMode,
+    trajectory_config: &tmg_trajectory::TrajectoryConfig,
 ) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
@@ -767,27 +858,102 @@ fn run_prompt(
             }
         }
 
+        // Optional trajectory recorder for one-shot mode (issue #55).
+        // One-shot has no `RunRunner`, so we synthesise a trajectory
+        // file under `.tsumugi/trajectories/oneshot_<timestamp>.jsonl`
+        // when `[trajectory] enabled = true`. The recorder is opened
+        // before the turn so the meta record appears first.
+        let trajectory_recorder: Option<std::sync::Arc<tmg_trajectory::Recorder>> =
+            if trajectory_config.enabled {
+                match build_oneshot_recorder(&canonical_cwd, trajectory_config, model, prompt) {
+                    Ok(r) => Some(r),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to open one-shot trajectory recorder");
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
         // The agent's `turn` method takes `&mut impl StreamSink` which
         // is `Sized`, so we cannot use `Box<dyn StreamSink>` here.
-        // Branch on the event-log presence and call `turn` separately
-        // in each arm so the sink type is statically known.
-        if let Some(path) = event_log {
-            let log = tmg_core::EventLogWriter::new(path).context("opening event log file")?;
-            let mut sink = tmg_core::TeeStreamSink::new(StdoutSink::default(), log);
-            agent
-                .turn(prompt, &mut sink)
-                .await
-                .context("running one-shot agent turn")?;
-        } else {
-            let mut sink = StdoutSink::default();
-            agent
-                .turn(prompt, &mut sink)
-                .await
-                .context("running one-shot agent turn")?;
+        // Branch on (event-log, trajectory) presence and call `turn`
+        // in each arm so the sink type is statically known. The
+        // tee chain is `TrajectoryStreamSink<TeeStreamSink<StdoutSink>>`
+        // when both are present.
+        let stdout_sink = StdoutSink::default();
+        match (event_log, trajectory_recorder.as_ref()) {
+            (Some(path), traj) => {
+                let log = tmg_core::EventLogWriter::new(path).context("opening event log file")?;
+                let inner = tmg_core::TeeStreamSink::new(stdout_sink, log);
+                let mut sink = tmg_trajectory::TrajectoryStreamSink::new(inner, traj.cloned());
+                agent
+                    .turn(prompt, &mut sink)
+                    .await
+                    .context("running one-shot agent turn")?;
+            }
+            (None, traj) => {
+                let mut sink =
+                    tmg_trajectory::TrajectoryStreamSink::new(stdout_sink, traj.cloned());
+                agent
+                    .turn(prompt, &mut sink)
+                    .await
+                    .context("running one-shot agent turn")?;
+            }
+        }
+
+        // Close the trajectory with a verdict so the file shape is
+        // valid even for one-shot mode.
+        if let Some(rec) = trajectory_recorder.as_ref() {
+            if let Err(e) = rec.record_verdict("completed", Vec::new()) {
+                tracing::warn!(error = %e, "trajectory verdict (one-shot) failed");
+            }
+            if let Err(e) = rec.flush() {
+                tracing::warn!(error = %e, "trajectory flush (one-shot) failed");
+            }
         }
 
         Ok::<(), anyhow::Error>(())
     })
+}
+
+/// Build a synthetic per-run [`Recorder`] for one-shot mode.
+///
+/// One-shot has no harness session boundary, so we mint a synthetic
+/// `oneshot` "run" under `.tsumugi/trajectories/`. The path layout
+/// (`<cwd>/.tsumugi/trajectories/oneshot_<UTC>.jsonl`) keeps the
+/// per-run convention loose for now; a follow-up could promote
+/// one-shot mode to issue its own ad-hoc run id and reuse the full
+/// `.tsumugi/runs/<id>/trajectories/` layout.
+fn build_oneshot_recorder(
+    project_root: &std::path::Path,
+    config: &tmg_trajectory::TrajectoryConfig,
+    model: &str,
+    user_prompt: &str,
+) -> anyhow::Result<std::sync::Arc<tmg_trajectory::Recorder>> {
+    let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let dir = project_root.join(".tsumugi").join("trajectories");
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    let path = dir.join(format!("oneshot_{stamp}.jsonl"));
+    let recorder = tmg_trajectory::Recorder::create(&path, config.clone())
+        .context("creating one-shot trajectory recorder")?;
+    recorder
+        .record_meta(tmg_trajectory::MetaRecord {
+            run_id: format!("oneshot-{stamp}"),
+            session_num: 1,
+            model: model.to_owned(),
+            scope: "oneshot".to_owned(),
+            started_at: chrono::Utc::now(),
+            ended_at: None,
+            outcome: None,
+        })
+        .context("writing trajectory meta record")?;
+    // No system prompt is exposed at this layer; the AgentLoop owns
+    // it. We write a placeholder so the file shape is valid.
+    let _ = recorder.record_system("(one-shot mode; system prompt internal to AgentLoop)");
+    let _ = recorder.record_user(user_prompt);
+    Ok(std::sync::Arc::new(recorder))
 }
 
 /// One-shot stdout sink that mirrors [`StreamEvent`] output to the
@@ -971,6 +1137,7 @@ fn run_tui(
     skills_section: &SkillsSection,
     memory_config: &config::MemoryConfig,
     search_config: &SearchConfig,
+    trajectory_config: &tmg_trajectory::TrajectoryConfig,
     subagent_pool: Option<&tmg_llm::PoolConfig>,
     explicit_run_id: Option<&tmg_harness::RunId>,
 ) -> anyhow::Result<()> {
@@ -1142,6 +1309,48 @@ fn run_tui(
             .begin_session()
             .context("beginning harness session")?;
         let run_summary: RunSummary = runner.summary();
+
+        // Build the trajectory recorder for this session (issue #55).
+        // Best-effort: a misconfigured `redact_extra_patterns` regex
+        // surfaces as a warning and disables recording for this run
+        // rather than aborting startup.
+        let trajectory_recorder: Option<Arc<tmg_trajectory::Recorder>> = if trajectory_config.enabled
+        {
+            let active_run_dir = store.run_dir(runner.run_id());
+            let session_index = session_handle.index;
+            let traj_path = tmg_trajectory::trajectory_path(
+                &active_run_dir,
+                &trajectory_config.output_dir,
+                session_index,
+            );
+            match tmg_trajectory::Recorder::create(&traj_path, trajectory_config.clone()) {
+                Ok(rec) => {
+                    let arc = Arc::new(rec);
+                    let scope = match runner.scope() {
+                        tmg_harness::RunScope::AdHoc => "ad-hoc".to_owned(),
+                        tmg_harness::RunScope::Harnessed { .. } => "harnessed".to_owned(),
+                    };
+                    if let Err(e) = arc.record_meta(tmg_trajectory::MetaRecord {
+                        run_id: runner.run_id().as_str().to_owned(),
+                        session_num: session_index,
+                        model: model.to_owned(),
+                        scope,
+                        started_at: chrono::Utc::now(),
+                        ended_at: None,
+                        outcome: None,
+                    }) {
+                        tracing::warn!(error = %e, "trajectory meta record failed");
+                    }
+                    Some(arc)
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to open trajectory recorder; continuing without recording");
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
         // Wrap the runner in Arc<Mutex<...>> so the Run-scoped tools and
         // the bootstrap path share one source of truth for the active
@@ -1654,6 +1863,7 @@ fn run_tui(
             startup_banner,
             skills_runtime.clone(),
             skill_outcome_recorder.clone(),
+            trajectory_recorder.clone(),
         )
         .await;
 
@@ -1687,10 +1897,36 @@ fn run_tui(
         };
         let end_result = {
             let mut guard = runner.lock().await;
-            guard.end_session(&session_handle, trigger)
+            guard.end_session(&session_handle, trigger.clone())
         };
         if let Err(e) = end_result {
             log_end_session_error(&e);
+        }
+
+        // Trajectory verdict (issue #55). The features-marked-passing
+        // list is read off the active session's snapshot (the
+        // `end_session` call above persists them to disk; we re-read
+        // here to avoid threading the value through the trigger).
+        if let Some(rec) = trajectory_recorder.as_ref() {
+            let outcome_label = tmg_trajectory::record_outcome_label(&trigger);
+            let features = {
+                let guard = runner.lock().await;
+                // Re-load the just-persisted session via the session
+                // log so we get the same `features_marked_passing`
+                // list end_session wrote.
+                let log = guard.session_log();
+                log.load(session_handle.index)
+                    .ok()
+                    .flatten()
+                    .map(|s| s.features_marked_passing)
+                    .unwrap_or_default()
+            };
+            if let Err(e) = rec.record_verdict(&outcome_label, features) {
+                tracing::warn!(error = %e, "trajectory verdict record failed");
+            }
+            if let Err(e) = rec.flush() {
+                tracing::warn!(error = %e, "trajectory flush failed");
+            }
         }
 
         tui_result?;
@@ -2095,6 +2331,82 @@ mod tests {
                 assert_eq!(run_id.as_deref(), Some("abc12345"));
             }
             other => panic!("expected Run(Status), got {other:?}"),
+        }
+    }
+
+    /// Issue #55: `tmg trajectory enable --yes` parses with the
+    /// consent flag set.
+    #[test]
+    fn cli_trajectory_enable_parses() {
+        let cli = Cli::try_parse_from(["tmg", "trajectory", "enable", "--yes"])
+            .unwrap_or_else(|e| panic!("{e}"));
+        match cli.command {
+            Some(Command::Trajectory {
+                op: TrajectoryCommand::Enable { yes },
+            }) => {
+                assert!(yes);
+            }
+            other => panic!("expected Trajectory(Enable), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_trajectory_disable_parses() {
+        let cli = Cli::try_parse_from(["tmg", "trajectory", "disable"])
+            .unwrap_or_else(|e| panic!("{e}"));
+        match cli.command {
+            Some(Command::Trajectory {
+                op: TrajectoryCommand::Disable,
+            }) => {}
+            other => panic!("expected Trajectory(Disable), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_trajectory_export_parses_all_flags() {
+        let cli = Cli::try_parse_from([
+            "tmg",
+            "trajectory",
+            "export",
+            "--run",
+            "abc12345",
+            "--out",
+            "/tmp/out",
+            "--since",
+            "2026-04-01T00:00:00Z",
+        ])
+        .unwrap_or_else(|e| panic!("{e}"));
+        match cli.command {
+            Some(Command::Trajectory {
+                op:
+                    TrajectoryCommand::Export {
+                        run,
+                        out,
+                        all,
+                        since,
+                    },
+            }) => {
+                assert_eq!(run.as_deref(), Some("abc12345"));
+                assert_eq!(out.as_deref(), Some(std::path::Path::new("/tmp/out")));
+                assert!(!all);
+                assert_eq!(since.as_deref(), Some("2026-04-01T00:00:00Z"));
+            }
+            other => panic!("expected Trajectory(Export), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_trajectory_bundle_parses() {
+        let cli = Cli::try_parse_from(["tmg", "trajectory", "bundle", "--out", "x.tar.zst"])
+            .unwrap_or_else(|e| panic!("{e}"));
+        match cli.command {
+            Some(Command::Trajectory {
+                op: TrajectoryCommand::Bundle { out, compression },
+            }) => {
+                assert_eq!(out, std::path::PathBuf::from("x.tar.zst"));
+                assert_eq!(compression, 3);
+            }
+            other => panic!("expected Trajectory(Bundle), got {other:?}"),
         }
     }
 

--- a/tmg-cli/src/main.rs
+++ b/tmg-cli/src/main.rs
@@ -956,6 +956,59 @@ fn build_oneshot_recorder(
     Ok(std::sync::Arc::new(recorder))
 }
 
+/// Build a per-session [`tmg_trajectory::Recorder`] for the TUI / harnessed
+/// session path.
+///
+/// On success, this opens the JSONL file at `traj_path` and writes:
+///
+/// 1. a `meta` record with the supplied identifiers and the current UTC time
+///    as `started_at`;
+/// 2. a `system` record with a TUI-mode placeholder string. The actual
+///    system prompt is owned by `AgentLoop` and is not exposed at this
+///    layer; the placeholder makes the file shape consistent with the
+///    one-shot recorder built by [`build_oneshot_recorder`].
+///
+/// Failures are best-effort: an I/O / config error surfaces as a
+/// `tracing::warn!` and the function returns `None` so the caller proceeds
+/// without trajectory recording rather than aborting the run.
+fn build_session_recorder(
+    traj_path: &std::path::Path,
+    config: &tmg_trajectory::TrajectoryConfig,
+    run_id: &str,
+    session_index: u32,
+    model: &str,
+    scope: &str,
+) -> Option<std::sync::Arc<tmg_trajectory::Recorder>> {
+    match tmg_trajectory::Recorder::create(traj_path, config.clone()) {
+        Ok(rec) => {
+            let arc = std::sync::Arc::new(rec);
+            if let Err(e) = arc.record_meta(tmg_trajectory::MetaRecord {
+                run_id: run_id.to_owned(),
+                session_num: session_index,
+                model: model.to_owned(),
+                scope: scope.to_owned(),
+                started_at: chrono::Utc::now(),
+                ended_at: None,
+                outcome: None,
+            }) {
+                tracing::warn!(error = %e, "trajectory meta record failed");
+            }
+            // Match the one-shot path: write a placeholder `system`
+            // record so the trajectory file shape is consistent across
+            // both modes. The actual system prompt is owned by
+            // `AgentLoop` and is not exposed at this layer.
+            if let Err(e) = arc.record_system("(TUI mode; system prompt internal to AgentLoop)") {
+                tracing::warn!(error = %e, "trajectory system record failed");
+            }
+            Some(arc)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to open trajectory recorder; continuing without recording");
+            None
+        }
+    }
+}
+
 /// One-shot stdout sink that mirrors [`StreamEvent`] output to the
 /// terminal. Tool calls and warnings are surfaced as bracketed lines
 /// so the user can see what the agent is doing without the TUI.
@@ -1311,40 +1364,43 @@ fn run_tui(
         let run_summary: RunSummary = runner.summary();
 
         // Build the trajectory recorder for this session (issue #55).
-        // Best-effort: a misconfigured `redact_extra_patterns` regex
-        // surfaces as a warning and disables recording for this run
-        // rather than aborting startup.
+        // Best-effort: a misconfigured `redact_extra_patterns` regex,
+        // or an `output_dir` that escapes the project root, surfaces
+        // as a warning and disables recording for this run rather than
+        // aborting startup. The escape check is a software-level guard
+        // because Landlock only fires on Linux — macOS / other
+        // platforms rely on this check.
         let trajectory_recorder: Option<Arc<tmg_trajectory::Recorder>> = if trajectory_config.enabled
         {
             let active_run_dir = store.run_dir(runner.run_id());
             let session_index = session_handle.index;
-            let traj_path = tmg_trajectory::trajectory_path(
-                &active_run_dir,
-                &trajectory_config.output_dir,
-                session_index,
-            );
-            match tmg_trajectory::Recorder::create(&traj_path, trajectory_config.clone()) {
-                Ok(rec) => {
-                    let arc = Arc::new(rec);
+            match trajectory_config
+                .resolve_output_dir_within(&canonical_cwd, &active_run_dir)
+            {
+                Ok(_) => {
+                    let traj_path = tmg_trajectory::trajectory_path(
+                        &active_run_dir,
+                        &trajectory_config.output_dir,
+                        session_index,
+                    );
                     let scope = match runner.scope() {
                         tmg_harness::RunScope::AdHoc => "ad-hoc".to_owned(),
                         tmg_harness::RunScope::Harnessed { .. } => "harnessed".to_owned(),
                     };
-                    if let Err(e) = arc.record_meta(tmg_trajectory::MetaRecord {
-                        run_id: runner.run_id().as_str().to_owned(),
-                        session_num: session_index,
-                        model: model.to_owned(),
-                        scope,
-                        started_at: chrono::Utc::now(),
-                        ended_at: None,
-                        outcome: None,
-                    }) {
-                        tracing::warn!(error = %e, "trajectory meta record failed");
-                    }
-                    Some(arc)
+                    build_session_recorder(
+                        &traj_path,
+                        trajectory_config,
+                        runner.run_id().as_str(),
+                        session_index,
+                        model,
+                        &scope,
+                    )
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, "failed to open trajectory recorder; continuing without recording");
+                    tracing::warn!(
+                        error = %e,
+                        "trajectory output_dir escapes project root; recording disabled for this run",
+                    );
                     None
                 }
             }
@@ -2352,8 +2408,8 @@ mod tests {
 
     #[test]
     fn cli_trajectory_disable_parses() {
-        let cli = Cli::try_parse_from(["tmg", "trajectory", "disable"])
-            .unwrap_or_else(|e| panic!("{e}"));
+        let cli =
+            Cli::try_parse_from(["tmg", "trajectory", "disable"]).unwrap_or_else(|e| panic!("{e}"));
         match cli.command {
             Some(Command::Trajectory {
                 op: TrajectoryCommand::Disable,
@@ -2668,5 +2724,52 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap_or_else(|e| panic!("{e}"));
         let result = compute_diff_lines(&workspace).await;
         assert_eq!(result, 0);
+    }
+
+    // ---------------------------------------------------------------
+    // Trajectory recorder builders (issue #55 PR #79 review)
+    // ---------------------------------------------------------------
+
+    /// Both the one-shot and the TUI / session paths must produce a
+    /// `system` record so the on-disk JSONL shape is consistent across
+    /// modes. Regression for PR #79 review #2 — the TUI path used to
+    /// only write `meta`.
+    #[test]
+    fn both_modes_write_system_record() {
+        let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("{e}"));
+        let project_root = tmp.path().to_path_buf();
+        let cfg = tmg_trajectory::TrajectoryConfig {
+            enabled: true,
+            ..tmg_trajectory::TrajectoryConfig::default()
+        };
+
+        // One-shot.
+        let oneshot = build_oneshot_recorder(&project_root, &cfg, "test-model", "hello world")
+            .unwrap_or_else(|e| panic!("{e}"));
+        oneshot.flush().unwrap_or_else(|e| panic!("{e}"));
+        let oneshot_path = oneshot.path();
+        let oneshot_body = std::fs::read_to_string(&oneshot_path).unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            oneshot_body.contains(r#""type":"system""#),
+            "one-shot trajectory missing system record: {oneshot_body}"
+        );
+
+        // TUI / session-mode.
+        let traj_path = project_root.join("tui_session.jsonl");
+        let Some(session) =
+            build_session_recorder(&traj_path, &cfg, "run-abc123", 1, "test-model", "ad-hoc")
+        else {
+            panic!("session recorder build returned None");
+        };
+        session.flush().unwrap_or_else(|e| panic!("{e}"));
+        let session_body = std::fs::read_to_string(&traj_path).unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            session_body.contains(r#""type":"system""#),
+            "session-mode trajectory missing system record: {session_body}"
+        );
+        assert!(
+            session_body.contains(r#""type":"meta""#),
+            "session-mode trajectory missing meta record: {session_body}"
+        );
     }
 }

--- a/tmg-cli/src/trajectory_commands.rs
+++ b/tmg-cli/src/trajectory_commands.rs
@@ -19,6 +19,7 @@ use anyhow::{Context as _, anyhow};
 use chrono::{DateTime, Utc};
 use tmg_harness::RunStore;
 use tmg_trajectory::ExportFilter;
+use toml_edit::{DocumentMut, Item as TomlItem, Table as TomlTable, value as toml_value};
 
 use crate::config::TsumugiConfig;
 
@@ -89,40 +90,41 @@ pub fn cmd_disable(config_path: Option<&Path>) -> anyhow::Result<()> {
 
 /// Locate (and create if missing) the project `tsumugi.toml`, then
 /// rewrite the `[trajectory]` block to set `enabled` to the supplied
-/// value. The rest of the file is preserved verbatim — we use
-/// `toml_edit` semantics by deserialising into `toml::Value`,
-/// patching, and re-serialising. Comments are not preserved (a TODO
-/// for `toml_edit`); the project config is small enough that this is
-/// acceptable for the first cut.
+/// value.
+///
+/// The rest of the file is preserved **verbatim**, including comments,
+/// blank lines, and key ordering, because we drive the edit through
+/// [`toml_edit::DocumentMut`] (the same crate `cargo` uses to edit
+/// `Cargo.toml`). Only the single `enabled` key under `[trajectory]`
+/// is mutated; if the section or the key are missing they are
+/// created with the cleanest formatting `toml_edit` can produce.
 fn set_trajectory_enabled(config_path: Option<&Path>, value: bool) -> anyhow::Result<()> {
     let path = config_path.map_or_else(default_project_config_path, Path::to_path_buf);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
     }
-    let mut value_table: toml::Value = if path.exists() {
+    let mut doc: DocumentMut = if path.exists() {
         let raw = std::fs::read_to_string(&path)
             .with_context(|| format!("reading {}", path.display()))?;
-        toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?
+        raw.parse::<DocumentMut>()
+            .with_context(|| format!("parsing {}", path.display()))?
     } else {
-        toml::Value::Table(toml::value::Table::new())
+        DocumentMut::new()
     };
-    let toml::Value::Table(table) = &mut value_table else {
-        return Err(anyhow!(
-            "expected a TOML table at {}; refusing to overwrite a non-table top level",
-            path.display(),
-        ));
-    };
-    let traj_entry = table
-        .entry("trajectory".to_owned())
-        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
-    let toml::Value::Table(traj_table) = traj_entry else {
+
+    // Get-or-create the `[trajectory]` table, refusing to clobber a
+    // non-table value at that key.
+    let traj_item = doc
+        .entry("trajectory")
+        .or_insert_with(|| TomlItem::Table(TomlTable::new()));
+    let Some(traj_table) = traj_item.as_table_mut() else {
         return Err(anyhow!("[trajectory] in {} is not a table", path.display()));
     };
-    traj_table.insert("enabled".to_owned(), toml::Value::Boolean(value));
-    let serialized =
-        toml::to_string_pretty(&value_table).context("serialising updated tsumugi.toml")?;
-    std::fs::write(&path, serialized).with_context(|| format!("writing {}", path.display()))?;
+    traj_table["enabled"] = toml_value(value);
+
+    std::fs::write(&path, doc.to_string())
+        .with_context(|| format!("writing {}", path.display()))?;
     Ok(())
 }
 
@@ -272,5 +274,58 @@ mod tests {
         );
         assert!(body.contains("[trajectory]"), "{body}");
         assert!(body.contains("enabled = true"), "{body}");
+    }
+
+    /// Comments and key ordering in the user's `tsumugi.toml` survive
+    /// the `enable` / `disable` round-trip. Regression for PR #79
+    /// review #3 — the previous `toml::Value` based implementation
+    /// dropped every `#` comment and re-formatted the file.
+    #[test]
+    fn enable_preserves_comments() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let cfg = tmp.path().join("tsumugi.toml");
+        let original = "\
+# tsumugi project configuration
+# Edit this file to override the defaults.
+
+[llm]
+# Endpoint must point at an OpenAI-compatible server.
+endpoint = \"http://localhost:8080\"
+model = \"foo\" # default local model
+
+[trajectory]
+# Master switch for trajectory recording (issue #55).
+enabled = false
+include_thinking = true # keep reasoning blocks for SFT
+";
+        std::fs::write(&cfg, original).unwrap_or_else(|e| panic!("{e}"));
+        set_trajectory_enabled(Some(&cfg), true).unwrap_or_else(|e| panic!("{e}"));
+        let body = std::fs::read_to_string(&cfg).unwrap_or_else(|e| panic!("{e}"));
+        // Top-level comments survive.
+        assert!(
+            body.contains("# tsumugi project configuration"),
+            "lost top-level comment: {body}"
+        );
+        assert!(
+            body.contains("# Edit this file to override the defaults."),
+            "{body}"
+        );
+        // Section-internal comments survive.
+        assert!(
+            body.contains("# Endpoint must point at an OpenAI-compatible server."),
+            "{body}"
+        );
+        assert!(
+            body.contains("# Master switch for trajectory recording (issue #55)."),
+            "{body}"
+        );
+        // Trailing inline comments survive.
+        assert!(body.contains("# default local model"), "{body}");
+        assert!(body.contains("# keep reasoning blocks for SFT"), "{body}");
+        // The `enabled` flag flipped.
+        assert!(body.contains("enabled = true"), "{body}");
+        // Non-touched keys preserved.
+        assert!(body.contains("include_thinking = true"), "{body}");
+        assert!(body.contains("model = \"foo\""), "{body}");
     }
 }

--- a/tmg-cli/src/trajectory_commands.rs
+++ b/tmg-cli/src/trajectory_commands.rs
@@ -1,0 +1,276 @@
+//! `tmg trajectory ...` subcommand implementations (issue #55).
+//!
+//! Five operations:
+//!
+//! - `enable`  — flip `[trajectory] enabled = true` in the project
+//!   `tsumugi.toml` (with a one-time consent warning).
+//! - `disable` — flip it back to `false`.
+//! - `list`    — enumerate trajectory files already on disk.
+//! - `export`  — reconstruct trajectories from `session_log/*.json`
+//!   plus optional `event_log/*.jsonl`.
+//! - `bundle`  — pack every trajectory into a `tar.zst` archive.
+//!
+//! These commands operate on the project store directly; none of them
+//! touch the agent loop.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, anyhow};
+use chrono::{DateTime, Utc};
+use tmg_harness::RunStore;
+use tmg_trajectory::ExportFilter;
+
+use crate::config::TsumugiConfig;
+
+/// Resolve the project root + runs dir the same way the rest of the
+/// CLI does. Centralised so the trajectory commands and the live
+/// recorder agree on which `.tsumugi/runs/` they target.
+fn resolve_paths(config: &TsumugiConfig) -> anyhow::Result<(PathBuf, PathBuf)> {
+    let cwd = std::env::current_dir().context("reading current working directory")?;
+    let canonical = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+    let runs_dir = if config.harness.runs_dir.is_absolute() {
+        config.harness.runs_dir.clone()
+    } else {
+        canonical.join(&config.harness.runs_dir)
+    };
+    Ok((canonical, runs_dir))
+}
+
+/// One-time consent message shown by `tmg trajectory enable`.
+pub const ENABLE_CONSENT_MESSAGE: &str = "\
+WARNING: trajectory recording stores the FULL conversation text and \
+code diffs (including system prompts, user input, assistant output, \
+tool call arguments, and tool result payloads) under \
+`.tsumugi/runs/<run-id>/trajectories/`.\n\
+\n\
+Default redaction masks API keys / tokens, but other sensitive \
+content (file contents, command output, internal URLs) will be \
+captured verbatim unless you set `[trajectory] include_tool_results \
+= \"summary_only\"` or extend `redact_extra_patterns`.\n\
+\n\
+Trajectories are intended for SFT/RL training datasets. Do NOT \
+share `.tsumugi/runs/<run-id>/trajectories/` outside trusted \
+machines without reviewing the contents first.\n";
+
+/// `tmg trajectory enable` — flip the master switch in
+/// `.tsumugi/tsumugi.toml`. Prints the consent warning once before
+/// proceeding; `--yes` skips the prompt for CI / scripted use.
+#[expect(
+    clippy::print_stdout,
+    reason = "documented stdout surface for CLI subcommands"
+)]
+pub fn cmd_enable(config_path: Option<&Path>, yes: bool) -> anyhow::Result<()> {
+    println!("{ENABLE_CONSENT_MESSAGE}");
+    if !yes {
+        println!(
+            "Re-run with `--yes` to confirm and write `[trajectory] enabled = true` to your tsumugi.toml.",
+        );
+        return Ok(());
+    }
+    set_trajectory_enabled(config_path, true)?;
+    println!(
+        "trajectory recording ENABLED. New runs will write to `.tsumugi/runs/<run-id>/trajectories/`."
+    );
+    Ok(())
+}
+
+/// `tmg trajectory disable` — flip the master switch back to `false`.
+#[expect(
+    clippy::print_stdout,
+    reason = "documented stdout surface for CLI subcommands"
+)]
+pub fn cmd_disable(config_path: Option<&Path>) -> anyhow::Result<()> {
+    set_trajectory_enabled(config_path, false)?;
+    println!(
+        "trajectory recording DISABLED. Existing files under `.tsumugi/runs/<run-id>/trajectories/` are preserved."
+    );
+    Ok(())
+}
+
+/// Locate (and create if missing) the project `tsumugi.toml`, then
+/// rewrite the `[trajectory]` block to set `enabled` to the supplied
+/// value. The rest of the file is preserved verbatim — we use
+/// `toml_edit` semantics by deserialising into `toml::Value`,
+/// patching, and re-serialising. Comments are not preserved (a TODO
+/// for `toml_edit`); the project config is small enough that this is
+/// acceptable for the first cut.
+fn set_trajectory_enabled(config_path: Option<&Path>, value: bool) -> anyhow::Result<()> {
+    let path = config_path.map_or_else(default_project_config_path, Path::to_path_buf);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let mut value_table: toml::Value = if path.exists() {
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?
+    } else {
+        toml::Value::Table(toml::value::Table::new())
+    };
+    let toml::Value::Table(table) = &mut value_table else {
+        return Err(anyhow!(
+            "expected a TOML table at {}; refusing to overwrite a non-table top level",
+            path.display(),
+        ));
+    };
+    let traj_entry = table
+        .entry("trajectory".to_owned())
+        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+    let toml::Value::Table(traj_table) = traj_entry else {
+        return Err(anyhow!("[trajectory] in {} is not a table", path.display()));
+    };
+    traj_table.insert("enabled".to_owned(), toml::Value::Boolean(value));
+    let serialized =
+        toml::to_string_pretty(&value_table).context("serialising updated tsumugi.toml")?;
+    std::fs::write(&path, serialized).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+fn default_project_config_path() -> PathBuf {
+    PathBuf::from(".tsumugi").join("tsumugi.toml")
+}
+
+/// `tmg trajectory list` — print one line per trajectory file.
+#[expect(
+    clippy::print_stdout,
+    reason = "documented stdout surface for CLI subcommands"
+)]
+pub fn cmd_list(config: &TsumugiConfig) -> anyhow::Result<()> {
+    let (_, runs_dir) = resolve_paths(config)?;
+    let entries = tmg_trajectory::list_trajectories(&runs_dir, &config.trajectory)?;
+    if entries.is_empty() {
+        println!(
+            "(no trajectories under {} — enable with `tmg trajectory enable --yes`)",
+            runs_dir.display()
+        );
+        return Ok(());
+    }
+    println!("{:<10}  {:>6}  {:>10}  PATH", "RUN", "SESSION", "BYTES");
+    for e in entries {
+        println!(
+            "{:<10}  {:>6}  {:>10}  {}",
+            e.run_id,
+            e.session_num,
+            e.size_bytes,
+            e.path.display()
+        );
+    }
+    Ok(())
+}
+
+/// `tmg trajectory export` — reconstruct trajectories from on-disk
+/// `session_log` + (optional) `event_log` artifacts.
+#[expect(
+    clippy::print_stdout,
+    reason = "documented stdout surface for CLI subcommands"
+)]
+pub fn cmd_export(
+    config: &TsumugiConfig,
+    run: Option<String>,
+    out: Option<&Path>,
+    all: bool,
+    since: Option<String>,
+) -> anyhow::Result<()> {
+    let (_, runs_dir) = resolve_paths(config)?;
+    let store = RunStore::new(&runs_dir);
+    let since_dt: Option<DateTime<Utc>> = match since {
+        Some(s) => Some(
+            DateTime::parse_from_rfc3339(&s)
+                .with_context(|| format!("parsing --since {s:?}"))?
+                .with_timezone(&Utc),
+        ),
+        None => None,
+    };
+    let filter = ExportFilter {
+        run_id: run,
+        all,
+        since: since_dt,
+    };
+    let mut effective = config.trajectory.clone();
+    // Export should NOT require enabled=true: it is the way you
+    // backfill historical sessions. We override locally so the
+    // recorder constructed inside the export path opens its files.
+    effective.enabled = true;
+    let summaries = tmg_trajectory::export(&store, &filter, out, &effective)?;
+    if summaries.is_empty() {
+        println!("(no runs matched the selection)");
+        return Ok(());
+    }
+    for s in summaries {
+        let fallback = if s.had_summary_only_fallback {
+            " (some sessions used summary-only fallback)"
+        } else {
+            ""
+        };
+        println!(
+            "exported {} sessions for run {}{}",
+            s.sessions_exported, s.run_id, fallback,
+        );
+    }
+    Ok(())
+}
+
+/// `tmg trajectory bundle` — pack every trajectory under the runs
+/// dir into one `tar.zst` archive.
+#[expect(
+    clippy::print_stdout,
+    reason = "documented stdout surface for CLI subcommands"
+)]
+pub fn cmd_bundle(config: &TsumugiConfig, out: &Path, compression: i32) -> anyhow::Result<()> {
+    let (_, runs_dir) = resolve_paths(config)?;
+    let count = tmg_trajectory::bundle::bundle(&runs_dir, &config.trajectory, out, compression)?;
+    println!(
+        "bundled {count} session trajectory file(s) → {} (compression level {compression})",
+        out.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "test assertions use panic-based macros")]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn enable_writes_trajectory_block() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let cfg = tmp.path().join("tsumugi.toml");
+        set_trajectory_enabled(Some(&cfg), true).unwrap_or_else(|e| panic!("{e}"));
+        let body = std::fs::read_to_string(&cfg).unwrap_or_else(|e| panic!("{e}"));
+        assert!(body.contains("[trajectory]"), "{body}");
+        assert!(body.contains("enabled = true"), "{body}");
+    }
+
+    #[test]
+    fn disable_flips_back() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let cfg = tmp.path().join("tsumugi.toml");
+        set_trajectory_enabled(Some(&cfg), true).unwrap_or_else(|e| panic!("{e}"));
+        set_trajectory_enabled(Some(&cfg), false).unwrap_or_else(|e| panic!("{e}"));
+        let body = std::fs::read_to_string(&cfg).unwrap_or_else(|e| panic!("{e}"));
+        assert!(body.contains("enabled = false"), "{body}");
+    }
+
+    /// Existing TOML content (other sections) must survive the
+    /// `enable` round-trip.
+    #[test]
+    fn enable_preserves_other_sections() {
+        let tmp = TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let cfg = tmp.path().join("tsumugi.toml");
+        std::fs::write(
+            &cfg,
+            "[llm]\nendpoint = \"http://localhost:8080\"\nmodel = \"foo\"\n",
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+        set_trajectory_enabled(Some(&cfg), true).unwrap_or_else(|e| panic!("{e}"));
+        let body = std::fs::read_to_string(&cfg).unwrap_or_else(|e| panic!("{e}"));
+        assert!(body.contains("[llm]"), "{body}");
+        assert!(
+            body.contains("endpoint = \"http://localhost:8080\""),
+            "{body}"
+        );
+        assert!(body.contains("[trajectory]"), "{body}");
+        assert!(body.contains("enabled = true"), "{body}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #55: a new `tmg-trajectory` workspace crate plus
full CLI / TUI / one-shot integration so operators can opt into
structured per-session JSONL recording for SFT / RL training datasets.

- **New crate `crates/tmg-trajectory/`** with `record.rs` (tagged
  `TrajectoryRecord` enum: meta, system, user, assistant with
  optional thinking + tool_calls, tool_result, feedback, verdict —
  every variant round-trips through `serde_json`), `recorder.rs`
  (append-only JSONL writer that runs redaction on every content
  path, honours `include_thinking`, and supports
  `full`/`redacted`/`summary_only` tool-result modes), `redact.rs`
  (re-exports `tmg_search::redact::redact_secrets` so the regex set
  is shared, adds a `Redactor` that composes the shared base
  patterns with operator-supplied extras), `sink.rs`
  (`TrajectorySink` trait + `TrajectoryStreamSink` that wraps any
  `tmg_core::StreamSink` so the existing tee chain gets a third
  observer for free), `export.rs` (reconstructs trajectories from
  `session_log/*.json` plus the matching `event_log/*.jsonl` when
  available, with a summary-only fallback otherwise), and
  `bundle.rs` (`tar.zst` archive).
- **New `tmg trajectory <enable|disable|list|export|bundle>` CLI
  family**. `enable` prints a one-time consent warning and requires
  `--yes` before flipping the project `tsumugi.toml` flag.
- **New `[trajectory]` config section** (default OFF) with
  `output_dir` / `include_thinking` / `include_tool_results` /
  `redact_extra_patterns` plus matching `TMG_TRAJECTORY_*` env vars.
- **Live wiring**: TUI spawn closure layers `TrajectoryStreamSink`
  on top of `TeeStreamSink<HarnessStreamSink<...>>`; one-shot mode
  synthesises a `.tsumugi/trajectories/oneshot_<utc>.jsonl` file.
  Verdict + flush fire on session-end.
- **Workspace deps**: adds `tar = "0.4"` and `zstd = "0.13"`.

## Acceptance criteria checklist

- [x] `crates/tmg-trajectory/` registered in workspace Cargo.toml.
- [x] All record types (meta / system / user / assistant /
  tool_result / feedback / verdict) serialize + deserialize.
- [x] Redaction masks API keys (5+ patterns; reuses #53's test set
  via `Redactor::apply` smoke test).
- [x] `tmg trajectory export` rebuilds from session_log + event_log.
- [x] `tmg trajectory bundle` produces a valid `tar.zst` archive
  (verified end-to-end with `zstd -d` + `tar -tf`).
- [x] Default OFF; `enable` prints the consent warning before
  writing the flag.
- [x] `include_thinking = false` strips the thinking block;
  `include_tool_results = "summary_only"` produces compact
  `<N chars, ok>` placeholders.
- [x] `clippy --all-targets --all-features -- -D warnings`.
- [x] OpenAI-superset format documented in
  `record.rs`'s module-level rustdoc.

## Quality checks

- `cargo build --workspace` PASS
- `cargo clippy --all-targets --all-features -- -D warnings` PASS
- `cargo fmt --all -- --check` PASS
- `cargo test --workspace` PASS (28 new trajectory tests, 4 new
  CLI parsing tests, plus existing suites)

## Runtime Verification

- LLM server: available
- One-shot mode: PASS
  - Trajectory file `.tsumugi/trajectories/oneshot_<utc>.jsonl`
    captures `meta` + `system` + `user` + `assistant` + `verdict`
    records correctly.
  - Event log `--event-log` at the same time emits 2+ tokens, 0
    errors, 1 done.
- TUI mode: PASS (partial — meta + user records confirmed; the LLM
  generation did not finish within the expect-driven 60s timeout
  on a slow local model, so the assistant / verdict records were
  not yet written when Ctrl+C fired. The wiring path is identical
  to the one-shot mode, which is the ground-truth check.)
- Bundle: PASS — `zstd -d traj.tar.zst | tar -tf` lists
  `abc12345/session_001.jsonl` and member contents survive.

## Test plan

- [ ] `cargo test --workspace`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] `tmg trajectory enable --yes` → `tmg trajectory list` shows
  files after a session.
- [ ] `tmg trajectory export --all` reconstructs trajectories from
  pre-feature `session_log/*.json` files.
- [ ] `tmg trajectory bundle --out /tmp/x.tar.zst` round-trips via
  `zstd -d` + `tar -xf`.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)